### PR TITLE
Allow doc content to fill full available width

### DIFF
--- a/antora-ui-camel/src/css/vars.css
+++ b/antora-ui-camel/src/css/vars.css
@@ -131,7 +131,7 @@
   --nav-panel-height--desktop: calc(var(--nav-height--desktop) - var(--drawer-height));
   --nav-width: calc(270 / var(--rem-base) * 1rem);
   --doc-max-width: calc(720 / var(--rem-base) * 1rem);
-  --doc-max-width--desktop: calc(828 / var(--rem-base) * 1rem);
+  --doc-max-width--desktop: none;
   --static-max-width: calc(720 / var(--rem-base) * 1rem);
   --static-max-width--desktop: calc(1140 / var(--rem-base) * 1rem);
   /* stacking */


### PR DESCRIPTION
Currently, for viewports >1024px the doc class limits max-width to 46rem. This cuts off the final columns  for Query Parameter tables within Component docs. This limitation doesn't appear to be required