### PR TITLE
[CAMEL-14700] Improve colour contrast

### DIFF
--- a/antora-ui-camel/src/css/base.css
+++ b/antora-ui-camel/src/css/base.css
@@ -13,6 +13,7 @@ body {
 
 *::selection {
   background: var(--color-highlight);
+  color: var(--color-white);
 }
 
 html {

--- a/antora-ui-camel/src/css/base.css
+++ b/antora-ui-camel/src/css/base.css
@@ -79,7 +79,7 @@ button::-moz-focus-inner {
 }
 
 mark {
-  background: var(--color-highlight);
+  color: var(--color-camel-orange);
 }
 
 .text-center {

--- a/antora-ui-camel/src/css/base.css
+++ b/antora-ui-camel/src/css/base.css
@@ -80,6 +80,8 @@ button::-moz-focus-inner {
 
 mark {
   color: var(--color-camel-orange);
+  font-weight: bold;
+  background: var(--color-white);
 }
 
 .text-center {

--- a/antora-ui-camel/src/css/header.css
+++ b/antora-ui-camel/src/css/header.css
@@ -131,7 +131,7 @@ body {
 
 .navbar-item {
   flex: none;
-  margin: 1rem;
+  padding: 1rem 2rem 1rem 0;
 }
 
 .navbar-item .icon {
@@ -346,7 +346,7 @@ body {
     position: absolute;
     transform: rotate(-45deg);
     width: 0.5em;
-    right: -0.6rem;
+    right: -0.8rem;
     top: 50%;
   }
 
@@ -376,7 +376,7 @@ body {
   }
 
   .navbar-dropdown a.navbar-item {
-    padding-right: 3rem;
+    padding: 0.6rem 2rem 0.6rem 1rem;
   }
 
   .navbar-dropdown.is-right {

--- a/antora-ui-camel/src/css/header.css
+++ b/antora-ui-camel/src/css/header.css
@@ -205,11 +205,6 @@ body {
     padding: 0.5rem 0;
   }
 
-  .navbar-menu a.navbar-item:hover,
-  .navbar-menu .navbar-link:hover {
-    background-color: var(--navbar-menu-hover-background);
-  }
-
   .navbar-link::after {
     border-width: 0 0 2px 2px;
     border-style: solid;
@@ -295,7 +290,6 @@ body {
     position: absolute;
     transform: rotate(-45deg);
     width: 0.5em;
-    margin-top: 0.6em;
     margin-right: 1rem;
     right: 0;
     top: 40%;

--- a/antora-ui-camel/src/css/header.css
+++ b/antora-ui-camel/src/css/header.css
@@ -36,17 +36,19 @@ body {
 
   .navbar-end > a.navbar-item:hover,
   .navbar-end .navbar-link:hover {
-    background: var(--navbar-hover-background);
-    color: var(--navbar-hover-font-color);
+    color: var(--color-asf-dark-blue);
   }
 
   .navbar-end .navbar-link::after {
     border-color: var(--navbar-font-color);
   }
 
+  .navbar-item.has-dropdown:hover .navbar-link::after {
+    border-color: var(--color-asf-dark-blue);
+  }
+
   .navbar-item.has-dropdown:hover .navbar-link {
-    background: var(--navbar-hover-background);
-    color: var(--navbar-hover-font-color);
+    color: var(--color-asf-dark-blue);
   }
 }
 

--- a/antora-ui-camel/src/css/header.css
+++ b/antora-ui-camel/src/css/header.css
@@ -129,11 +129,6 @@ body {
   position: relative;
 }
 
-.navbar-item {
-  flex: none;
-  padding: 1rem 2rem 1rem 0;
-}
-
 .navbar-item .icon {
   width: 1.1rem;
   height: 1.1rem;
@@ -195,6 +190,8 @@ body {
 
   .navbar-item {
     font-weight: bold;
+    flex: none;
+    margin: 1rem;
   }
 
   .navbar-dropdown .navbar-item:hover,
@@ -273,6 +270,8 @@ body {
 
   .navbar-item {
     font-weight: bold;
+    flex: none;
+    margin: 1rem;
   }
 
   .navbar-dropdown .navbar-item:hover,
@@ -321,6 +320,10 @@ body {
     align-items: flex-end;
     display: flex;
     font-weight: bold;
+  }
+
+  .navbar-item {
+    padding: 1rem 2rem 1rem 0;
   }
 
   .navbar-item.has-dropdown {

--- a/antora-ui-camel/src/css/header.css
+++ b/antora-ui-camel/src/css/header.css
@@ -17,9 +17,6 @@ body {
   word-wrap: break-word;
   z-index: var(--z-index-navbar);
   border-bottom: 1px solid var(--color-smoke-90);
-}
-
-.homepage .navbar {
   box-shadow: 0 0.5rem 3rem var(--color-smoke-70);
 }
 
@@ -389,8 +386,6 @@ body {
 
   .navbar-dropdown a.navbar-item:hover {
     background-color: var(--navbar-menu-hover-background);
-    text-decoration: underline;
-    text-decoration-color: var(--navbar-menu-hover-decoration-color);
   }
 }
 
@@ -416,8 +411,7 @@ body {
 }
 
 .navbar-search input {
-  border: 0;
-  border-bottom: 1px solid var(--nav-panel-divider-color);
+  border: 1px solid var(--nav-panel-divider-color);
   margin-top: 1rem;
   padding: 0.3rem 0.5rem 0.3rem 1.7rem;
   font-family: Open Sans, sans-serif;

--- a/antora-ui-camel/src/css/vars.css
+++ b/antora-ui-camel/src/css/vars.css
@@ -19,7 +19,6 @@
   --color-asf-dark-blue: #303284;
   --color-asf-moderate-blue: #585ac2;
   --color-camel-orange: #ed8225;
-  --color-highlight: #fffcdd;
   --color-glow: #fff7a3;
   /* fonts */
   --rem-base: 18; /* used to compute rem value from desired pixel value (e.g., calc(18 / var(--rem-base) * 1rem) = 18px) */
@@ -47,8 +46,7 @@
   --navbar-menu-border-color: var(--panel-border-color);
   --navbar-menu-background: var(--color-white);
   --navbar-menu-font-color: var(--body-font-color);
-  --navbar-menu-hover-background: var(--color-white);
-  --navbar-menu-hover-decoration-color: var(--color-camel-orange);
+  --navbar-menu-hover-background: var(--color-smoke-70);
   /* nav */
   --nav-background: var(--panel-background);
   --nav-border-color: var(--color-smoke-50);

--- a/antora-ui-camel/src/css/vars.css
+++ b/antora-ui-camel/src/css/vars.css
@@ -19,6 +19,7 @@
   --color-asf-dark-blue: #303284;
   --color-asf-moderate-blue: #585ac2;
   --color-camel-orange: #ed8225;
+  --color-highlight: #cf7428;
   --color-glow: #fff7a3;
   /* fonts */
   --rem-base: 18; /* used to compute rem value from desired pixel value (e.g., calc(18 / var(--rem-base) * 1rem) = 18px) */


### PR DESCRIPTION
- drop-down submenus turn grey on hovering
- put an outline around the search bar to make it stand out
- added a grey shaded gradient (shadow) below nav-bar
- tried changing the background of the highlighted text to darker colours, but it was looking very odd, so I instead changed the colour of the text to camel orange - please comment on this. I have attached screenshots for both cases - background colour and orange text
- menu-items turn dark blue on hovering and while drop downs are open

![color_contast_latest](https://user-images.githubusercontent.com/32356795/76684458-36158780-6632-11ea-82a0-edda7200bd8b.png)

How the highlights look :

![camel_highlight_1](https://user-images.githubusercontent.com/32356795/76563287-20d31880-64cd-11ea-83be-2046b07c6bee.png)

And how the bold orange text looks :
![highlight_orange](https://user-images.githubusercontent.com/32356795/76563552-a951b900-64cd-11ea-9839-492ab4219765.png)
![highlight_orange_2](https://user-images.githubusercontent.com/32356795/76563559-ad7dd680-64cd-11ea-89b5-c89978ffc725.png)

