### PR TITLE
chore: add width toggle

### DIFF
--- a/antora-ui-camel/src/css/site.css
+++ b/antora-ui-camel/src/css/site.css
@@ -5,6 +5,7 @@
 @import "body.css";
 @import "nav.css";
 @import "main.css";
+@import "toggle-width.css";
 @import "toolbar.css";
 @import "breadcrumbs.css";
 @import "page-versions.css";

--- a/antora-ui-camel/src/css/toggle-width.css
+++ b/antora-ui-camel/src/css/toggle-width.css
@@ -1,0 +1,23 @@
+#toggle-width {
+  display: none;
+}
+
+#toggle-width:checked + article {
+  max-width: none;
+}
+
+#toggle-width-label {
+  display: none;
+  cursor: pointer;
+}
+
+#toggle-width-label:hover {
+  text-decoration: underline;
+}
+
+@media screen and (min-width: 1024px) {
+  #toggle-width-label {
+    display: block;
+    padding: 0.5rem;
+  }
+}

--- a/antora-ui-camel/src/partials/article.hbs
+++ b/antora-ui-camel/src/partials/article.hbs
@@ -1,3 +1,4 @@
+<input type="checkbox" id="toggle-width" />
 <article class="doc">
 {{#if (eq page.layout '404')}}
 <h1 class="page">{{{or page.title 'Page Not Found'}}}</h1>

--- a/antora-ui-camel/src/partials/toggle-width.hbs
+++ b/antora-ui-camel/src/partials/toggle-width.hbs
@@ -1,0 +1,3 @@
+<div>
+  <label id="toggle-width-label" for="toggle-width">Wide / Narrow</label>
+</div>

--- a/antora-ui-camel/src/partials/toolbar.hbs
+++ b/antora-ui-camel/src/partials/toolbar.hbs
@@ -4,6 +4,7 @@
   <a href="{{relativize page.url site.homeUrl}}" class="home-link{{#if page.home}} is-current{{/if}}"></a>
   {{/if}}
 {{> breadcrumbs}}
+{{> toggle-width }}
 {{> page-versions}}
   {{#if (and page.editUrl (not page.origin.private))}}
   <div class="edit-this-page"><a href="{{editPageUrl page}}">Edit this Page</a></div>


### PR DESCRIPTION
This adds a toggle in the toolbar for documentation built by Antora to
switch between narrow (column) mode and wide (full width).

Perhaps as an alternative to #94 by @JoshBhurruthMO we can have the full width as an option.