### PR TITLE
chore: improve navbar readability

### DIFF
--- a/antora-ui-camel/src/css/doc.css
+++ b/antora-ui-camel/src/css/doc.css
@@ -98,6 +98,10 @@
   overflow-x: auto;
 }
 
+.doc .table-wrapper table {
+  width: 100%;
+}
+
 .doc .tableblock p {
   font-size: inherit;
 }
@@ -219,6 +223,7 @@
 
 .doc .admonitionblock {
   margin: 1.4rem 0 0;
+  box-shadow: inset 0 0 1.75px var(--abstract-border-color);
 }
 
 .doc .admonitionblock p,

--- a/antora-ui-camel/src/css/header.css
+++ b/antora-ui-camel/src/css/header.css
@@ -16,8 +16,11 @@ body {
   width: 100%;
   word-wrap: break-word;
   z-index: var(--z-index-navbar);
-  box-shadow: 0 0.5rem 3rem var(--color-smoke-70);
   border-bottom: 1px solid var(--color-smoke-90);
+}
+
+.homepage .navbar {
+  box-shadow: 0 0.5rem 3rem var(--color-smoke-70);
 }
 
 .navbar a {

--- a/antora-ui-camel/src/css/nav.css
+++ b/antora-ui-camel/src/css/nav.css
@@ -102,7 +102,7 @@ html.is-clipped--nav {
   border: 1px solid var(--nav-background);
   padding: 0.5rem 1.23rem 0.5rem 1.7rem;
   margin: 0;
-  background: var(--panel-background) no-repeat 0.3rem/1.2rem url(../img/search.svg);
+  background: var(--nav-background) no-repeat 0.3rem/1.2rem url(../img/search.svg);
   z-index: var(--z-index-nav-search);
   font-size: calc(17 / var(--rem-base) * 1rem);
   font-family: var(--body-font-family);
@@ -117,7 +117,6 @@ html.is-clipped--nav {
 
 .nav-menu {
   top: 2.5rem;
-  flex-grow: 1;
   min-height: 0;
   width: 100%;
   padding: 0.5rem 0.75rem;
@@ -222,7 +221,6 @@ html.is-clipped--nav {
 
 .nav-panel-explore .components {
   line-height: var(--doc-line-height);
-  flex-grow: 1;
   box-shadow: inset 0 1px 5px var(--nav-panel-divider-color);
   background: var(--nav-secondary-background);
   padding: 0.5rem 0.75rem 0 0.75rem;

--- a/antora-ui-camel/src/css/vars.css
+++ b/antora-ui-camel/src/css/vars.css
@@ -34,7 +34,7 @@
   --monospace-font-weight-bold: 500;
   /* base */
   --body-background: var(--color-white);
-  --panel-background: var(--color-smoke-30);
+  --panel-background: var(--color-smoke-10);
   --panel-border-color: var(--color-smoke-90);
   /* navbar */
   --navbar-background: var(--color-white);
@@ -51,17 +51,17 @@
   --navbar-menu-hover-decoration-color: var(--color-camel-orange);
   /* nav */
   --nav-background: var(--panel-background);
-  --nav-border-color: var(--color-gray-10);
+  --nav-border-color: var(--color-smoke-50);
   --nav-line-height: 1.35;
   --nav-heading-font-color: var(--color-asf-dark-blue);
-  --nav-muted-color: var(--color-gray-70);
-  --nav-panel-divider-color: var(--color-smoke-90);
+  --nav-muted-color: var(--color-jet-50);
+  --nav-panel-divider-color: var(--color-smoke-50);
   --nav-secondary-background: var(--color-smoke-70);
   /* toolbar */
   --toolbar-background: var(--panel-background);
   --toolbar-border-color: var(--panel-border-color);
-  --toolbar-font-color: var(--color-gray-70);
-  --toolbar-muted-color: var(--color-gray-30);
+  --toolbar-font-color: var(--color-jet-80);
+  --toolbar-muted-color: var(--color-jet-80);
   --page-version-menu-background: var(--color-smoke-70);
   --page-version-missing-font-color: var(--color-gray-30);
   /* admonitions */
@@ -109,7 +109,7 @@
   --quote-font-color: var(--color-gray-70);
   --quote-attribution-font-color: var(--color-gray-30);
   --sidebar-background: var(--color-smoke-70);
-  --table-border-color: var(--panel-border-color);
+  --table-border-color: var(--color-asf-moderate-blue);
   /* static */
   --static-margin: 0 auto;
   /* frontpage */

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -29,7 +29,7 @@
     <link rel="stylesheet" href="{{ path.Join "_" (index .Site.Data "rev-manifest" "css/site.css") | relURL }}">
 </head>
 
-<body class="article">
+<body class="{{ if .Page.IsHome }}homepage {{ end }}article">
     <header class="header">
         <nav class="navbar">
             <div class="navbar-brand">


### PR DESCRIPTION
Removes the shadow from the top level navigation and restricts it only to the homepage and makes the navbar text, location in documentation and wide/narrow/edit this page links a bit darker.