### PR TITLE
chore: generate the top level menu from hugo configuration

### DIFF
--- a/antora-ui-camel/src/partials/header-content.hbs
+++ b/antora-ui-camel/src/partials/header-content.hbs
@@ -10,46 +10,26 @@
     </div>
     <div id="topbar-nav" class="navbar-menu">
       <div class="navbar-end">
-        <a class="navbar-item" href="/">Home</a>
-        <a class="navbar-item" href="/news/">News</a>
-        <div class="navbar-item has-dropdown is-hoverable">
-          <a class="navbar-link" href="#">Projects</a>
-          <div class="navbar-dropdown">
-            <a class="navbar-item" href="/projects/camel-k/">Camel K</a>
-          </div>
-        </div>
-        <div class="navbar-item has-dropdown is-hoverable">
-          <a class="navbar-link" href="#">Documentation</a>
-          <div class="navbar-dropdown">
-            <a class="navbar-item" href="/docs/getting-started/">Getting started</a>
-            <a class="navbar-item" href="/manual/latest/">User manual</a>
-            <a class="navbar-item" href="/components/latest/">Component reference</a>
-            <a class="navbar-item" href="/camel-k/latest/">Camel K</a>
-          </div>
-        </div>
-        <div class="navbar-item has-dropdown is-hoverable">
-          <a class="navbar-link" href="#">Community</a>
-          <div class="navbar-dropdown">
-            <a class="navbar-item" href="/community/support/">Support</a>
-            <a class="navbar-item" href="https://github.com/apache/camel/blob/master/CONTRIBUTING.md">Contributing</a>
-            <a class="navbar-item" href="/community/user-stories/">User stories</a>
-            <a class="navbar-item" href="/community/articles/">Articles</a>
-            <a class="navbar-item" href="/community/books/">Books</a>
-            <a class="navbar-item" href="/community/team/">Team</a>
-            <a class="navbar-item" href="/community/camel-extra/">Camel extra</a>
-          </div>
-        </div>
-        <a class="navbar-item" href="/download/">Download</a>
-        <div class="navbar-item has-dropdown is-hoverable">
-          <a class="navbar-link" href="#">About</a>
-          <div class="navbar-dropdown">
-            <a class="navbar-item" href="https://www.apache.org/events/current-event.html">Apache events</a>
-            <a class="navbar-item" href="https://www.apache.org/licenses/">License</a>
-            <a class="navbar-item" href="https://www.apache.org/security/">Security</a>
-            <a class="navbar-item" href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a>
-            <a class="navbar-item" href="https://www.apache.org/foundation/thanks.html">Thanks</a>
-          </div>
-        </div>
+        {{#withMenuData}}
+          {{#each items}}
+              {{#if children}}
+              <div class="navbar-item has-dropdown is-hoverable">
+                <a class="navbar-link" href="{{or site.url (or siteRootUrl siteRootPath)}}{{url}}">{{name}}</a>
+              {{else}}
+              <a class="navbar-item" href="{{or site.url (or siteRootUrl siteRootPath)}}{{url}}">{{name}}</a>
+              {{/if}}
+              {{#if children}}
+              <div class="navbar-dropdown">
+              {{#each children}}
+                <a class="navbar-item" href="{{or site.url (or siteRootUrl siteRootPath)}}{{url}}">{{name}}</a>
+              {{/each}}
+              </div>
+              {{/if}}
+              {{#if children}}
+              </div>
+              {{/if}}
+          {{/each}}
+        {{/withMenuData}}
       </div>
     </div>
   </nav>

--- a/menu.js
+++ b/menu.js
@@ -1,0 +1,25 @@
+const fs = require('fs');
+const path = require('path');
+const toml = require('toml');
+const Handlebars = require('handlebars');
+
+const data = fs.readFileSync(path.join(__dirname, 'config.toml'), 'utf8');
+const hugoConfig = toml.parse(data);
+const mainMenu = hugoConfig.menu.main;
+
+const createMenu = item => {
+  return {
+    url: item.url || '#',
+    name: item.name,
+    children: mainMenu.filter(child => child.parent === item.identifier).map(createMenu)
+  }
+}
+
+const menuData = mainMenu.filter(item => typeof(item.parent) === 'undefined').map(createMenu);
+
+Handlebars.registerHelper('withMenuData', (options) => {
+  return options.fn({
+    items: menuData
+  });
+});
+

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "version": "1.0.0-SNAPSHOT",
   "license": "Apache-2.0",
   "scripts": {
-    "documentation": "antora --clean --fetch site.yml",
+    "documentation": "antora --require ./menu.js --clean --fetch site.yml",
     "website": "hugo --minify",
     "critical": "gulp critical",
     "minify": "gulp minify",
@@ -21,5 +21,9 @@
   },
   "installConfig": {
     "pnp": true
+  },
+  "dependencies": {
+    "handlebars": "~4.1",
+    "toml": "~3.0"
   }
 }

--- a/site.yml
+++ b/site.yml
@@ -1,6 +1,6 @@
 site:
   title: Apache Camel
-  url: https://camel.apache.org/
+  url: https://camel.apache.org/staging/
   start_page: manual::index.adoc
 
 content:
@@ -18,10 +18,6 @@ content:
 ui:
   bundle:
     url: ./antora-ui-camel/build/ui-bundle.zip
-
-asciidoc:
-  attributes:
-    product-name: 'Apache Camel'
 
 urls:
   redirect_facility: disabled

--- a/yarn.lock
+++ b/yarn.lock
@@ -2418,7 +2418,7 @@ gulplog@^1.0.0:
   dependencies:
     glogg "^1.0.0"
 
-handlebars@^4.0.12:
+handlebars@^4.0.12, handlebars@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.1.2.tgz#b6b37c1ced0306b221e094fc7aca3ec23b131b67"
   integrity sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==
@@ -3514,12 +3514,24 @@ mime-db@~1.38.0:
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.38.0.tgz#1a2aab16da9eb167b49c6e4df2d9c68d63d8e2ad"
   integrity sha512-bqVioMFFzc2awcdJZIzR3HjZFX20QhilVS7hytkKrv7xFAn8bM1gzc/FOX2awLISvWe0PV8ptFKcon+wZ5qYkg==
 
-mime-types@^2.1.12, mime-types@^2.1.19, mime-types@^2.1.21, mime-types@~2.1.17, mime-types@~2.1.19:
+mime-db@~1.39.0:
+  version "1.39.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.39.0.tgz#f95a20275742f7d2ad0429acfe40f4233543780e"
+  integrity sha512-DTsrw/iWVvwHH+9Otxccdyy0Tgiil6TWK/xhfARJZF/QFhwOgZgOIvA2/VIGpM8U7Q8z5nDmdDWC6tuVMJNibw==
+
+mime-types@^2.1.12, mime-types@^2.1.19, mime-types@~2.1.17, mime-types@~2.1.19:
   version "2.1.22"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.22.tgz#fe6b355a190926ab7698c9a0556a11199b2199bd"
   integrity sha512-aGl6TZGnhm/li6F7yx82bJiBZwgiEa4Hf6CNr8YO+r5UHr53tSTYZb102zyU50DOWWKeOv0uQLRL0/9EiKWCog==
   dependencies:
     mime-db "~1.38.0"
+
+mime-types@^2.1.21:
+  version "2.1.23"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.23.tgz#d4eacd87de99348a6858fe1e479aad877388d977"
+  integrity sha512-ROk/m+gMVSrRxTkMlaQOvFmFmYDc7sZgrjjM76abqmd2Cc5fCV7jAMA5XUccEtJ3cYiYdgixUVI+fApc2LkXlw==
+  dependencies:
+    mime-db "~1.39.0"
 
 mime@2.0.3:
   version "2.0.3"
@@ -5345,6 +5357,11 @@ to-utf8@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/to-utf8/-/to-utf8-0.0.1.tgz#d17aea72ff2fba39b9e43601be7b3ff72e089852"
   integrity sha1-0Xrqcv8vujm55DYBvns/9y4ImFI=
+
+toml@~3.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/toml/-/toml-3.0.0.tgz#342160f1af1904ec9d204d03a5d61222d762c5ee"
+  integrity sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w==
 
 tough-cookie@~2.3.3:
   version "2.3.4"


### PR DESCRIPTION
With this a Handlebars helper, menu as defined in the `config.toml` for the Hugo generated portion of the site is parsed and a data structure is generated for the Handlebars template in the `antora-ui-camel` -- which makes the `config.toml` single place where the top level navigation menu is defined.