### PR TITLE
chore: navbar tools alignment with hamburger menu

### DIFF
--- a/antora-ui-camel/src/css/header.css
+++ b/antora-ui-camel/src/css/header.css
@@ -85,7 +85,7 @@ body {
   left: 50%;
   margin-left: -7px;
   position: absolute;
-  top: 50%;
+  top: 60%;
   width: 15px;
 }
 
@@ -411,22 +411,20 @@ body {
 
 @media screen and (max-width: 1023px) {
   .navbar-tools {
-    align-items: end;
-    padding: 0.5rem 0;
+    display: flex;
+    align-items: flex-end;
+    justify-content: flex-end;
+    padding: 0.3 0.5rem;
   }
 
   .navbar-tools .brand-icon {
-    margin: 1rem 0.8rem;
+    margin: 0.25  rem;
   }
 }
 
 /* Styling for mobile use */
 @media (max-width: 610px) {
   #search {
-    display: none;
-  }
-
-  #social-media {
     display: none;
   }
 }


### PR DESCRIPTION
* According to my opinion, the navbar tools must be added beside the hamburger menu and should be visible in any screen view. The reason behind this is that one can keep continuous track from their mobile and easily check the Github or twitter from the website itself through their mobile and understand the structure of the website. 

* A problem I observed that in a few screen width, the hamburger menu and the navbar tools weren't aligned, hence alignment was made possible by a minor change.