### PR TITLE
Fixed apache logo in mobile screen.

### DIFF
--- a/antora-ui-camel/src/css/frontpage.css
+++ b/antora-ui-camel/src/css/frontpage.css
@@ -226,6 +226,12 @@ section.frontpage h1 {
   max-width: 100%;
 }
 
+@media screen and (max-width: 626px) {
+  .split {
+    flex: 100%;
+  }
+}
+
 @media screen and (max-width: 1023px) {
   header.frontpage h1 {
     font-size: 9vw;

--- a/content/_index.md
+++ b/content/_index.md
@@ -91,6 +91,11 @@ Camel supports around 50 data formats, allowing to <mark>translate messages</mar
 # Apache &amp; OpenSource
 
 {{< div "split" >}}
+![20 years of Apache Software foundation](/img/apache-20.png)
+{{< /div >}}
+
+{{< div "split" >}}
+
 **Camel is your project!**
 
 Camel is an [Apache Software Foundation](https://www.apache.org) project, available under the [Apache v2 license](https://apache.org/licenses/LICENSE-2.0). It's a complete open community, always listening to proposals and comments.
@@ -101,10 +106,6 @@ We also love contributions: don't hesitate to [contribute](./manual/latest/contr
 
 [Be Involved In The Community](./manual/latest/contributing.html) | [How To Contribute](./manual/latest/contributing.html)
 
-{{< /div >}}
-
-{{< div "split" >}}
-![20 years of Apache Software foundation](/img/apache-20.png)
 {{< /div >}}
 
 {{< /section >}}


### PR DESCRIPTION
This solves [CAMEL-14701](https://issues.apache.org/jira/projects/CAMEL/issues/CAMEL-14701?filter=allopenissues)
**Before**
![beforechange](https://user-images.githubusercontent.com/51082429/76516548-9913ec80-6481-11ea-8f1b-125c939c6e32.gif)

**After**
<img width="265" alt="imagesss" src="https://user-images.githubusercontent.com/51082429/76516613-b8ab1500-6481-11ea-8187-5571affa3482.png">

Previously the `flex:50%` prevented to chnage the position but now `flex: 100%` in mobile screen does the job.