### PR TITLE
CAMEL-14718: add the push down hover effect to the buttons in frontpage

### DIFF
--- a/antora-ui-camel/src/css/frontpage.css
+++ b/antora-ui-camel/src/css/frontpage.css
@@ -59,15 +59,19 @@ header.frontpage a:active {
   outline: none;
   display: inline-block;
   white-space: nowrap;
+  box-shadow: 0 4px #8e480b;
 }
 
 .frontpage a.significant:hover {
   color: var(--color-white);
-  box-shadow: 0 0 1.5rem var(--color-glow);
+  box-shadow: 0 3px #8e480b;
+  transform: translateY(2px);
 }
 
 .frontpage a.significant:active {
   color: var(--color-white);
+  box-shadow: 0 3px #8e480b;
+  transform: translateY(2px);
 }
 
 header.frontpage svg {


### PR DESCRIPTION
* The problem I observed was that in different screen width including the mobile version, when I hovered over the buttons, the glow of each button used to overlap the other. Hence, I removed the outer glow effect for the buttons.

* Instead, I created a push-down hover effect for the button which will look sophisticated on the frontpage.