### PR TITLE
Fixed articles left and right margins

### DIFF
--- a/antora-ui-camel/src/css/doc.css
+++ b/antora-ui-camel/src/css/doc.css
@@ -2,7 +2,8 @@
   color: var(--doc-font-color);
   font-size: var(--doc-font-size);
   line-height: var(--doc-line-height);
-  margin: var(--doc-margin);
+  margin-left: auto;
+  margin-right: auto;
   max-width: var(--doc-max-width);
   padding: 0 1rem 4rem;
 }
@@ -10,7 +11,8 @@
 @media screen and (min-width: 1024px) {
   .doc {
     font-size: var(--doc-font-size--desktop);
-    margin: var(--doc-margin--desktop);
+    margin-left: auto;
+    margin-right: auto;
     max-width: var(--doc-max-width--desktop);
   }
 }


### PR DESCRIPTION
Fixed article left and right margins by setting them to **auto** since the max-width attribute was defined, this aligns the content of the article to the center.

![Screenshot from 2020-03-08 15-58-23](https://user-images.githubusercontent.com/26043567/76165547-31dffa80-6158-11ea-98b2-c5dd0abe1fea.png)