### PR TITLE
fix for external link errors, and dropdown navbar-link menu items were set to unclickable

### DIFF
--- a/antora-ui-camel/src/partials/header-content.hbs
+++ b/antora-ui-camel/src/partials/header-content.hbs
@@ -14,14 +14,14 @@
           {{#each @items}}
               {{#if children}}
               <div class="navbar-item has-dropdown is-hoverable">
-                <a class="navbar-link" href="{{../../siteRootPath}}{{url}}">{{name}}</a>
+                <a class="navbar-link">{{name}}</a>
               {{else}}
-              <a class="navbar-item" href="{{../../siteRootPath}}{{url}}">{{name}}</a>
+              <a class="navbar-item" href="{{siteRootPath}}{{url}}">{{name}}</a>
               {{/if}}
               {{#if children}}
               <div class="navbar-dropdown">
               {{#each children}}
-                <a class="navbar-item" href="{{../../../siteRootPath}}{{url}}">{{name}}</a>
+                <a class="navbar-item" href="{{siteRootPath}}{{url}}">{{name}}</a>
               {{/each}}
               </div>
               {{/if}}

--- a/antora-ui-camel/src/partials/header-content.hbs
+++ b/antora-ui-camel/src/partials/header-content.hbs
@@ -16,12 +16,12 @@
               <div class="navbar-item has-dropdown is-hoverable">
                 <a class="navbar-link">{{name}}</a>
               {{else}}
-              <a class="navbar-item" href="{{siteRootPath}}{{url}}">{{name}}</a>
+              <a class="navbar-item" href="{{url}}">{{name}}</a>
               {{/if}}
               {{#if children}}
               <div class="navbar-dropdown">
               {{#each children}}
-                <a class="navbar-item" href="{{siteRootPath}}{{url}}">{{name}}</a>
+                <a class="navbar-item" href="{{url}}">{{name}}</a>
               {{/each}}
               </div>
               {{/if}}

--- a/antora-ui-camel/src/partials/header-content.hbs
+++ b/antora-ui-camel/src/partials/header-content.hbs
@@ -14,14 +14,18 @@
           {{#each @items}}
               {{#if children}}
               <div class="navbar-item has-dropdown is-hoverable">
-                <a class="navbar-link">{{name}}</a>
+              <a class="navbar-link" href="#">{{name}}</a>
               {{else}}
-              <a class="navbar-item" href="{{url}}">{{name}}</a>
+              <a class="navbar-item" href="{{../../siteRootPath}}{{url}}">{{name}}</a>
               {{/if}}
               {{#if children}}
               <div class="navbar-dropdown">
               {{#each children}}
+                {{#hasPrefix url }}
                 <a class="navbar-item" href="{{url}}">{{name}}</a>
+                {{else}}
+                <a class="navbar-item" href="{{../../../siteRootPath}}{{url}}">{{name}}</a>
+                {{/hasPrefix}}
               {{/each}}
               </div>
               {{/if}}

--- a/content/community/mailing-list.md
+++ b/content/community/mailing-list.md
@@ -17,10 +17,10 @@ When posting to the mailing lists, use plain text mails. Do not use HTML mails. 
 {{< bootstrap-table "table table-hover text-left" >}}
 | List Name  | Address | Subscribe | Unsubscribe | Archive | Nabble (Online Forums) | Comment |
 |------------|---------|-----------|-------------|---------|------------------------|---------|
-| Camel User List  | users@camel.apache.org | [subscribe](users@camel.apache.org) | [unsubscribe](users@camel.apache.org) | [Archives](http://mail-archives.apache.org/mod_mbox/camel-users/) | [Nabble](http://camel.465427.n5.nabble.com/Camel-Users-f465428.html) | Use this list for your Camel questions. |
-| Camel Developer List  | dev@camel.apache.org | [subscribe](dev@camel.apache.org) | [unsubscribe](dev@camel.apache.org) | [Archives](http://mail-archives.apache.org/mod_mbox/camel-dev/) | [Nabble](http://camel.465427.n5.nabble.com/Camel-Development-f479097.html) | |
-| Camel Commits List  | commits@camel.apache.org | [subscribe](commits@camel.apache.org) | [unsubscribe](commits@camel.apache.org) | [Archives](http://mail-archives.apache.org/mod_mbox/camel-commits/) | [Nabble](http://camel.465427.n5.nabble.com/Camel-Commits-f498405.html) | |
-| Camel Issues List  | issues@camel.apache.org | [subscribe](issues@camel.apache.org) | [unsubscribe](issues@camel.apache.org) | [Archives](http://mail-archives.apache.org/mod_mbox/camel-issues/) | | |
+| Camel User List  | users@camel.apache.org | [subscribe](mailto:users@camel.apache.org) | [unsubscribe](mailto:users@camel.apache.org) | [Archives](http://mail-archives.apache.org/mod_mbox/camel-users/) | [Nabble](http://camel.465427.n5.nabble.com/Camel-Users-f465428.html) | Use this list for your Camel questions. |
+| Camel Developer List  | dev@camel.apache.org | [subscribe](mailto:dev@camel.apache.org) | [unsubscribe](mailto:dev@camel.apache.org) | [Archives](http://mail-archives.apache.org/mod_mbox/camel-dev/) | [Nabble](http://camel.465427.n5.nabble.com/Camel-Development-f479097.html) | |
+| Camel Commits List  | commits@camel.apache.org | [subscribe](mailto:commits@camel.apache.org) | [unsubscribe](mailto:commits@camel.apache.org) | [Archives](http://mail-archives.apache.org/mod_mbox/camel-commits/) | [Nabble](http://camel.465427.n5.nabble.com/Camel-Commits-f498405.html) | |
+| Camel Issues List  | issues@camel.apache.org | [subscribe](mailto:issues@camel.apache.org) | [unsubscribe](mailto:issues@camel.apache.org) | [Archives](http://mail-archives.apache.org/mod_mbox/camel-issues/) | | |
 {{< /bootstrap-table >}}
 
 There were various discussions before these mailing lists were setup on the ActiveMQ Mailing Lists such as these [threads](http://www.nabble.com/forum/Search.jtp?forum=2354&local=y&query=%5Bcamel%5D)

--- a/menu.js
+++ b/menu.js
@@ -25,3 +25,12 @@ Handlebars.registerHelper('withMenuData', (options) => {
   });
 });
 
+Handlebars.registerHelper('hasPrefix', function(str, options) {
+  str = Handlebars.Utils.escapeExpression(str);
+  var matches = new RegExp(/http\S+/);
+  if (matches.test(str)) {
+    return options.fn(this);
+  }else {
+    return options.inverse(this);
+  }
+});


### PR DESCRIPTION
I came up with a fix for those external link errors and it works well. But now link checker gives 545 errors previously it was 112, But when I check new errors they are functioning well but still shows as an error. 

[error log](https://github.com/apache/camel-website/files/3365302/2019.7.7.txt)

Any suggestions?
