### PR TITLE
chore: new image shortcode

### DIFF
--- a/antora-ui-camel/src/css/blog.css
+++ b/antora-ui-camel/src/css/blog.css
@@ -83,9 +83,14 @@ article.blog p {
   width: auto;
 }
 
-.blog .post-content img.featured {
+.blog .post-content img {
   width: 100%;
   height: auto;
+}
+
+.blog .post-content figcaption {
+  font-size: 0.8rem;
+  text-align: center;
 }
 
 @media screen and (min-width: 1024px) {

--- a/content/blog/Camel3-2monthsaway/index.md
+++ b/content/blog/Camel3-2monthsaway/index.md
@@ -11,11 +11,11 @@ As I am busy myself then I just wanted to write a short blog post to keep the co
 The latest deadline is to release Camel 3.0 before December 19th 2019 as it was exactly on that day 1 year ago, we switched the master branch to become the work branch for Apache Camel 3. That means the total development time for Camel 3 would be 1 year.
 Here is a illustration that highlights the timeline of Camel 3:
 
-![Camel 3 timeline](camel3-progress.png)
+{{< image "camel3-progress.png" "Camel 3 timeline" >}}
 
 That is not all Apache Camel, is now a family of 3 projects (at this moment). So working on Camel 3 is not all we do. [Camel K](https://github.com/apache/camel-k/) and [Camel Quarkus](https://github.com/apache/camel-quarkus) are very promising for cloud-native integration (microservices and serverless).
 
-![Camel 3 projects](camel3-projects.png)
+{{< image "camel3-projects.png" "Camel 3 projects" >}}
 
 These projects have their own lifecycle. Will will post more details about these projects, and what’s new in Camel 3 in the following months leading up to the final release of Camel 3. So stay tuned.
 

--- a/layouts/shortcodes/image.html
+++ b/layouts/shortcodes/image.html
@@ -1,0 +1,9 @@
+{{ $filename := (.Get 0) }}
+{{ $title := (.Get 1) }}
+{{ $image := .Page.Resources.GetMatch $filename}}
+{{ with $image.Resize "800x q95 Gaussian" }}
+<figure>
+  <a href="{{ $image.RelPermalink }}" title="{{ $title }} (Click to enlarge)"><img src="{{ .RelPermalink }}" width="{{ .Width }}" height="{{ .Height }}" alt="{{ $title }}"></a>
+  <figcaption>{{ $title }} (Click to enlarge)</figcaption>
+</figure>
+{{ end }} 


### PR DESCRIPTION
This adds the `image` shortcode used for adding images to the markdown pages, notably the blog section.