### PR TITLE
doc: rename 'Camel 3.x Migration Guide' -> 'Camel 3.x Upgrade Guide'

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -93,11 +93,11 @@ timeout = 300000
     url = "/manual/latest/camel-3-migration-guide.html"
 
 [[menu.main]]
-    name = "Camel 3.x Migration Guide"
+    name = "Camel 3.x Upgrade Guide"
     parent = "docs"
     weight = 8
-    identifier = "camel-3x-migration-guide"
-    url = "/manual/latest/camel-3x-migration-guide.html"
+    identifier = "camel-3x-upgrade-guide"
+    url = "/manual/latest/camel-3x-upgrade-guide.html"
 
 [[menu.main]]
     name = "Community"


### PR DESCRIPTION
See https://github.com/apache/camel-website/pull/124#issuecomment-564367500

Camel side is already done:
- https://github.com/apache/camel/commit/274e1dfafb665005f876e4ba32e8bdc9c94cfd76