### PR TITLE
CAMEL-11492 : Site Documentation improvement

### DIFF
--- a/content/projects/camel-k.md
+++ b/content/projects/camel-k.md
@@ -2,8 +2,6 @@
 title: Camel K
 ---
 
-# Apache Camel K
-
 Apache Camel K is a lightweight integration framework built from Apache Camel that runs natively on Kubernetes and is specifically designed for serverless and microservice architectures.
 
 Users of Camel K can instantly run integration code written in Camel DSL on their preferred cloud (Kubernetes or OpenShift).

--- a/content/projects/camel-k.md
+++ b/content/projects/camel-k.md
@@ -4,6 +4,26 @@ title: Camel K
 
 # Apache Camel K
 
-Apache Camel K is a lightweight integration platform, born on Kubernetes, with serverless superpowers.
+Apache Camel K is a lightweight integration framework built from Apache Camel that runs natively on Kubernetes and is specifically designed for serverless and microservice architectures.
 
-For more information checkout the [Camel K manual](../../camel-k/latest/) and join the community on on the [Camel Users mailing list](../../community/mailing-list/) and have a look at the [Camel K GitHub repository](https://github.com/apache/camel-k/).
+Users of Camel K can instantly run integration code written in Camel DSL on their preferred cloud (Kubernetes or OpenShift).
+
+## HOW IT WORKS 
+
+Just write a _helloworld.groovy_ integration file with the following content:
+
+```groovy
+from('timer:tick?period=3s')
+  .setBody().constant('Hello world from Camel K')
+  .to('log:info')
+```
+
+You can then execute the following command:
+
+```
+kamel run helloworld.groovy
+```
+
+The integration code immediately runs in the cloud. **Nothing else** is needed.
+
+For more information checkout the [Camel K manual](../../camel-k/latest/installation/installation.html) and join the community on on the [Camel Users mailing list](../../community/mailing-list/) and have a look at the [Camel K GitHub repository](https://github.com/apache/camel-k/).


### PR DESCRIPTION
* Apache Camel K under project sections was blank or very little detail was provided. 
* The description of Apache Camel K from the docs section was copied to Apache Camel K in the project section.
* From the project section, the Camel K Manual links to the Installation page within the docs.