### PR TITLE
fixed blog page categories width

### DIFF
--- a/antora-ui-camel/src/css/doc.css
+++ b/antora-ui-camel/src/css/doc.css
@@ -634,7 +634,7 @@ kbd,
 .stretch {
   width: 100%;
 }
-
+/* for mobile screens */
 @media screen and (max-width: 600px) {
   .doc aside {
     width: auto;

--- a/antora-ui-camel/src/css/doc.css
+++ b/antora-ui-camel/src/css/doc.css
@@ -634,3 +634,9 @@ kbd,
 .stretch {
   width: 100%;
 }
+
+@media screen and (max-width: 600px) {
+  .doc aside {
+    width: auto;
+  }
+}

--- a/antora-ui-camel/src/css/doc.css
+++ b/antora-ui-camel/src/css/doc.css
@@ -635,8 +635,8 @@ kbd,
   width: 100%;
 }
 /* for mobile screens */
-@media screen and (max-width: 600px) {
+@media screen and (max-width: 1023px) {
   .doc aside {
-    width: auto;
+    display: none;
   }
 }


### PR DESCRIPTION
Hi,
I have found an issue on the https://camel.apache.org/blog/ for mobile screens. The main menu is going outside the page and there is a blank space in the bottom. Please check the following screenshot.
![blog-page](https://user-images.githubusercontent.com/36660186/76498506-0bc19f80-6463-11ea-9bf1-f1fba8aae938.png)

This PR fixes this problem. Here is an updated screenshot after the fix.
![changed-blog-page](https://user-images.githubusercontent.com/36660186/76498569-23992380-6463-11ea-9568-c3996caa50de.PNG)

@zregvart please check.