### PR TITLE
add uniform category sizing with inline-block styling

### DIFF
--- a/antora-ui-camel/src/css/blog.css
+++ b/antora-ui-camel/src/css/blog.css
@@ -18,6 +18,7 @@
   list-style: none;
   padding: 0;
   margin-top: 1rem;
+  display: inline-block;
 }
 
 article.blog:first-child {

--- a/antora-ui-camel/src/css/category.css
+++ b/antora-ui-camel/src/css/category.css
@@ -18,6 +18,12 @@ a.category {
   text-decoration: none;
 }
 
+li > a.category {
+  display: block;
+  margin: 0.2rem;
+  line-height: 2;
+}
+
 a.category:hover {
   color: var(--color-white);
 }


### PR DESCRIPTION
This is a PR to resolve https://issues.apache.org/jira/browse/CAMEL-14686, "The blog categories item sizes could be same".

<img width="655" alt="Screenshot 2020-03-10 at 2 26 14 PM" src="https://user-images.githubusercontent.com/10054415/76360951-354fbf00-62db-11ea-9f6e-3302fb5baf4d.png">

Through testing, the changes don't appear to have an impact on mobile styling/bevhavior, and if a longer category is added, all the categories expand to the new, longest length category.
