### PR TITLE
feat: add Spring Boot starters project

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -43,7 +43,14 @@ timeout = 300000
     parent = "projects"
     weight = 3
     identifier = "project-camel-kafka-connector"
-    url = "/projects/camel-kafka-connector/"    
+    url = "/projects/camel-kafka-connector/"
+
+[[menu.main]]
+    name = "Camel Spring Boot"
+    parent = "projects"
+    weight = 4
+    identifier = "project-camel-spring-boot"
+    url = "/camel-spring-boot/latest/"
 
 [[menu.main]]
     name = "Documentation"

--- a/content/_index.md
+++ b/content/_index.md
@@ -76,6 +76,14 @@ Camel supports around 50 data formats, allowing to <mark>translate messages</mar
 <a class="significant" href="./camel-kafka-connector/latest/">Read the docs</a>
 {{< /div >}}
 
+{{< div "project" >}}
+# Camel Spring Boot
+
+**Apache Camel Spring Boot** run Camel on [Spring Boot](https://spring.io/projects/spring-boot).
+
+<a class="significant" href="./camel-spring-boot/latest/">Read the docs</a>
+{{< /div >}}
+
 {{< /section >}}
 
 {{< section "frontpage columns apache" >}}


### PR DESCRIPTION
This adds the Spring Boot starters to the Projects menu and links from
the homepage.