### PR TITLE
fix: allow the logo to resize with font sizes

### DIFF
--- a/antora-ui-camel/src/css/nav.css
+++ b/antora-ui-camel/src/css/nav.css
@@ -289,10 +289,10 @@ html.is-clipped--nav {
 .nav-logo {
   background-image: url('../img/logo-camel-medium.png');
   background-repeat: no-repeat;
-  background-size: 160px;
+  background-size: 9.5rem;
   background-position-x: 10px;
   background-position-y: 10px;
-  width: 180px;
+  width: 11rem;
 }
 
 .nav-logo span {


### PR DESCRIPTION
By using the `rem` unit we're able to scale the logo with respect to the
any changes to the font size that the user might customize.
For instance changing the font size to 11 should not crop the logo now.