### PR TITLE
original image has disappeared, replace with sized SVG

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Apache Camel Website ![Logo][1]
+# Apache Camel Website <img alt="Apache Camel" src="antora-ui-camel/src/img/logo-d.svg" height="30 px">
 
 This is a site generator project for Apache Camel. It generates static HTML and
 resources that are to be published.
@@ -188,10 +188,6 @@ change there.
 - [Camel K docs](https://github.com/apache/camel-k/tree/antora/docs)
 
 Your changes in these repositories will automatically get visible on the website after a site rebuild.
-
-[1]: antora-ui-camel/src/img/logo32-d.png "Apache Camel"
-
-
 
 ## Build with Maven
 


### PR DESCRIPTION
As the new logo is a SVG and GitHub flavored Markdown doesn't allow for image sizes, this PR replaces it with an image tag.

old (broken link):
![image](https://user-images.githubusercontent.com/3957921/71490971-34f06d80-282e-11ea-9378-a4a736bdee2d.png)


new:
![image](https://user-images.githubusercontent.com/3957921/71490957-1db18000-282e-11ea-86b9-d7fbb6347286.png)
