### PR TITLE
fix: make sure RC versions are not promoted

### DIFF
--- a/content/releases/release-3.0.0-RC1.md
+++ b/content/releases/release-3.0.0-RC1.md
@@ -3,6 +3,7 @@ date: 2019-09-01
 draft: false 
 type: release-note
 version: 3.0.0-RC1
+rc: true
 title: "Release 3.0.0-RC1"
 preview: "First release candidate for 3.0.0"
 apiBreaking: ""

--- a/content/releases/release-3.0.0-RC2.md
+++ b/content/releases/release-3.0.0-RC2.md
@@ -3,6 +3,7 @@ date: 2019-10-06
 draft: false 
 type: release-note
 version: 3.0.0-RC2
+rc: true
 title: "Release 3.0.0-RC2"
 preview: "Second release candidate for 3.0.0"
 apiBreaking: ""

--- a/content/releases/release-3.0.0-RC3.md
+++ b/content/releases/release-3.0.0-RC3.md
@@ -3,6 +3,7 @@ date: 2019-10-25
 draft: false 
 type: release-note
 version: 3.0.0-RC3
+rc: true
 title: "Release 3.0.0-RC3"
 preview: "Third release candidate for 3.0.0"
 apiBreaking: ""

--- a/layouts/download/download.html
+++ b/layouts/download/download.html
@@ -10,7 +10,7 @@
             <p>Apache Camel community provides support for the latest three major versions. Latest version receives new features, next two supported versions receive only bug fixes.</p>
 
             <ul>
-            {{ $releases := ((where .Site.Pages "Type" "release-note").ByParam "version").Reverse }}
+            {{ $releases := ((where (where .Site.Pages "Type" "release-note") ".Params.rc" "ne" "true").ByParam "version").Reverse }}
             {{ $major := "" }}
             {{ $cnt := 1 }}
             {{ range $releases }}
@@ -27,7 +27,6 @@
 
             <h3>Binary Distribution</h3>
 
-            {{ $releases := ((where .Site.Pages "Type" "release-note").ByParam "version").Reverse }}
             {{ $major := "" }}
             {{ $cnt := 1 }}
             <table class="tableblock frame-all grid-all stretch">
@@ -67,7 +66,6 @@
 
             <h3>Source Distribution</h3>
 
-            {{ $releases := ((where .Site.Pages "Type" "release-note").ByParam "version").Reverse }}
             {{ $major := "" }}
             {{ $cnt := 1 }}
             <table class="tableblock frame-all grid-all stretch">


### PR DESCRIPTION
On the downloads page we need to make sure that the RC versions are not
included in the last three releases. Currently this would exclude 2.25.x
which we still support as the latest release on 2.x.