### PR TITLE
CAMEL-11492: cleanup Antora parameters

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "license": "Apache-2.0",
   "scripts": {
     "theme": "(cd antora-ui-camel && yarn install && yarn gulp bundle)",
-    "documentation": "antora --pull site.yml",
+    "documentation": "antora --clean --fetch site.yml",
     "website": "hugo --minify",
     "critical": "gulp critical",
     "minify": "gulp minify",


### PR DESCRIPTION
This adds `--clean` and replaces `--pull` with `--fetch` as `--pull` was deprecated in Antora 2.0.0.