### PR TITLE
chore: increase timout in Hugo

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -6,6 +6,7 @@ disablePathToLower = true
 staticDir = ["static", "documentation"]
 disableKinds = ["taxonomyTerm"]
 enableRobotsTXT = true
+timeout = 300000
 
 [params]
     socialProfiles = ["https://twitter.com/ApacheCamel"]


### PR DESCRIPTION
Seems that on the CI server default timeout 10s is not enough to
complete the build, this increases the timeout to 300s.