### PR TITLE
[CAMEL-13902] Publish links to JavaDoc on the website 

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -225,4 +225,3 @@ timeout = 300000
   [[module.mounts]]
     source = "documentation/_/data"
     target = "data"
-    

--- a/config.toml
+++ b/config.toml
@@ -79,44 +79,51 @@ timeout = 300000
     url = "/components/latest/"
 
 [[menu.main]]
-    name = "Camel K"
+    name = "API Documentation"
     parent = "docs"
     weight = 4
+    identifier = "api-documentation"
+    url = "https://www.javadoc.io/doc/org.apache.camel/camel-api/latest/index.html" 
+
+[[menu.main]]
+    name = "Camel K"
+    parent = "docs"
+    weight = 5
     identifier = "camel-k"
     url = "/camel-k/latest/"
 
 [[menu.main]]
     name = "Camel Quarkus"
     parent = "docs"
-    weight = 5
+    weight = 6
     identifier = "camel-quarkus"
     url = "/camel-quarkus/latest/"
 
 [[menu.main]]
     name = "Camel Kafka Connector"
     parent = "docs"
-    weight = 6
+    weight = 7
     identifier = "camel-kafka-connector"
     url = "/camel-kafka-connector/latest/"
 
 [[menu.main]]
     name = "Enterprise Integration Patterns"
     parent = "docs"
-    weight = 7
+    weight = 8
     identifier = "eip"
     url = "/manual/latest/enterprise-integration-patterns.html"
 
 [[menu.main]]
     name = "Camel 2.x to 3.0 Migration Guide"
     parent = "docs"
-    weight = 8
+    weight = 9
     identifier = "camel-3-migration-guide"
     url = "/manual/latest/camel-3-migration-guide.html"
 
 [[menu.main]]
     name = "Camel 3.x Upgrade Guide"
     parent = "docs"
-    weight = 9
+    weight = 10
     identifier = "camel-3x-upgrade-guide"
     url = "/manual/latest/camel-3x-upgrade-guide.html"
 
@@ -218,3 +225,4 @@ timeout = 300000
   [[module.mounts]]
     source = "documentation/_/data"
     target = "data"
+    


### PR DESCRIPTION
- Added "API Documentation" under the "Documentation" menu 
- Linked API documentation to [this](https://www.javadoc.io/doc/org.apache.camel/camel-api/latest/index.html) JavaDocs page 

![API_menu](https://user-images.githubusercontent.com/32356795/76220430-7e513600-623d-11ea-803d-2b70c9ca58f2.png)