### PR TITLE
CAMEL-13470: Publish security advisories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,8 @@ node
 target
 node_modules
 public
-static
+static/*
+!**/.htaccess
 
 .idea
 *.iml

--- a/README.md
+++ b/README.md
@@ -195,7 +195,20 @@ areas of the website:
 - [news](content/news): News, blogs, posts
 - [community](content/community): Support, contributing, articles, etc.
 - [projects](content/projects): Subproject information (e.g. Camel K)
+- [security](content/security): Security information and advisories
 
+#### Adding new security advisory content
+
+Use the `security-advisory` archetype to create a new markdown content file in `content/security`:
+
+    $ yarn run hugo new --kind security-advisory security/CVE-YYYY-NNNNN # replace YYYY-NNNNN with the CVE number
+
+This will create a `content/security/CVE-YYYY-NNNNN.md` file which you need to edit to and fill in the required parameters.
+The content of the created markdown file is added to the _Notes_ section.
+
+Place the signed PGP advisory in plain text as `content/security/CVE-YYYY-NNNNN.txt.asc`.
+
+Make sure that you set the `draft: false` property to have the page published.
 
 #### Layout and templates
 
@@ -226,3 +239,4 @@ change there.
 Your changes in these repositories will automatically get visible on the website after a site rebuild.
 
 [1]: antora-ui-camel/src/img/logo32-d.png "Apache Camel"
+

--- a/archetypes/security-advisory.md
+++ b/archetypes/security-advisory.md
@@ -1,0 +1,15 @@
+---
+title: "Apache Camel Security Advisory - {{ .Name | title }}"
+url: /security/{{ .Name }}.html
+date: {{ .Date }}
+draft: true
+type: security-advisory
+cve: {{ .Name }}
+severity: 
+summary: ""
+description: ""
+mitigation: ""
+credit: ""
+affected: 
+fixed: 
+---

--- a/config.toml
+++ b/config.toml
@@ -2,6 +2,7 @@ baseURL = "https://camel.apache.org/"
 languageCode = "en-us"
 title = "Apache Camel"
 relativeURLs = true
+disablePathToLower = true
 
 [[menu.main]]
     name = "Home"
@@ -144,7 +145,7 @@ relativeURLs = true
     parent = "about"
     weight = 3
     identifier = "about-security"
-    url = "https://www.apache.org/security/"
+    url = "/security/"
 
 [[menu.main]]
     name = "Sponsorship"

--- a/content/security/CVE-2013-4330.md
+++ b/content/security/CVE-2013-4330.md
@@ -1,0 +1,23 @@
+---
+title: "Apache Camel Security Advisory - CVE-2013-4330"
+url: /security/CVE-2013-4330.html
+date: 2013-10-04T13:55:09.853000
+draft: false 
+type: security-advisory
+cve: CVE-2013-4330
+severity: CRITICAL
+summary: "Writing files using FILE or FTP components, can potentially be exploited by a malicious user."
+description: "When sending an Exchange with the in Message Header 'CamelFileName' with a value of '$simple{...}' to a FILE or FTP producer, it will interpret the value as simple language expression which can be exploited by a malicious user."
+mitigation: "2.9.x users should upgrade to 2.9.8, 2.10.x users should upgrade to 2.10.7, 2.11.x users should upgrade to 2.11.2 and 2.12.0 users should upgrade to 2.12.1. This patch will be included from Camel 2.13.0: https://git-wip-us.apache.org/repos/asf?p=camel.git;a=commitdiff;h=27a9752a565fbef436bac4fcf22d339e3295b2a0"
+credit: "This issue was discovered by Grégory Draperi"
+affected: 2.9.0 up to 2.9.7, 2.10.0 up to 2.10.6, 2.11.0 up to 2.11.1, 2.12.0
+fixed: 2.9.8, 2.10.7, 2.11.2, 2.12.1 and newer
+---
+
+Example: Create a simple route which moves files from one directory to another, e.g.:
+
+    from("file:c:/tmp/in")
+      .to("file:/c:/tmp/out");
+
+If you are using Windows, create an file with a name like `"$simple{<some malicious code>}"` (without the quotes) and drop it into the "c:/tmp/in" directory. The file consumer will read and process this file. It will also set the Exchange in Message Header '`CamelFileName`' with the value `"$simple{<some malicious code>}"`. In the next step, the file producer will interpreted the value of this header as simple language expression and execute the malicious code.
+

--- a/content/security/CVE-2013-4330.txt.asc
+++ b/content/security/CVE-2013-4330.txt.asc
@@ -1,0 +1,46 @@
+-----BEGIN PGP SIGNED MESSAGE-----
+Hash: SHA1
+
+CVE-2013-4330: Apache Camel critical disclosure vulnerability
+
+Severity: Critical
+
+Vendor: The Apache Software Foundation
+
+Versions Affected: Camel 2.9.0 to 2.9.7, Camel 2.10.0 to 2.10.6, Camel 2.11.0 to 2.11.1, Camel 2.12.0
+The unsupported Camel 2.3.x, 2.4.x, 2.5.x, 2.6.x, 2.7.x and 2.8.x versions may be also affected.
+
+Description: When sending an Exchange with the in Message Header 'CamelFileName' with a value of '$simple{...}' to a FILE or FTP producer, it will interpret the value as simple language expression which can be exploited by a malicious user.
+
+Mitigation: 2.9.x users should upgrade to 2.9.8, 2.10.x users should upgrade to 2.10.7, 2.11.x users should upgrade to 2.11.2 and 2.12.0 users should upgrade to 2.12.1. This patch will be included from Camel 2.13.0: https://git-wip-us.apache.org/repos/asf?p=camel.git;a=commitdiff;h=27a9752a565fbef436bac4fcf22d339e3295b2a0
+
+Example: Create a simple route which moves files from one directory to another, e.g.:
+from("file:c:/tmp/in")
+  .to("file:/c:/tmp/out");
+
+If you are using Windows, create an file with a name like
+"$simple{<some malicious code>}" (without the quotes)
+and drop it into the "c:/tmp/in" directory. The file consumer will read and process this file. It will also set the Exchange in Message Header 'CamelFileName' with the value "$simple{<some malicious code>}". In the next step, the file producer will interpreted the value of this header as simple language expression and execute the malicious code.
+
+Credit: This issue was discovered by Grégory Draperi.
+
+References: http://camel.apache.org/security-advisories.html
+
+-----BEGIN PGP SIGNATURE-----
+Version: GnuPG/MacGPG2 v2.0.20 (Darwin)
+Comment: GPGTools - http://gpgtools.org
+
+iQIcBAEBAgAGBQJSSszOAAoJEImh9lEqI5wsaNEQAIoITjC6AWQru4H3Eqm7XmGJ
+X2PGYY08XhwDGR7qqnIsYFHIqsSMoW+1YhQqZNV66zrU1hDgpFDz3dj3IaQUXpaE
+9dI6B1eGvayF2GxoBnsc0Dua/43WdhWm9KBHrcGL3TQVEi3D7QmTv4Udsx3+5ita
+xQcYrmrltdKDp8r08GHwFV1jZnafPEbJ5Vw/ATqHAb0hZ7ozv3c3iAqTkER++dzL
+DL+gNKbN1eD8ZeixitQO4eirEkkiRlU8fC6dy+6e6Hra/0L16nyEmpsYWvx+mWnt
+C+1fQQjmwZW/zV2tVqznc8mlVUYuttp3F4GDybYqPgMXlWC9Ri0JZWlNoXTZ0zak
+f6KxcWqHvKs+LhCENFV2cnCtq2uHvGX0HMT4h/eVvGa/t/8gI2tgvaUtt0ylUNWn
+a1znMCjDRwISlqu+jfSja7g1IydtvN1/tssfTMJjRDmng4mpGEa03iunVuwHFJv2
+Y6khePzKKP4wXS5oQ9aMev039IKB2725R28iZ2YH2TolgjicAay8ulBGHq0jx0rm
+QI5zVrAAdWdX3kYjDGED/70gVfhF6N0cG4wpZzT9RW0oYU0kFeTEPJN/1jg3u9Mc
+Fm0FEDCOSRkX4OKKa5nQX8EL92Jz0g6YukPAaQyvegvbjvvMCSxgQbIwFyBh0Yt/
+9JRZ0jp01139FFdpa+QM
+=UpK9
+-----END PGP SIGNATURE-----

--- a/content/security/CVE-2014-0002.md
+++ b/content/security/CVE-2014-0002.md
@@ -1,0 +1,26 @@
+---
+title: "Apache Camel Security Advisory - CVE-2014-0002"
+url: /security/CVE-2014-0002.html
+date: 2014-03-21T00:38:59.027000
+draft: false
+cve: CVE-2014-0002
+severity: CRITICAL
+summary: "The Apache Camel XSLT component will resolve entities in XML messages when transforming them using an xslt route."
+description: "The Apache Camel XSLT component will resolve entities in XML messages when transforming them using an xslt route. A remote attacker able to submit messages to an xslt route could use this flaw to read files accessible to the running application server and potentially perform other more advanced XXE attacks."
+mitigation: "2.11.x users should upgrade to 2.11.4, 2.12.x users should upgrade to 2.12.3. This patch will be included from Camel 2.13.0: https://git-wip-us.apache.org/repos/asf?p=camel.git;a=commitdiff;h=341d4e6cca71c53c90962d1c3d45fc9e05cc50c6"
+credit: "This issue was discovered by David Jorm."
+type: security-advisory
+affected: 2.11.0 up to 2.11.3, 2.12.0 up to 2.12.2
+fixed: 2.11.4, 2.12.3, 2.13.0 and newer
+---
+
+Example: Create a simple route which receives an HTTP request, apply a (safe) stylesheet and store the result in a file:
+
+    <route>
+      <from uri="servlet:///hello"/>
+      <to uri="xslt:file:/tmp/transform.xsl" />
+      <to uri="file:/tmp/output" />
+    </route>
+
+If an attacker is able to submit a message to this route, they can provide a message that is an XML document containing external entities. These entities will be resolved, and their contents included in the output of the transformation performed by the xslt route.
+

--- a/content/security/CVE-2014-0002.txt.asc
+++ b/content/security/CVE-2014-0002.txt.asc
@@ -1,0 +1,46 @@
+-----BEGIN PGP SIGNED MESSAGE-----
+Hash: SHA1
+
+CVE-2014-0002: Apache Camel critical disclosure vulnerability
+
+Severity: Critical
+
+Vendor: The Apache Software Foundation
+
+Versions Affected: Camel 2.11.0 to 2.11.3, Camel 2.12.0 to 2.12.2
+The unsupported Camel 2.3.x, 2.4.x, 2.5.x, 2.6.x, 2.7.x, 2.8.x, 2.9.x and 2.10.x versions may be also affected.
+
+Description: The Apache Camel XSLT component will resolve entities in XML messages when transforming them using an xslt route. A remote attacker able to submit messages to an xslt route could use this flaw to read files accessible to the running application server and potentially perform other more advanced XXE attacks.
+
+Mitigation: 2.11.x users should upgrade to 2.11.4, 2.12.x users should upgrade to 2.12.3. This patch will be included from Camel 2.13.0: https://git-wip-us.apache.org/repos/asf?p=camel.git;a=commitdiff;h=341d4e6cca71c53c90962d1c3d45fc9e05cc50c6
+
+Example: Create a simple route which receives an HTTP request, apply a (safe) stylesheet and store the result in a file:
+<route>
+  <from uri="servlet:///hello"/>
+  <to uri="xslt:file:/tmp/transform.xsl" />
+  <to uri="file:/tmp/output" />
+</route>
+
+If an attacker is able to submit a message to this route, they can provide a message that is an XML document containing external entities. These entities will be resolved, and their contents included in the output of the transformation performed by the xslt route.
+
+Credit: This issue was discovered by David Jorm.
+
+References: http://camel.apache.org/security-advisories.html
+-----BEGIN PGP SIGNATURE-----
+Version: GnuPG/MacGPG2 v2.0.22 (Darwin)
+Comment: GPGTools - http://gpgtools.org
+
+iQIcBAEBAgAGBQJTENZhAAoJEImh9lEqI5wsukkP/2q4Tr9N2NMWYu9+5YYrpSST
+TWnhcE7QGVOu3ITRp0WslzzJoa6Dl1q1XB7NRiV9CrHrUAk/GMaMo0M51ezaYUOq
++8HfiHpVbU+frk67bbTCceSug1xLsCb1upD0LUvM28siimMme2lmZtZuzKwYws2o
+dG3gqIIgBYxl6Z6tKb7BIqQobsiK/50q5iZ1Z7PLT1hNrJvnBh0N6wgqfSPM0CLj
+1NBN1xLJufcooT5pMYSXq8UAKvp9x7CymUTk/b/xbTGE5e8T/XNKAuXoe1/XRfMO
+mETrN11hQdrEtflK9uOwHhDOu2SvsBBjBmDGY90K/Da1d1Hjued2Uaz3qGf4nQ9F
+SVVLKfB4Z6VZkNqyjZ8JZjdJGWtrLMeixUxoGLKp8S2SXHG9HTfxh0a9GD7g3vfj
+hO10B3qJKeWcVnBru4tRy/lmPfmCw28gizR4KEej4YFiPDFp60Z2Rxxsz5dHyOq6
+fUkOcCsMmLUoj1i3YoIcFDos8ZPl6Zuu1xkmOxq+hslixaT9ROUwfuIkV8lRofgT
+c1A2Ao5FZu0UK7uR81TNflbTCy+4q7Wojfs6LMydU9VjcGkCl+ES2q9mtv3BE6rN
+r69g5lba6ooyZEqPNvDGwTznQVUiHM5roaEooDYnTSU4FhT56isTANqaGncIXCnZ
+t3sXFGy7PXvfxxpeKHTb
+=VJ0D
+-----END PGP SIGNATURE-----

--- a/content/security/CVE-2014-0003.md
+++ b/content/security/CVE-2014-0003.md
@@ -1,0 +1,26 @@
+---
+title: "Apache Camel Security Advisory - CVE-2014-0003"
+url: /security/CVE-2014-0003.html
+date: 2014-03-21T00:38:59.057000
+draft: false
+type: security-advisory
+cve: CVE-2014-0003
+severity: CRITICAL
+summary: "The Apache Camel XSLT component allows XSL stylesheets to perform calls to external Java methods."
+description: "The Apache Camel XSLT component allows XSL stylesheets to perform calls to external Java methods. A remote attacker able to submit messages to an xslt Camel route could use this flaw to perform arbitrary remote code execution in the context of the Camel server process."
+mitigation: "2.11.x users should upgrade to 2.11.4, 2.12.x users should upgrade to 2.12.3. This patch will be included from Camel 2.13.0: https://git-wip-us.apache.org/repos/asf?p=camel.git;a=commitdiff;h=e922f89290f236f3107039de61af0375826bd96d"
+credit: "This issue was discovered by David Jorm."
+affected: 2.11.0 up to 2.11.3, 2.12.0 up to 2.12.2
+fixed: 2.11.4, 2.12.3, 2.13.0 and newer
+---
+
+Example: Create a simple route which receives an HTTP request, apply a (safe) stylesheet and store the result in a file:
+
+    <route>
+      <from uri="servlet:///hello"/>
+      <to uri="xslt:file:/tmp/transform.xsl" />
+      <to uri="file:/tmp/output" />
+    </route>
+
+If an attacker is able to submit a message to this route, they can provide a message that is an XML document containing external entities. These entities will be resolved, and their contents included in the output of the transformation performed by the xslt route.
+

--- a/content/security/CVE-2014-0003.txt.asc
+++ b/content/security/CVE-2014-0003.txt.asc
@@ -1,0 +1,46 @@
+-----BEGIN PGP SIGNED MESSAGE-----
+Hash: SHA1
+
+CVE-2014-0003: Apache Camel critical disclosure vulnerability
+
+Severity: Critical
+
+Vendor: The Apache Software Foundation
+
+Versions Affected: Camel 2.11.0 to 2.11.3, Camel 2.12.0 to 2.12.2
+The unsupported Camel 2.3.x, 2.4.x, 2.5.x, 2.6.x, 2.7.x, 2.8.x, 2.9.x and 2.10.x versions may be also affected.
+
+Description: The Apache Camel XSLT component allows XSL stylesheets to perform calls to external Java methods. A remote attacker able to submit messages to an xslt Camel route could use this flaw to perform arbitrary remote code execution in the context of the Camel server process.
+
+Mitigation: 2.11.x users should upgrade to 2.11.4, 2.12.x users should upgrade to 2.12.3. This patch will be included from Camel 2.13.0: https://git-wip-us.apache.org/repos/asf?p=camel.git;a=commitdiff;h=e922f89290f236f3107039de61af0375826bd96d
+
+Example: Create a simple route which receives an HTTP request, apply a (safe) stylesheet and store the result in a file:
+<route>
+  <from uri="servlet:///hello"/>
+  <to uri="xslt:file:/tmp/transform.xsl" />
+  <to uri="file:/tmp/output" />
+</route>
+
+If an attacker is able to submit a message to this route, they can change the XSLT stylesheet to use for this transfiormation. This stylesheet could be provided by a valid URL and could perform arbitrary remote code execution.
+
+Credit: This issue was discovered by David Jorm.
+
+References: http://camel.apache.org/security-advisories.html
+-----BEGIN PGP SIGNATURE-----
+Version: GnuPG/MacGPG2 v2.0.22 (Darwin)
+Comment: GPGTools - http://gpgtools.org
+
+iQIcBAEBAgAGBQJTENZYAAoJEImh9lEqI5wsHK0P/35/jWdyzENsaPmW6dlivhuq
+b1GAeMQL5gN/lws1VC0+2cQ0HGqOxLItzpse3P0gApMqRi7uGnFT+Amblc2tLvFv
+mPJa1Zdm1jjtANPx1oweb3i7VtWXwefBivQ+RxxhKfaru96Q20NK8d2u203+GK9Y
+fjQmKHTgUtkpNxKfEgbtkHpCOX1C8xrBs/+JWHhtZFEBQHpzbllO5M2ofrjyJIsL
+OaJsd8hVxPXRgyjGDjuSrEObnvszEYkABCbrUgVrTI0NxewUg3orKb1GQjSpw9D9
+YehQurloyHcoqzRkNZsGaeZtiKnCmbyXmii61EoopoWnUyF1lRC8iCgmvyQDpoto
+ZVmkhhVl4VON7wSii4A9p4RDBch/zi6rlq+OYx13ZRMqtP6v+hgGNIZiSZ7j4ZTa
+wHh/A6MTN44/rAefnu8f2IhXPeTmWznez1jCc2hL4v/p+s4ttVNM1KBZkm/6saBH
+VNOrmu46Tcl/cll/tSP5rC+P/LMmCMPdciuV/zSofHjvG5meJMl0a08dMvdNobZi
+zGAcHAr6qXiYy6qMMMbTbQu++JUUWnbtaFndWHs/ALOUP9zF+fky30JTu/h2/RuZ
+98RnR19XsfL+JgouLmFkP/HtA/qUjbaUHQIvJj6J0R+aR+ItszthGDnSNRXWg1LR
+hvVPgX0RU6vPWJoJ0Wd5
+=gxws
+-----END PGP SIGNATURE-----

--- a/content/security/CVE-2015-0263.md
+++ b/content/security/CVE-2015-0263.md
@@ -1,0 +1,15 @@
+---
+title: "Apache Camel Security Advisory - CVE-2015-0263"
+url: /security/CVE-2015-0263.html
+date: 2015-06-03T16:59:02.917000
+draft: false
+type: security-advisory
+cve: CVE-2015-0263
+severity: MEDIUM
+summary: "The XML converter setup in Apache Camel allows remote attackers to read arbitrary files via an SAXSource containing an XML External Entity (XXE) declaration."
+description: "The XML converter setup in Apache Camel allows remote attackers to read arbitrary files via an SAXSource containing an XML External Entity (XXE) declaration."
+mitigation: "2.13.x users should upgrade to 2.13.4, 2.14.x users should upgrade to 2.14.2. This patch will be included from Camel 2.15.0: https://git-wip-us.apache.org/repos/asf?p=camel.git;a=commitdiff;h=7d19340bcdb42f7aae584d9c5003ac4f7ddaee36"
+credit: "This issue was discovered by Stephan Siano."
+affected: 2.13.0 up to 2.13.3, 2.14.0 up to 2.14.1
+fixed: 2.13.4, 2.14.2, 2.15.0 and newer
+---

--- a/content/security/CVE-2015-0263.txt.asc
+++ b/content/security/CVE-2015-0263.txt.asc
@@ -1,0 +1,38 @@
+-----BEGIN PGP SIGNED MESSAGE-----
+Hash: SHA1
+
+
+CVE-2015-0263: Apache Camel medium disclosure vulnerability
+
+Severity: MEDIUM
+
+Vendor: The Apache Software Foundation
+
+Versions Affected: Camel 2.13.0 to 2.13.3, Camel 2.14.0 to 2.14.1
+The unsupported Camel 2.3.x, 2.4.x, 2.5.x, 2.6.x, 2.7.x, 2.8.x, 2.9.x, 2.10.x, 2.11.x and 2.12.x versions may be also affected.
+
+Description: The XML converter setup in Apache Camel allows remote attackers to read arbitrary files via an SAXSource containing an XML External Entity (XXE) declaration.
+
+Mitigation: 2.13.x users should upgrade to 2.13.4, 2.14.x users should upgrade to 2.14.2. This patch will be included from Camel 2.15.0: https://git-wip-us.apache.org/repos/asf?p=camel.git;a=commitdiff;h=7d19340bcdb42f7aae584d9c5003ac4f7ddaee36
+
+Credit: This issue was discovered by Stephan Siano.
+
+References: http://camel.apache.org/security-advisories.html
+-----BEGIN PGP SIGNATURE-----
+Version: GnuPG/MacGPG2 v2.0.22 (Darwin)
+Comment: GPGTools - http://gpgtools.org
+
+iQIcBAEBAgAGBQJU/sahAAoJEImh9lEqI5wsKmkQAIPMcNnEvWWolihdFlC+4nQn
+Fo39aZ+nr6mH38PgH1Ho2wGPYYX6j6r41cJIOtU5lZzSmC8yaX5tEavm0bKK9XJu
+ScNKixYwxSejF326CKlm2Nl9X26OtZaPSrCyXn9fdFtvkSyo2qcypbYkIGujZW9R
+8sKLKHPgCupBjrDh0271D2BEw9eqZvNsKeBE2o/sePcHy5dhS8GQdKbBmfF1tDDl
+lfAWr+djLJ018X10krVek7GWajdXiZEsMmUZZ6i+Ao0Y9dTguVjTRxcO6gHPM4xq
+AyyDBF2tT2/JvP6QzeaspAI9Wpjr2CD0HKS3eURsfghsjWNklueYeEc/kE/5Usls
+4WiM2MCMPfhef5uY2cbt+BEeouAkIvNdyjzadEdIHJYzqwyWdTwuuabNG+X2zI+m
++Sz0aepvpAXdWrfNFAiiGrzIDRVnZsTjEQ8THAeoSND08e111cy0S2TmKhVlljF+
+Ag5gqduoReWnIrksxJ5M0wkaOfubBgactRFoc8ZhIdmyY8xbiFJmywI9sZ1aTP5s
+tV/hFq7hcGCDqwFAHFsYRoXecfVHWEN/zr0MjXpQ6xT3f8Jedeamq1ZiaBDtfM5p
+SHumY30Tc+cCBV3nFVjxM+zAcFQ8gjnORnZEnZ2F+HQaJHZzQOLWZ6V/urcuHUzu
+HWeqvw4nphzuGl88Vv1M
+=IvV+
+-----END PGP SIGNATURE-----

--- a/content/security/CVE-2015-0264.md
+++ b/content/security/CVE-2015-0264.md
@@ -1,0 +1,15 @@
+---
+title: "Apache Camel Security Advisory - CVE-2015-0264"
+url: /security/CVE-2015-0264.html
+date: 2015-06-03T16:59:04.403000
+draft: false
+type: security-advisory
+cve: CVE-2015-0264
+severity: MEDIUM
+summary: "The XPath handling in Apache Camel for invalid XML Strings or invalid XML GenericFile objects allows remote attackers to read arbitrary files via an XML External Entity (XXE) declaration. The XML External Entity (XXE) will be resolved before the Exception is thrown."
+description: "The XPath handling in Apache Camel for invalid XML Strings or invalid XML GenericFile objects allows remote attackers to read arbitrary files via an XML External Entity (XXE) declaration. The XML External Entity (XXE) will be resolved before the Exception is thrown."
+mitigation: "2.13.x users should upgrade to 2.13.4, 2.14.x users should upgrade to 2.14.2. This patch will be included from Camel 2.15.0: https://git-wip-us.apache.org/repos/asf?p=camel.git;a=commitdiff;h=1df559649a96a1ca0368373387e542f46e4820da"
+credit: "This issue was discovered by Stephan Siano."
+affected: 2.13.0 up to 2.13.3, 2.14.0 up to 2.14.1
+fixed: 2.13.4, 2.14.2, 2.15.0 and newer
+---

--- a/content/security/CVE-2015-0264.txt.asc
+++ b/content/security/CVE-2015-0264.txt.asc
@@ -1,0 +1,38 @@
+-----BEGIN PGP SIGNED MESSAGE-----
+Hash: SHA1
+
+
+CVE-2015-0264: Apache Camel medium disclosure vulnerability
+
+Severity: MEDIUM
+
+Vendor: The Apache Software Foundation
+
+Versions Affected: Camel 2.13.0 to 2.13.3, Camel 2.14.0 to 2.14.1
+The unsupported Camel 2.3.x, 2.4.x, 2.5.x, 2.6.x, 2.7.x, 2.8.x, 2.9.x, 2.10.x, 2.11.x and 2.12.x versions may be also affected.
+
+Description: The XPath handling in Apache Camel for invalid XML Strings or invalid XML GenericFile objects allows remote attackers to read arbitrary files via an XML External Entity (XXE) declaration. The XML External Entity (XXE) will be resolved before the Exception is thrown.
+
+Mitigation: 2.13.x users should upgrade to 2.13.4, 2.14.x users should upgrade to 2.14.2. This patch will be included from Camel 2.15.0: https://git-wip-us.apache.org/repos/asf?p=camel.git;a=commitdiff;h=1df559649a96a1ca0368373387e542f46e4820da
+
+Credit: This issue was discovered by Stephan Siano.
+
+References: http://camel.apache.org/security-advisories.html
+-----BEGIN PGP SIGNATURE-----
+Version: GnuPG/MacGPG2 v2.0.22 (Darwin)
+Comment: GPGTools - http://gpgtools.org
+
+iQIcBAEBAgAGBQJU/saFAAoJEImh9lEqI5wsh5MQALhKWptMPv5ktFPxVcqORosf
+wXiUWvqL4MM67ZDzf4EqsOdMUWtoFB9gPD7ZUU529yji5uzEdPibrkvlPUUBkR6n
+funLrsIK3/rFsY/UFWJxGpm0ZWRbp+XqS8iykU27jsACQFPZVSTeURkYHAvKbwOj
+s6kAfF72y229kDGi12CP/z+r3XgL7dwrOCZ+Y+WxRUFq6TFSqECSn8+gQtRd9CN+
+/+sXjr+TBmVc2FBz06nFGbS72qVVVxKf0krdrqP8u34Ca9nV0686vozcINxH0CzC
+LtGuTCcyqFP+efEbEsC29SlAtQqq0zdTVLmlJF6CmC7yB5wSr0l9BE3nWPDx6OLI
+MXtoqXfdvQiOVQB8WlyP9D+c14Vl4U/ywuTERGl+e+QVSp35jdMju4UJJoMzGsM1
+2+PDm5BG7uuu5iuWQMTlwCBeJTPGhFLYrxTtwQ7zGvXZJdG7kElhzuESwDgo+gol
+i1AHBVS2w800AkStpSxo6El1/RiZJtq0hp1JJI8oWyUuY4zJqKRAQXtymOgH5xae
+o8BF5meg8UmidtQi9woG28o8VRxtfeZIhd/DeM6nuSWtFNdEItzV4ksm89F4Glhy
+oNLR1ufk5BJlG7EPj89w7MIklX70u3Q/LWeJOk6u6TGVxPhrZzOH2k7RMALIlKoB
+b4sZQjwpBaJG8hlJbvSK
+=8G1w
+-----END PGP SIGNATURE-----

--- a/content/security/CVE-2015-5344.md
+++ b/content/security/CVE-2015-5344.md
@@ -1,0 +1,20 @@
+---
+title: "Apache Camel Security Advisory - CVE-2015-5344"
+url: /security/CVE-2015-5344.html
+date: 2016-02-03T13:59:00.117000
+draft: false
+type: security-advisory
+cve: CVE-2015-5344
+severity: MEDIUM
+summary: "Apache Camel's XStream usage is vulnerable to Remote Code Execution attacks."
+description: "Apache Camel's camel-xstream component is vulnerable to Java object de-serialisation vulnerability. Such as de-serializing untrusted data can lead to security flaws as demonstrated in various similar reports about Java de-serialization issues."
+mitigation: "2.15.x users should upgrade to 2.15.5, 2.16.0 users should upgrade to 2.16.1. And if you are using camel-xstream to serialize payload to Java objects, then you need to explicitly list trusted packages. To see how to do that, please take a look at: http://camel.apache.org/xstream"
+credit: "This issue was discovered by Christian Schneider."
+affected: 2.15.0 up to 2.15.4, 2.16.0
+fixed: 2.15.5, 2.16.1 and newer
+---
+
+The JIRA ticket: https://issues.apache.org/jira/browse/CAMEL-9297 refers to the various commits that resovoled the issue, and have more details.
+
+A related xstream de-serialization vulnerability was recently reported for Apache ActiveMQ: http://activemq.apache.org/security-advisories.data/CVE-2015-5254-announcement.txt?version=1&modificationDate=1449589734000&api=v2
+

--- a/content/security/CVE-2015-5344.txt.asc
+++ b/content/security/CVE-2015-5344.txt.asc
@@ -1,0 +1,52 @@
+-----BEGIN PGP SIGNED MESSAGE-----
+Hash: SHA512
+
+=============================================
+
+CVE-2015-5344: Apache Camel's XStream usage is vulnerable
+to Remote Code Execution attacks
+
+Severity: MEDIUM
+
+Vendor: The Apache Software Foundation
+
+Versions Affected: Camel 2.15.0 to 2.15.4, Camel 2.16.0
+The unsupported Camel 2.x (2.14 and earlier) versions may be also affected.
+
+Description: Apache Camel's camel-xstream component is vulnerable to Java object
+de-serialisation vulnerability. Such as de-serializing untrusted data can lead
+to security flaws as demonstrated in various similar reports about Java de-serialization issues.
+
+Mitigation: 2.15.x users should upgrade to 2.15.5, 2.16.0 users should
+upgrade to 2.16.1. And if you are using camel-xstream to serialize payload to Java objects,
+then you need to explicitly list trusted packages. 
+
+To see how to do that, please take a look at: http://camel.apache.org/xstream
+
+The JIRA ticket: https://issues.apache.org/jira/browse/CAMEL-9297
+refers to the various commits that resovoled the issue, and have more details.
+
+Credit: This issue was discovered by Christian Schneider.
+
+A related xstream de-serialization vulnerability was recently reported for Apache ActiveMQ:
+http://activemq.apache.org/security-advisories.data/CVE-2015-5254-announcement.txt?version=1&modificationDate=1449589734000&api=v2
+
+
+=============================================
+-----BEGIN PGP SIGNATURE-----
+Comment: GPGTools - https://gpgtools.org
+
+iQIcBAEBCgAGBQJWqyUtAAoJEN1wUKdrQA9p+ooP+wRwqVaLWcCpVNur91oJY7Ez
+w0x+Rl/tNsGX6U/1Mow/iJSYPSvaDhjrfCUgwLYlhLp3MDvkYE5C9e2nBkQU1Jjl
+REo2R0t8NmOARqF9pvZIDKj0F2/JViaOB/gT3ENZSDbroX1T78jr4kL6Ro48VrVj
+4WyAdTgRR73t/2e/R8S+H+ObjkzCYvdcRI7swXdlrJhDy93t08ebf69UpxL5Zdr2
+Dk/yavsYqYDGObAVCgdkAMiMayNeEjPbb+dD4DnohTs5egXkCfc0Dqg1/l/NdTK9
+ONTlGeFyNNLCAoyNd8iJZPR0mwi/juAfVA2zqabnMoZvosM6YwXqjzg8/5OLbaiZ
+765Dr7wP+zgUmB0y7AR+LMqjCvaw2jprOo17jtjMEBOAojaWWEJTl3ZBTdLYDAKE
+qfpbwPLcY+sBdBO93LM6g92kQ3AFnH3Gcc3J1dKvQuI2NEd/0EfKWGCCAMXXaHg/
+9hJjtWgCuzIXqHXptcu5CzfU0QPyNd30+3HpgEYR2XavUi4RVm+FvqPZh6b67ZHX
+X7GsRGkLcSFbDFtSAhLYKTp0P50AKo7l2W16ZZFJi0v7c9cZ7J1UbyjQxa67gfR4
+yH23PYKU3Bh7U1gZiqDVRw8jXjAuc5WLH/fJg4e0Vrlhxa2W8qcykSu745T9b7+9
+Hu/gcBdRJG8ZWo9XzSsH
+=zUaO
+-----END PGP SIGNATURE-----

--- a/content/security/CVE-2015-5348.md
+++ b/content/security/CVE-2015-5348.md
@@ -1,0 +1,20 @@
+---
+title: "Apache Camel Security Advisory - CVE-2015-5348"
+url: /security/CVE-2015-5348.html
+date: 2016-04-15T11:59:00.110000
+draft: false
+type: security-advisory
+cve: CVE-2015-5348
+severity: MEDIUM
+summary: "Apache Camel's Jetty/Servlet usage is vulnerable to Java object de-serialisation vulnerability."
+description: "Apache Camel's Jetty/Servlet usage is vulnerable to Java object de-serialisation vulnerability"
+mitigation: "2.15.x users should upgrade to 2.15.5, 2.16.0 users should upgrade to 2.16.1."
+credit: "This issue was discovered by Sim Yih Tsern."
+affected: 2.15.0 up to 2.15.4, 2.16.0
+fixed: 2.15.5, 2.16.1 and newer
+---
+
+If using camel-jetty, or camel-servlet as a consumer in Camel routes, then Camel will automatic de-serialize HTTP requests that uses the content-header: application/x-java-serialized-object. 
+
+The JIRA ticket: https://issues.apache.org/jira/browse/CAMEL-9309 refers to the various commits that resovoled the issue.
+

--- a/content/security/CVE-2015-5348.txt.asc
+++ b/content/security/CVE-2015-5348.txt.asc
@@ -1,0 +1,37 @@
+-----BEGIN PGP SIGNED MESSAGE-----
+Hash: SHA512
+
+CVE-2015-5348: Apache Camel medium disclosure vulnerability
+
+Severity: MEDIUM
+
+Vendor: The Apache Software Foundation
+
+Versions Affected: Camel 2.15.0 to 2.15.4, Camel 2.16.0
+The unsupported Camel 2.6.x, 2.7.x, 2.8.x, 2.9.x, 2.10.x, 2.11.x, 2.12.x, 2.13.x, and 2.14.x are also affected.
+
+Description: Apache Camel's Jetty/Servlet usage is vulnerable to Java object de-serialisation vulnerability
+
+If using camel-jetty, or camel-servlet as a consumer in Camel routes, then Camel will automatic de-serialize HTTP requests that uses the content-header: application/x-java-serialized-object. 
+
+Mitigation: 2.15.x users should upgrade to 2.15.5, 2.16.0 users should upgrade to 2.16.1.
+The JIRA ticket: https://issues.apache.org/jira/browse/CAMEL-9309 refers to the various commits that resovoled the issue.
+
+Credit: This issue was discovered by Sim Yih Tsern.
+-----BEGIN PGP SIGNATURE-----
+Comment: GPGTools - https://gpgtools.org
+
+iQIcBAEBCgAGBQJWcnDDAAoJEN1wUKdrQA9pc2IQANO6MRTi2J5xjWrNJ9vFGMEK
+5Mm6SXnn0KAYp/ET2WxBfe7D9V+WpcmGejost+7zhixKZ6sqo9uaQ45JRd5Ce6vg
+gOfcJVEp0tJWtfR3Tgzpe9x8iL76zrRHlFlUFlo3w09AfA3H/ogeV+jE7in6P/Fu
+JNlDWdbmV/WbflaqU643uo6/kScuE5Nzmhdon7QLnztirCzkFSXgx9t9+2mc9X+t
+FfliGvIxM54nZ/RR13SeE0BFh4KS2+kEZRivB3fyRMl3pwWzU3pYxYJt81AsupJb
+razSEon5281M2G1zaZK8ng/6P3bHACHkOYK6ivsdkQ4zg4YKnShU1nkX2BBBXXrd
+dhn5ilcmA65R4jq7Vzk9D3QwwN9Io+0OPdca1WeT79qLpCqlkMOuJQFE6hIfVoQe
+sTmz5QIoPyQIWP1tPQS+QzSDx+zNlqte4t48wRkTqXuja/sfi5JzuXtDJwBjGt+L
+FO1oA2CEoaiCzOdCVthvZrNBsgYCig7dmeKaYzVRCm1oYHkwd7hCvsg261uOSTHJ
+glZrmn3FT/G7qx6MaNLXQD6UZ5XMwx5ToSnILCORDf2UH8sEtyJfkJtIOIQxTeh4
++vV9GYDxNOV/rpqfxcYzyIcfcGK2R4MaoAdLx4RSJoZSz88N2372pTs4pZGAmS7K
+cXFnb/HjMssv62nffgkE
+=Qn8/
+-----END PGP SIGNATURE-----

--- a/content/security/CVE-2016-8749.md
+++ b/content/security/CVE-2016-8749.md
@@ -1,0 +1,18 @@
+---
+title: "Apache Camel Security Advisory - CVE-2016-8749"
+url: /security/CVE-2016-8749.html
+date: 2017-03-28T14:59:00.143000
+draft: false
+type: security-advisory
+cve: CVE-2016-8749
+severity: MEDIUM
+summary: "Apache Camel's Jackson and JacksonXML unmarshalling operation are vulnerable to Remote Code Execution attacks"
+description: "Apache Camel's camel-jackson and camel-jacksonxml components are vulnerable to Java object de-serialisation vulnerability. Camel allows to specify such a type through the 'CamelJacksonUnmarshalType' property. De-serializing untrusted data can lead to security flaws as demonstrated in various similar reports about Java de-serialization issues."
+mitigation: "2.16.x users should upgrade to 2.16.5, 2.17.x users should upgrade to 2.17.5, 2.18.x users should upgrade to 2.18.2."
+credit: "This issue was discovered by Moritz Bechler from AgNO3 GmbH & Co."
+affected: 2.16.0 up to 2.16.4, 2.17.0 up to 2.17.4, 2.18.0 up to 2.18.1
+fixed: 2.16.5, 2.17.5, 2.18.2
+---
+
+The JIRA tickets: https://issues.apache.org/jira/browse/CAMEL-10567 and https://issues.apache.org/jira/browse/CAMEL-10604 refers to the various commits that resovoled the issue, and have more details.
+

--- a/content/security/CVE-2016-8749.txt.asc
+++ b/content/security/CVE-2016-8749.txt.asc
@@ -1,0 +1,35 @@
+-----BEGIN PGP SIGNED MESSAGE-----
+Hash: SHA1
+
+CVE-2016-8749: Apache Camel's Jackson and JacksonXML unmarshalling operation are vulnerable
+to Remote Code Execution attacks
+
+Severity: MEDIUM
+
+Vendor: The Apache Software Foundation
+
+Versions Affected: Camel 2.16.0 to 2.16.4, Camel 2.17.0 to 2.17.4, Camel 2.18.0 to 2.18.1
+The unsupported Camel 2.x (2.14 and earlier) versions may be also affected.
+
+Description: Apache Camel's camel-jackson and camel-jacksonxml components are vulnerable to Java object
+de-serialisation vulnerability. Camel allows to specify such a type through the 'CamelJacksonUnmarshalType'
+property. De-serializing untrusted data can lead to security flaws as demonstrated in various similar reports about Java de-serialization issues.
+
+Mitigation: 2.16.x users should upgrade to 2.16.5, 2.17.x users should upgrade to 2.17.5, 2.18.x users should
+upgrade to 2.18.2. 
+
+The JIRA tickets: https://issues.apache.org/jira/browse/CAMEL-10567 and https://issues.apache.org/jira/browse/CAMEL-10604
+refers to the various commits that resovoled the issue, and have more details.
+
+Credit: This issue was discovered by Moritz Bechler from AgNO3 GmbH & Co.
+-----BEGIN PGP SIGNATURE-----
+Version: GnuPG v2.0.22 (GNU/Linux)
+
+iQEcBAEBAgAGBQJYmy0QAAoJEONOnzgC/0EABM0H/2hA/LOWlYB9iatYjg054mqZ
+BxMgMrDbvapoTr/ga7FPgm48nTlWlI2Xw0chOV3ZMg1fgH/rCEAhaMQnEgyd4Aor
+tVl8GW43bKwiYv+QrTWmQLXeK4PJHtR8DP0LG7f2EDvwsFcRSo0yE5MmsrQFiWjM
+rXEZINqe56s60pgrdFU0aqsf37iciI9A/UYnOZeBHLQf9QaZv38AMVrTz1awRoX7
+R6b3RvYh0qjGcyYMVH7RDTZ8BS+XdX3GZVKTFPFTZgMjKofA/XDJiOsMJsE2rT+1
+eSOd3Gr2LTIgXAhX1BH1FBghoHXV7hxKmwYo1yT7Dqw2xpdANUtlaEhtTP/Dl9I=
+=/6Ky
+-----END PGP SIGNATURE-----

--- a/content/security/CVE-2017-12633.md
+++ b/content/security/CVE-2017-12633.md
@@ -1,0 +1,18 @@
+---
+title: "Apache Camel Security Advisory - CVE-2017-12633"
+url: /security/CVE-2017-12633.html
+date: 2017-11-15T10:29:00.210000
+draft: false
+type: security-advisory
+cve: CVE-2017-12633
+severity: MEDIUM
+summary: "Apache Camel's Hessian unmarshalling operation is vulnerable to Remote Code Execution attacks"
+description: "Apache Camel's camel-hessian component is vulnerable to Java object de-serialisation vulnerability. De-serializing untrusted data can lead to security flaws."
+mitigation: "2.19.x users should upgrade to 2.19.4, 2.20.0 users should upgrade to 2.20.1."
+credit: "This issue was discovered by Moritz Bechler from AgNO3 GmbH & Co."
+affected: 2.19.0 up to 2.19.3, 2.20.0
+fixed: 2.19.4, 2.20.1 and newer
+---
+
+The JIRA ticket: https://issues.apache.org/jira/browse/CAMEL-11923 refers to the various commits that resovoled the issue, and have more details.
+

--- a/content/security/CVE-2017-12633.txt.asc
+++ b/content/security/CVE-2017-12633.txt.asc
@@ -1,0 +1,33 @@
+-----BEGIN PGP SIGNED MESSAGE-----
+Hash: SHA1
+
+CVE-2017-12633: Apache Camel's Hessian unmarshalling operation is vulnerable
+to Remote Code Execution attacks
+
+Severity: MEDIUM
+
+Vendor: The Apache Software Foundation
+
+Versions Affected: Camel 2.19.0 to 2.19.3 and Camel 2.20.0
+The unsupported Camel 2.x (2.18 and earlier) versions may be also affected.
+
+Description: Apache Camel's camel-hessian component is vulnerable to Java object
+de-serialisation vulnerability. De-serializing untrusted data can lead to security flaws.
+
+Mitigation: 2.19.x users should upgrade to 2.19.4, 2.20.0 users should upgrade to 2.20.1. 
+
+The JIRA ticket: https://issues.apache.org/jira/browse/CAMEL-11923
+refers to the various commits that resovoled the issue, and have more details.
+
+Credit: This issue was discovered by Moritz Bechler from AgNO3 GmbH & Co.
+-----BEGIN PGP SIGNATURE-----
+Version: GnuPG v2.0.22 (GNU/Linux)
+
+iQEcBAEBAgAGBQJaC/hCAAoJEONOnzgC/0EANYoH/3L/EMwTMeF/bHw+rHN6TYEf
+vS6fYmpG9zygJt0yIA+yHqgidxKdtPHpoOnBhCw/pQsoiEpDTe75eiilTE6j5U1d
+DDtHri3Im45WEL28BeHfb5Eme2ccVj055pYgPnQpGTN2cO5+rkykWdU/obfk44Rr
+01b8a+i0nM+LJ9N6Tw8n1wQMvfwNYQTHdK1RVXYbm2JedjJYHGBgqgjEZOfrCQ1r
+QNqSr9U0hkt0CdYgxGIY2WJi/AIHwLbOuYH3u+m02WJgw2abJRRabLNMiQCz93IF
+k9FZBUTf2I45FPpT/Y5FC5+HgKzW40vTCRAcuZlpwdq9Kv8nF3DFcsPVxBSM9ok=
+=knWB
+-----END PGP SIGNATURE-----

--- a/content/security/CVE-2017-12634.md
+++ b/content/security/CVE-2017-12634.md
@@ -1,0 +1,17 @@
+---
+title: "Apache Camel Security Advisory - CVE-2017-12634"
+url: /security/CVE-2017-12634.html
+date: 2017-11-15T10:29:00.257000
+draft: false
+type: security-advisory
+cve: CVE-2017-12634
+severity: MEDIUM
+summary: "Apache Camel's Castor unmarshalling operation is vulnerable to Remote Code Execution attacks"
+description: "Apache Camel's camel-castor component is vulnerable to Java object de-serialisation vulnerability. De-serializing untrusted data can lead to security flaws."
+mitigation: "2.19.x users should upgrade to 2.19.4, 2.20.0 users should upgrade to 2.20.1."
+credit: "This issue was discovered by Man Yue Mo <mmo at semmle dot com> from Semmle/lgtm.com."
+affected: 2.19.0 up to 2.19.3, 2.20.0
+fixed: 2.19.4, 2.20.1 and newer
+---
+
+The JIRA ticket: https://issues.apache.org/jira/browse/CAMEL-11929 refers to the various commits that resovoled the issue, and have more details.

--- a/content/security/CVE-2017-12634.txt.asc
+++ b/content/security/CVE-2017-12634.txt.asc
@@ -1,0 +1,33 @@
+-----BEGIN PGP SIGNED MESSAGE-----
+Hash: SHA1
+
+CVE-2017-12634: Apache Camel's Castor unmarshalling operation is vulnerable
+to Remote Code Execution attacks
+
+Severity: MEDIUM
+
+Vendor: The Apache Software Foundation
+
+Versions Affected: Camel 2.19.0 to 2.19.3 and Camel 2.20.0
+The unsupported Camel 2.x (2.18 and earlier) versions may be also affected.
+
+Description: Apache Camel's camel-castor component is vulnerable to Java object
+de-serialisation vulnerability. De-serializing untrusted data can lead to security flaws.
+
+Mitigation: 2.19.x users should upgrade to 2.19.4, 2.20.0 users should upgrade to 2.20.1. 
+
+The JIRA ticket: https://issues.apache.org/jira/browse/CAMEL-11929
+refers to the various commits that resovoled the issue, and have more details.
+
+Credit: This issue was discovered by Man Yue Mo <mmo at semmle dot com> from Semmle/lgtm.com.
+-----BEGIN PGP SIGNATURE-----
+Version: GnuPG v2.0.22 (GNU/Linux)
+
+iQEcBAEBAgAGBQJaC/hNAAoJEONOnzgC/0EAjcgH/0pwXq7bn9HTnKJOswZ64QWA
+7yhFD2UASVaV3jZJnl/gavlHeLXqGdi+jBs2INxveNF9MWdSacRfi6aO+4scYZDw
+18Ra+nH2FVeIeO3VhrI0WQTTK9TNByLmiZ3Rn0v2eH06XV7Oc3MR5JsdEHBR3YCx
+T6TLqGB8QD/fXICmr5ztLeIVAWMFhThNVHiNX281cOtiyZrWWNHGfJAKTPEVz+nL
+/EiNn7M2o/8NGWNVr1rC+yBAGxoMrSd7eyNoMC7kd42uF+rpJWzi/QE8we6wQrDO
+3hhzUJsmAHv+Ap/97gp/Z+plDvysDREj3YnFMUFrJkJeBVqeg5c8XJGTiwMCN+k=
+=Cb8h
+-----END PGP SIGNATURE-----

--- a/content/security/CVE-2017-3159.md
+++ b/content/security/CVE-2017-3159.md
@@ -1,0 +1,17 @@
+---
+title: "Apache Camel Security Advisory - CVE-2017-3159"
+url: /security/CVE-2017-3159.html
+date: 2017-03-07T10:59:00.517000
+draft: false
+type: security-advisory
+cve: CVE-2017-3159
+severity: MEDIUM
+summary: "Apache Camel's Snakeyaml unmarshalling operation is vulnerable to Remote Code Execution attacks"
+description: "Apache Camel's camel-snakeyaml component is vulnerable to Java object de-serialisation vulnerability. De-serializing untrusted data can lead to security flaws."
+mitigation: "2.17.x users should upgrade to 2.17.5, 2.18.x users should upgrade to 2.18.2."
+credit: "This issue was discovered by Moritz Bechler from AgNO3 GmbH & Co."
+affected: 2.17.0 up to 2.17.4, 2.18.0 up to 2.18.1
+fixed: 2.17.5, 2.18.2 and newer
+---
+
+The JIRA ticket: https://issues.apache.org/jira/browse/CAMEL-10575 refers to the various commits that resovoled the issue, and have more details.

--- a/content/security/CVE-2017-3159.txt.asc
+++ b/content/security/CVE-2017-3159.txt.asc
@@ -1,0 +1,33 @@
+-----BEGIN PGP SIGNED MESSAGE-----
+Hash: SHA1
+
+CVE-2017-3159: Apache Camel's Snakeyaml unmarshalling operation is vulnerable
+to Remote Code Execution attacks
+
+Severity: MEDIUM
+
+Vendor: The Apache Software Foundation
+
+Versions Affected: Camel 2.17.0 to 2.17.4, Camel 2.18.0 to 2.18.1
+The unsupported Camel 2.x (2.14 and earlier) versions may be also affected.
+
+Description: Apache Camel's camel-snakeyaml component is vulnerable to Java object
+de-serialisation vulnerability. De-serializing untrusted data can lead to security flaws.
+
+Mitigation: 2.17.x users should upgrade to 2.17.5, 2.18.x users should upgrade to 2.18.2. 
+
+The JIRA ticket: https://issues.apache.org/jira/browse/CAMEL-10575
+refers to the various commits that resovoled the issue, and have more details.
+
+Credit: This issue was discovered by Moritz Bechler from AgNO3 GmbH & Co.
+-----BEGIN PGP SIGNATURE-----
+Version: GnuPG v2.0.22 (GNU/Linux)
+
+iQEcBAEBAgAGBQJYmy8MAAoJEONOnzgC/0EAujYIAI7eOnnkKE7wcHXjMeqUUDrb
+EyqEFaWuUWenUhx5PoVu2zQ0m9m1uRC3vzRQTJzZpN83WOlkDUlcXcJzLAWDy1AW
+W9dHgDTaP2zbUIPKo4Zjy+pur9afirAMRasCS0NAWAETHVi54ZBpCFQVkxk72xdO
+pLxAAnvTQfxbCfqEgTlzttU0ovaG4DOvAteQfpHZyjPxGaY3T15pAGK0ZOBvmd0T
+jATx/Nk3CoSuC8n6ECAbBcenRtycRh6HwvA6HFDFpgR3EI/FOq2/ikG4bLyJdgTW
+VsTmanwq4zKtlhQAAyQvfSJcr/7EoRL1k4Ui0D2oZvMat1fQnwOR13QQQmb73RU=
+=U+u3
+-----END PGP SIGNATURE-----

--- a/content/security/CVE-2017-5643.md
+++ b/content/security/CVE-2017-5643.md
@@ -1,0 +1,17 @@
+---
+title: "Apache Camel Security Advisory - CVE-2017-5643"
+url: /security/CVE-2017-5643.html
+date: 2017-03-16T11:59:00.947000
+draft: false
+type: security-advisory
+cve: CVE-2017-5643
+severity: MEDIUM
+summary: "Apache Camel's Validation Component is vulnerable against SSRF via remote DTDs and XXE"
+description: "The Validation Component of Apache Camel evaluates DTD headers of XML stream sources, although a validation against XML schemas (XSD) is executed. Remote attackers can use this feature to make Server-Side Request Forgery (SSRF) attacks by sending XML documents with remote DTDs URLs or XML External Entities (XXE).  The vulnerability is not given for SAX or StAX sources."
+mitigation: "2.17.x users should upgrade to 2.17.6, 2.18.x users should upgrade to 2.18.3."
+credit: "This issue was discovered by Franz Forsthofer"
+affected: 2.17.0 up to 2.17.5, 2.18.0 up to 2.18.2
+fixed: 2.17.6, 2.18.3 and newer
+---
+
+The JIRA tickets https://issues.apache.org/jira/browse/CAMEL-10894 refers to the various commits that resolved the issue, and have more details.

--- a/content/security/CVE-2017-5643.txt.asc
+++ b/content/security/CVE-2017-5643.txt.asc
@@ -1,0 +1,30 @@
+-----BEGIN PGP SIGNED MESSAGE-----
+Hash: SHA1
+
+CVE-2017-5643: Apache Camel's Validation Component is vulnerable against SSRF via remote DTDs and XXE.
+
+Severity: MEDIUM
+
+Vendor: The Apache Software Foundation
+
+Versions Affected: Camel 2.17.0 to 2.17.5, Camel 2.18.0 to 2.18.2
+The unsupported Camel 2.x (2.16 and earlier) versions may be also affected.
+
+Description: The Validation Component of Apache Camel evaluates DTD headers of XML stream sources, although a validation against XML schemas (XSD) is executed. Remote attackers can use this feature to make Server-Side Request Forgery (SSRF) attacks by sending XML documents with remote DTDs URLs or XML External Entities (XXE).  The vulnerability is not given for SAX or StAX sources.
+
+Mitigation: 2.17.x users should upgrade to 2.17.6, 2.18.x users should upgrade to 2.18.3. 
+
+The JIRA tickets https://issues.apache.org/jira/browse/CAMEL-10894 refers to the various commits that resolved the issue, and have more details.
+
+Credit: This issue was discovered by Franz Forsthofer
+-----BEGIN PGP SIGNATURE-----
+Version: GnuPG v2.0.22 (GNU/Linux)
+
+iQEcBAEBAgAGBQJYykp3AAoJEONOnzgC/0EAW1IH+gK4vn5vD+Nve0BWGjMwi7ja
+37HH89UdViakH44YBhUObxXrZ+zAJ53fSuXhorcH8zT8hSdgIhuSkhvMKfWfSr5t
+pVAh2sNLO8Mnpv/8K2HZ8QVL5RuaYdDcI19TAYO2iSrxI+PX8P3SGqbBmNu1c6E3
+0uVJSCcBscvSporgXdNi4+Oh8YpuuQAmocHbUJf+kK8Sc/Z7rTlMzCJwORvuoekM
+0HDC+bfhNgoBU/k6qclTxTEbxMByDX354go/fz8RB/VKzaLuT8UcMp5rvgIYBJTs
+kT6K2NchfXIMo8Zmq2iq3QfabtuXgsJtUjYRFHasrFSvrzoqzXpoaTE1XCFgobE=
+=BTx+
+-----END PGP SIGNATURE-----

--- a/content/security/CVE-2018-8027.md
+++ b/content/security/CVE-2018-8027.md
@@ -1,0 +1,18 @@
+---
+title: "Apache Camel Security Advisory - CVE-2018-8027"
+url: /security/CVE-2018-8027.html
+date: 2018-07-31T09:29:00.857000
+draft: false
+type: security-advisory
+cve: CVE-2018-8027
+severity: MEDIUM
+summary: "Apache Camel's Core is vulnerable to XXE in XSD validation processor"
+description: "Apache Camel's Core is vulnerable to XXE External Entity vulnerability XSD validation processor."
+mitigation: "2.20.x users should upgrade to 2.20.4, 2.21.0 users should upgrade to 2.21.1. The JIRA tickets: https://issues.apache.org/jira/browse/CAMEL-12444 and https://issues.apache.org/jira/browse/CAMEL-10894 (partial fix) refer to the various commits that resovoled the issue, and have more details."
+credit: "This issue was discovered by Karel Jelínek <karel dot jelinek at unicorn dot com> from Unicorn Systems."
+affected: 2.20.0 up to 2.20.3, 2.21.0
+fixed: 2.20.4, 2.21.1 and newer
+---
+
+The JIRA tickets: https://issues.apache.org/jira/browse/CAMEL-12444 and https://issues.apache.org/jira/browse/CAMEL-10894 (partial fix) refer to the various commits that resovoled the issue, and have more details.
+

--- a/content/security/CVE-2018-8027.txt.asc
+++ b/content/security/CVE-2018-8027.txt.asc
@@ -1,0 +1,31 @@
+-----BEGIN PGP SIGNED MESSAGE-----
+Hash: SHA1
+
+CVE-2018-8027: Apache Camel's Core is vulnerable to XXE in XSD validation processor
+
+Severity: MEDIUM
+
+Vendor: The Apache Software Foundation
+
+Versions Affected: Camel 2.20.0 to 2.20.3 and Camel 2.21.0
+The unsupported Camel 2.x (2.19 and earlier) versions may be also affected.
+
+Description: Apache Camel's Core is vulnerable to XXE External Entity vulnerability XSD validation processor.
+
+Mitigation: 2.20.x users should upgrade to 2.20.4, 2.21.0 users should upgrade to 2.21.1. 
+
+The JIRA tickets: https://issues.apache.org/jira/browse/CAMEL-12444 and https://issues.apache.org/jira/browse/CAMEL-10894 (partial fix)
+refer to the various commits that resovoled the issue, and have more details.
+
+Credit: This issue was discovered by Karel Jelínek <karel dot jelinek at unicorn dot com> from Unicorn Systems.
+-----BEGIN PGP SIGNATURE-----
+Version: GnuPG v2.0.22 (GNU/Linux)
+
+iQEcBAEBAgAGBQJbYAqQAAoJEONOnzgC/0EABaoIALQPhIMQnay46DuHSs6j369P
+FgDCWP9gI5ObErP0CDFB+B0ubTPFgeieQPJ1/x5h1/V1zOakO30q4P+omHfL69xt
+5WbOEPG4vO6w3AugaJ8Hxu9ixLMBfBWc2Blt5ABxSxz+dmOmEgRt0Rfwy81KwbUL
+jzx7mo9v0kEd6E8i31yc+nlfYLgkRL+j4CWI2HbfngEh/vm1HRUHMvM/lbw3c+O7
+q0Xkfu5hwCBiNG4AZLGvPXyVy50Woi6DqdS0wydZSdS5gppdYo72I/jm1Q31m+uy
+cR7ytwOn9TPbOQ1MQbk7cJB1Y9zNY1Uy4A74bHGPyXMIP9hrSbS4khxspbFH2Xw=
+=/C9K
+-----END PGP SIGNATURE-----

--- a/content/security/CVE-2018-8041.md
+++ b/content/security/CVE-2018-8041.md
@@ -1,0 +1,18 @@
+---
+title: "Apache Camel Security Advisory - CVE-2018-8041"
+url: /security/CVE-2018-8041.html
+date: 2018-09-17T10:29:00.920000
+draft: false
+type: security-advisory
+cve: CVE-2018-8041
+severity: MEDIUM
+summary: "Apache Camel's Mail is vulnerable to path traversal"
+description: "Apache Camel's Mail is vulnerable to path traversal"
+mitigation: "2.20.x users should upgrade to 2.20.4, 2.21.0 users should upgrade to 2.21.2 and Camel 2.22.x users should upgrade to 2.22.1"
+credit: "This issue was discovered by Eedo Shapira <eedo dot shapira at ge dot com> from GE."
+affected: 2.20.0 up to 2.20.3, 2.21.0 up to 2.21.1, 2.22.0
+fixed: 2.20.4, 2.21.1, 2.22.1 and newer
+---
+
+The JIRA tickets: https://issues.apache.org/jira/browse/CAMEL-12630 refers to the various commits that resovoled the issue, and have more details.
+

--- a/content/security/CVE-2018-8041.txt.asc
+++ b/content/security/CVE-2018-8041.txt.asc
@@ -1,0 +1,32 @@
+-----BEGIN PGP SIGNED MESSAGE-----
+Hash: SHA1
+
+CVE-2018-8041: Apache Camel's Mail is vulnerable to path traversal
+
+Severity: MEDIUM
+
+Vendor: The Apache Software Foundation
+
+Versions Affected: Camel 2.20.0 to 2.20.3, Camel 2.21.0 to 2.21.1 and Camel 2.22.0 
+
+The unsupported Camel 2.x (2.19 and earlier) versions may be also affected.
+
+Description: Apache Camel's Mail is vulnerable to path traversal
+
+Mitigation: 2.20.x users should upgrade to 2.20.4, 2.21.0 users should upgrade to 2.21.2 and Camel 2.22.x users should upgrade to 2.22.1
+
+The JIRA tickets: https://issues.apache.org/jira/browse/CAMEL-12630 
+refers to the various commits that resovoled the issue, and have more details.
+
+Credit: This issue was discovered by Eedo Shapira <eedo dot shapira at ge dot com> from GE .
+-----BEGIN PGP SIGNATURE-----
+Version: GnuPG v2.0.22 (GNU/Linux)
+
+iQEcBAEBAgAGBQJbmOMKAAoJEONOnzgC/0EAfSkH+wdNhAyFodwWREYgmHNbxTdf
+c3JFH+jeqCpg1wiDZmGS4GpRi0f7s4W09tTIgiTtFhJINzpxJ6JOkZX8AzB43bSx
+g83RdYmAplgrYaeY4dQnjAN9LrUSHTbLxWKsG+gR0FigkmL3B3qM30jGD3T4t3WM
+AJ5PXRR87v85I9A1CzjtBgrxY6Zjn8A70Jm1AYdQ83Ywwj8dUD8Sw8qiFl/V/VBm
+P77Y6/S0PzBu6AJR5k+31dy5aZaStwts0uWuCwwZl74DfDVwgM44rj9WTRJ9aseq
+hc9T/Y3S7JKHMA3oo6Wu3MjU9kSO1PQ39CNO5/oCnjAtk4SVVSwU3wNYlXWj1t0=
+=3846
+-----END PGP SIGNATURE-----

--- a/content/security/CVE-2019-0194.md
+++ b/content/security/CVE-2019-0194.md
@@ -1,0 +1,18 @@
+---
+title: "Apache Camel Security Advisory - CVE-2019-0194"
+url: /security/CVE-2019-0194.html
+date: 2019-04-30T18:29:00.607000
+draft: false
+type: security-advisory
+cve: CVE-2019-0194
+severity: MEDIUM
+summary: "Apache Camel's File is vulnerable to directory traversal"
+description: "Apache Camel's File is vulnerable to directory traversal"
+mitigation: "2.21.x users should upgrade to 2.21.5, 2.22.x users should upgrade to 2.22.3 and Camel 2.23.x users should upgrade to 2.23.1"
+credit: "This issue was discovered by Colm O. HEigeartaigh <coheigea at apache dot org> from Apache Software Foundation"
+affected: 2.21.0 up to 2.21.3, 2.22.0 up to 2.22.2, 2.23.0
+fixed: 2.21.5, 2.22.3, 2.23.1
+---
+
+The JIRA ticket: https://issues.apache.org/jira/browse/CAMEL-13042 refers to the various commits that resovoled the issue, and have more details.
+

--- a/content/security/CVE-2019-0194.txt.asc
+++ b/content/security/CVE-2019-0194.txt.asc
@@ -1,0 +1,27 @@
+-----BEGIN PGP SIGNED MESSAGE-----
+Hash: SHA1
+
+CVE-2019-0194: Apache Camel's File is vulnerable to directory traversal
+
+Severity: MEDIUM
+
+Vendor: The Apache Software Foundation
+
+Versions Affected: Camel 2.21.0 to 2.21.3, Camel 2.22.0 to 2.22.2 and Camel 2.23.0 The unsupported Camel 2.x (2.19 and earlier) versions may be also affected.
+
+Description: Apache Camel's File is vulnerable to directory traversal
+
+Mitigation: 2.21.x users should upgrade to 2.21.5, 2.22.x users should upgrade to 2.22.3 and Camel 2.23.x users should upgrade to 2.23.1 The JIRA tickets: https://issues.apache.org/jira/browse/CAMEL-13042 refers to the various commits that resovoled the issue, and have more details.
+
+Credit: This issue was discovered by Colm O. HEigeartaigh <coheigea at apache dot org> from Apache Software Foundation
+-----BEGIN PGP SIGNATURE-----
+Version: GnuPG v2.0.22 (GNU/Linux)
+
+iQEcBAEBAgAGBQJcyCQMAAoJEONOnzgC/0EAoi4H/iqigma2trual75FfCiiJuRz
+HEwjmJ+/aqWwGo5sBY53aDpD2OtCNylmCoRGDEgP3ToAv+WyEgfSXJYPjRJGT1wo
++8DLiHe3m5Z/tJk9sscYPn5s9/4bd+gES16hBWNtTpF/yryvMMS9jgGWglgVHAD3
+wP9AyWV1HVbuf7axW/Q9SS/Tw0pgBfKTVuQrZBmMNpcO/0YTGQR3uIbr8KGpwq3P
+asNvlUgCub3osq4qM5OsjQTvtkGYQfHmnuotavKXuRZbBW18KxCaqcKQPUjOOedG
+SZ5aOhwNLCcXZ4A550FB6QJxAwRG/8SXzwXS90MT5WwFgfJKE3dzRAH2PWEIaxo=
+=u2h4
+-----END PGP SIGNATURE-----

--- a/content/security/_index.md
+++ b/content/security/_index.md
@@ -1,0 +1,16 @@
+---
+title: "Apache Camel security information"
+---
+
+# Apache Camel security information
+
+## Reporting new security problems with Apache Camel
+
+The Apache Software Foundation takes a very active stance in eliminating security problems.
+
+We strongly encourage folks to report such problems to the private security mailing list of the ASF Security Team, before disclosing them in a public forum.
+
+Please see the [page of the ASF Security Team](https://www.apache.org/security/) for further information and contact information.
+
+## Security advisories
+

--- a/layouts/security-advisory/single.html
+++ b/layouts/security-advisory/single.html
@@ -1,0 +1,30 @@
+{{ partial "header.html" . }}
+
+<div class="container pb-5">
+  <h4>Apache Camel security advisory: {{ .Params.cve }}</h4>
+  <h5>Severity</h5>
+  {{ .Params.severity }}
+  <h5>Summary</h5>
+  {{ .Params.summary }}
+  <h5>Versions affected</h5>
+  {{ .Params.affected }}
+  <h5>Versions fixed</h5>
+  {{ .Params.fixed }}
+  <h5>Description</h5>
+  {{ .Params.description }}
+  {{ with .Content }}
+  <h5>Notes</h5>
+  {{ . }}
+  {{ end }}
+  <h5>Mitigation</h5>
+  {{ .Params.mitigation | markdownify }}
+  <h5>Credit</h5>
+  {{ .Params.credit }}
+  <h5>References</h5>
+  <dl>
+    <dt>PGP signed advisory data: <a href="{{ .Params.cve }}.txt.asc">{{ .Params.cve }}.txt.asc</a></dt>
+    <dt>Mitre CVE Entry: <a href="https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2013-4330">https://cve.mitre.org/cgi-bin/cvename.cgi?name={{ .Params.cve }}</a></dt>
+  </dl>
+</div>
+
+{{ partial "footer.html" . }}

--- a/layouts/security/list.html
+++ b/layouts/security/list.html
@@ -1,0 +1,36 @@
+{{ partial "header.html" . }}
+
+<div class="container pb-5">
+  {{ .Content }}
+
+  <table class="table">
+    <caption>Security advisories by year</caption>
+    <thead>
+      <tr>
+        <td>Reference</td>
+        <td>Affected</td>
+        <td>Fixed</td>
+        <td>CVSS score</td>
+        <td>Description</td>
+      </tr>
+    </thead>
+    <tbody>
+  {{ range .Pages.GroupByDate "2006" "desc" }}
+      <tr>
+        <th colspan="5" scope="row"><strong>{{ .Key }}</strong></th>
+      </tr>
+      {{ range .Pages }}
+      <tr>
+        <td><a href="{{ .RelPermalink }}">{{ .Params.cve }}</a></td>
+        <td>{{ .Params.affected }}</td>
+        <td>{{ .Params.fixed }}</td>
+        <td>{{ .Params.severity }}</td>
+        <td>{{ .Params.summary }}</td>
+      </tr>
+      {{ end }}
+  {{ end }}
+    </tbody>
+  </table>
+</div>
+
+{{ partial "footer.html" . }}

--- a/static/.htaccess
+++ b/static/.htaccess
@@ -1,0 +1,3 @@
+RewriteEngine on
+RewriteRule "security-advisories.data/(.+)$" "security/$1" [R=permanent,L]
+


### PR DESCRIPTION
Adds two layouts for `security` and `security-advisory` and a archetype
for `security-advisory`. Security advisories are now served from
`/security` (instead of `/security-advisories.data`) so a `.htaccess`
file was added to redirect from previous URL to the current one.

README was updated to show how to use the Hugo archetype to publish a
new security advisory.