### PR TITLE
CAMEL-14718: Improvize on the front-page of the website

### DIFF
--- a/antora-ui-camel/src/css/frontpage.css
+++ b/antora-ui-camel/src/css/frontpage.css
@@ -249,6 +249,10 @@ section.frontpage h1 {
     flex-direction: column;
   }
 
+  section.frontpage.projects .project p:nth-child(2) {
+    text-align: center;
+  }
+
   section.frontpage.projects .project p:nth-child(3) {
     text-align: center;
   }


### PR DESCRIPTION
* In the front-page within the section where it states about Camel, Camel-K and provided with the button to read the documentation, it is observed that for a smaller screen width, the title and buttons are center-aligned but the paragraph isn't. Thus, I have made the paragraph center-aligned as well. This creates neatness in the front-page presentation.