### PR TITLE
feat: breaking news to the top of the homepage

### DIFF
--- a/antora-ui-camel/src/css/breaking.css
+++ b/antora-ui-camel/src/css/breaking.css
@@ -1,0 +1,18 @@
+.breaking {
+  display: flex;
+  justify-content: center;
+  color: var(--color-camel-orange);
+  padding: 1rem;
+  padding-top: 0.5rem;
+  text-shadow: -1px -1px 1px hsla(0, 50%, 100%, 0.8), 1px -1px 1px hsla(0, 50%, 100%, 0.8), -1px 1px 1px hsla(0, 50%, 100%, 0.8), 1px 1px 1px hsla(0, 50%, 100%, 0.8);
+  position: absolute;
+  margin-left: auto;
+  margin-right: auto;
+  left: 0;
+  right: 0;
+}
+
+.breaking a {
+  color: var(--color-camel-orange);
+  text-decoration: underline;
+}

--- a/antora-ui-camel/src/css/site.css
+++ b/antora-ui-camel/src/css/site.css
@@ -2,6 +2,7 @@
 @import "typeface-droid-sans-mono.css";
 @import "vars.css";
 @import "base.css";
+@import "breaking.css";
 @import "body.css";
 @import "nav.css";
 @import "main.css";

--- a/content/_breaking-news.md
+++ b/content/_breaking-news.md
@@ -1,0 +1,5 @@
+---
+type: breaking
+headless: true
+---
+## &#x1f680; Camel 3.0 is here, [what's new](blog/Camel3-Whatsnew/)

--- a/layouts/breaking/single.html
+++ b/layouts/breaking/single.html
@@ -1,0 +1,3 @@
+<header class="breaking">
+{{ .Content }}
+</header>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,5 +1,7 @@
 {{ partial "header.html" . }}
 
+{{ with .Site.GetPage "/_breaking-news.md" }}{{.Render}}{{ end }}
+
 <header class="frontpage">
   <h1>Integration you want</h1>
   <svg viewBox="0 0 500 70" preserveAspectRatio="none">


### PR DESCRIPTION
This adds breaking news band to the top of the homepage. The rendering
is controlled by the existence of `content/_breaking-news.md` once
removed it will not be rendered. First breaking news is about the
release of Camel 3.