### PR TITLE
CAMEL-13889: website - Tab title should be just Apache Camel

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -1,5 +1,5 @@
 ---
-title: Home page
+title: Home
 description: Camel is an open source integration framework that empowers you to quickly and easily integrate various systems consuming or producing data. 
 ---
 

--- a/content/news/_index.md
+++ b/content/news/_index.md
@@ -1,5 +1,5 @@
 ---
-title: "Apache Camel News"
+title: "News"
 ---
 
 # Apache Camel news


### PR DESCRIPTION
I've changed "Home page - Apache Camel" to "Home - Apache Camel".
I've also fixed the News page, which went from "Apache Camel News - Apache Camel" to "News - Apache Camel".