### PR TITLE
chore: add Camel Kafka Connector documentation

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -79,23 +79,30 @@ timeout = 300000
     url = "/camel-quarkus/latest/"
 
 [[menu.main]]
-    name = "Enterprise Integration Patterns"
+    name = "Camel Kafka Connector"
     parent = "docs"
     weight = 6
+    identifier = "camel-kafka-connector"
+    url = "/camel-kafka-connector/latest/"
+
+[[menu.main]]
+    name = "Enterprise Integration Patterns"
+    parent = "docs"
+    weight = 7
     identifier = "eip"
     url = "/manual/latest/enterprise-integration-patterns.html"
 
 [[menu.main]]
     name = "Camel 2.x to 3.0 Migration Guide"
     parent = "docs"
-    weight = 7
+    weight = 8
     identifier = "camel-3-migration-guide"
     url = "/manual/latest/camel-3-migration-guide.html"
 
 [[menu.main]]
     name = "Camel 3.x Upgrade Guide"
     parent = "docs"
-    weight = 8
+    weight = 9
     identifier = "camel-3x-upgrade-guide"
     url = "/manual/latest/camel-3x-upgrade-guide.html"
 

--- a/content/_index.md
+++ b/content/_index.md
@@ -68,6 +68,14 @@ Camel supports around 50 data formats, allowing to <mark>translate messages</mar
 <a class="significant" href="./camel-quarkus/latest/">Read the docs</a>
 {{< /div >}}
 
+{{< div "project" >}}
+# Camel Kafka Connector
+
+**Apache Camel Kafka Connector** embeds Camel within [Kafka Connect](https://kafka.apache.org/documentation/#connect), enabling declarative use of Camel components as sources or sinks to Kafka topics.
+
+<a class="significant" href="./camel-kafka-connector/latest/">Read the docs</a>
+{{< /div >}}
+
 {{< /section >}}
 
 {{< section "frontpage columns apache" >}}

--- a/site.yml
+++ b/site.yml
@@ -17,6 +17,9 @@ content:
     - url: git@github.com:apache/camel-quarkus.git
       branches: master
       start_path: docs
+    - url: git@github.com:apache/camel-kafka-connector.git
+      branches: master
+      start_path: docs
 
 ui:
   bundle:


### PR DESCRIPTION
This adds Camel Kafka Connector to the Documentation menu, list of
sub-projects, and renders the documentation from the
`camel-kafka-connector` git repository.