### PR TITLE
chore: add Spring Boot docs

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -20,6 +20,9 @@ content:
     - url: git@github.com:apache/camel-kafka-connector.git
       branches: master
       start_path: docs
+    - url: git@github.com:apache/camel-spring-boot.git
+      branches: master
+      start_path: docs
 
 ui:
   bundle:


### PR DESCRIPTION
This adds Camel Spring Boot git repository to the list of Antora pulled
git repositories. Which is required for the Spring Boot Starter
documentation to be included in the component reference.