### PR TITLE
Fix side nav-bar issues

### DIFF
--- a/antora-ui-camel/src/css/nav.css
+++ b/antora-ui-camel/src/css/nav.css
@@ -88,11 +88,13 @@ html.is-clipped--nav {
   left: 0;
 }
 
-.nav-panel-menu::-webkit-scrollbar {
+.nav-panel-menu::-webkit-scrollbar,
+.nav-list::-webkit-scrollbar {
   width: 0.25rem;
 }
 
-.nav-panel-menu::-webkit-scrollbar-thumb {
+.nav-panel-menu::-webkit-scrollbar-thumb,
+.nav-list::-webkit-scrollbar-thumb {
   background-color: var(--nav-border-color);
 }
 
@@ -145,6 +147,11 @@ html.is-clipped--nav {
   margin-bottom: 0.5rem;
 }
 
+.nav-list .nav-list .nav-list {
+  max-height: 200px;
+  overflow-y: auto;
+}
+
 .nav-item {
   list-style: none;
   margin-top: 0.5em;
@@ -184,6 +191,13 @@ html.is-clipped--nav {
 .is-current-page > .nav-link,
 .is-current-page > .nav-text {
   font-weight: var(--body-font-weight-bold);
+}
+
+.nav-link:hover,
+.nav-text:hover {
+  color: var(--color-camel-orange);
+  font-weight: var(--body-font-weight-bold);
+  text-decoration: underline;
 }
 
 .nav-panel-explore {

--- a/antora-ui-camel/src/css/nav.css
+++ b/antora-ui-camel/src/css/nav.css
@@ -159,10 +159,6 @@ html.is-clipped--nav {
   padding: 0.6rem 0.3rem 0.6rem 0;
 }
 
-.nav-menu > .nav-list > .nav-item > .nav-list > .nav-item {
-  border-bottom: 1px solid var(--nav-border-color);
-}
-
 /* adds some breathing room below a nested list */
 .nav-item-toggle ~ .nav-list {
   padding-bottom: 0.125rem;
@@ -203,7 +199,6 @@ html.is-clipped--nav {
 
 .nav-link:hover,
 .nav-text:hover {
-  font-weight: var(--body-font-weight-bold);
   text-decoration: underline;
 }
 

--- a/antora-ui-camel/src/css/nav.css
+++ b/antora-ui-camel/src/css/nav.css
@@ -156,7 +156,7 @@ html.is-clipped--nav {
 
 .nav-item {
   list-style: none;
-  padding: 0.6rem 0;
+  padding: 0.6rem 0.3rem 0.6rem 0;
 }
 
 .nav-menu > .nav-list > .nav-item > .nav-list > .nav-item {

--- a/antora-ui-camel/src/css/nav.css
+++ b/antora-ui-camel/src/css/nav.css
@@ -33,6 +33,7 @@
   position: relative;
   top: var(--toolbar-height);
   height: var(--nav-height);
+  border-right: 1px solid var(nav-border-color);
 }
 
 @media screen and (min-width: 769px) {
@@ -121,7 +122,7 @@ html.is-clipped--nav {
   top: 2.5rem;
   min-height: 0;
   width: 100%;
-  padding: 0.5rem 0.75rem;
+  padding: 0.5rem 0;
   line-height: var(--nav-line-height);
   position: relative;
 }
@@ -131,7 +132,8 @@ html.is-clipped--nav {
   font-size: inherit;
   font-weight: var(--body-font-weight-bold);
   margin: 0;
-  padding: 0.25em 0 0.125em;
+  text-transform: uppercase;
+  padding: 0.25em 0.75rem 0.125em;
 }
 
 .nav-menu a {
@@ -154,7 +156,11 @@ html.is-clipped--nav {
 
 .nav-item {
   list-style: none;
-  margin-top: 0.5em;
+  padding: 0.6rem 0;
+}
+
+.nav-menu > .nav-list > .nav-item > .nav-list > .nav-item {
+  border-bottom: 1px solid var(--nav-border-color);
 }
 
 /* adds some breathing room below a nested list */
@@ -174,10 +180,12 @@ html.is-clipped--nav {
 
 .nav-item-toggle {
   background: transparent url(../img/caret.svg) no-repeat center / 50%;
+  transform: rotate(90deg);
   border: none;
   outline: none;
   line-height: inherit;
   position: absolute;
+  right: 0;
   height: calc(var(--nav-line-height) * 1em);
   width: calc(var(--nav-line-height) * 1em);
   margin-top: -0.05em;
@@ -185,7 +193,7 @@ html.is-clipped--nav {
 }
 
 .nav-item.is-active > .nav-item-toggle {
-  transform: rotate(90deg);
+  transform: rotate(270deg);
 }
 
 .is-current-page > .nav-link,
@@ -195,7 +203,6 @@ html.is-clipped--nav {
 
 .nav-link:hover,
 .nav-text:hover {
-  color: var(--color-camel-orange);
   font-weight: var(--body-font-weight-bold);
   text-decoration: underline;
 }

--- a/antora-ui-camel/src/css/vars.css
+++ b/antora-ui-camel/src/css/vars.css
@@ -51,7 +51,7 @@
   --navbar-menu-hover-decoration-color: var(--color-camel-orange);
   /* nav */
   --nav-background: var(--panel-background);
-  --nav-border-color: var(--color-smoke-50);
+  --nav-border-color: var(--color-smoke-70);
   --nav-line-height: 1.35;
   --nav-heading-font-color: var(--color-asf-dark-blue);
   --nav-muted-color: var(--color-jet-50);

--- a/antora-ui-camel/src/css/vars.css
+++ b/antora-ui-camel/src/css/vars.css
@@ -50,8 +50,8 @@
   --navbar-menu-hover-background: var(--color-white);
   --navbar-menu-hover-decoration-color: var(--color-camel-orange);
   /* nav */
-  --nav-background: var(--panel-background);
-  --nav-border-color: var(--color-smoke-70);
+  --nav-background: var(--color-smoke-30);
+  --nav-border-color: var(--color-smoke-90);
   --nav-line-height: 1.35;
   --nav-heading-font-color: var(--color-asf-dark-blue);
   --nav-muted-color: var(--color-jet-50);

--- a/antora-ui-camel/src/js/05-nav-search.js
+++ b/antora-ui-camel/src/js/05-nav-search.js
@@ -33,7 +33,7 @@ document.addEventListener('DOMContentLoaded', function () {
           }
         }
       } else {
-        navLinks[i].style.display = 'none'
+        navLinks[i].parentNode.style.display = 'none'
         replacement = text
       }
       navLinks[i].innerHTML = replacement


### PR DESCRIPTION
In the current website, the left-side nav-bar has the following issues :
- on hover, some of the links don't get underlined : this is because the CSS comes from a:hover so only external links show the change on hover. I have changed this so that all menu items turn black and get underlined on hovering. Eg. the "Supported expression languages" and "Frequently asked questions" on the main menu of user manual don't show any hover effect.
- In the User Manual, the submenu list under Architecture and Integration patterns is so long that if you open the drop-down, the menu becomes very long and difficult to navigate (you can't see the other main-menu items due to the long sub-menu list). I have changed this such that if the submenu takes > 200px height, it becomes scrollable instead of taking up the entire space of the main-menu. I have styled the scrollbar to match the aesthetics.
- The drop-down arrow buttons on the left seem uneven, since they are not present for every item and hence the menu looks oddly indented. I have revamped the menu - please see the screenshot below. Now user can make out the difference between menu and content easily, each item of the menu is well separated, the drop-down buttons are on the right for even-ness. The sub-menus are scrollable.
- On using the quick search present in "components", extra border lines were appearing because only the nav-links were getting hidden, not the entire nav-item, so I changed that as well.

The problem :
![sidebar-menu-problem](https://user-images.githubusercontent.com/32356795/76871913-b5ed5d00-6891-11ea-85cc-0cbc885bb759.png)


The menu design :
![menu-design](https://user-images.githubusercontent.com/32356795/76981241-527e3080-6960-11ea-8309-ccd1a8da69ad.png)


Sub-menu design (scrollable) 
![menu-scroll](https://user-images.githubusercontent.com/32356795/76981554-c6b8d400-6960-11ea-9acd-92d0909e671f.png)



