### PR TITLE
Fixed right/left margin issue

### DIFF
--- a/antora-ui-camel/src/css/doc.css
+++ b/antora-ui-camel/src/css/doc.css
@@ -3,7 +3,6 @@
   font-size: var(--doc-font-size);
   line-height: var(--doc-line-height);
   margin: var(--doc-margin);
-  max-width: var(--doc-max-width);
   padding: 0 1rem 4rem;
 }
 
@@ -11,7 +10,6 @@
   .doc {
     font-size: var(--doc-font-size--desktop);
     margin: var(--doc-margin--desktop);
-    max-width: var(--doc-max-width--desktop);
   }
 }
 


### PR DESCRIPTION
Signed-off-by: Agha Saad Fraz <agha.saad04@gmail.com>

## Issue:
Article containers right margin is larger than the left margin

![image](https://user-images.githubusercontent.com/36513474/76072810-70d84980-5fba-11ea-8b52-4aa72308643e.png)

## Solution:
The issue was with the max-width property of the "doc" class. It was limiting the content to 46em max-width. I have removed the max-width property and now the result is:

![image](https://user-images.githubusercontent.com/36513474/76072988-bac12f80-5fba-11ea-9fa0-c11cf52fe8c5.png)

