### PR TITLE
config.toml should include params inorder to perform microdata scripts correctly

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -7,6 +7,11 @@ staticDir = ["static", "documentation"]
 disableKinds = ["taxonomy", "taxonomyTerm"]
 enableRobotsTXT = true
 
+[params]
+    socialProfiles = ["https://twitter.com/ApacheCamel"]
+    organizationLogo = "https://camel.apache.org/_/img/logo-d.svg"
+    organizationDescription = "Apache Camel ™ is a versatile open-source integration framework based on known Enterprise Integration Patterns. Camel empowers you to define routing and mediation rules in a variety of domain-specific languages, including a Java-based Fluent API, Spring or Blueprint XML Configuration files, and a Scala DSL."
+
 [[menu.main]]
     name = "News"
     weight = 2


### PR DESCRIPTION
I`ve mistakenly forgotten to include this change into "microdata" section from "add search " section. But this change is necessary in order to perform microdata scripts correctly. Sorry for the mistake