### PR TITLE
CAMEL-14732: Position footer to be at the bottom of the page

### DIFF
--- a/antora-ui-camel/src/css/footer.css
+++ b/antora-ui-camel/src/css/footer.css
@@ -1,6 +1,7 @@
 footer {
   display: flex;
   justify-content: center;
+  position: relative;
   background-color: var(--footer-background);
   color: var(--footer-font-color);
   font-size: calc(15 / var(--rem-base) * 1rem);
@@ -64,7 +65,10 @@ footer .footer dl dd {
 
 .edit {
   max-width: var(--static-max-width--desktop);
-  margin: auto;
+  position: relative;
+  margin-top: 10em;
+  margin-left: auto;
+  margin-right: auto;
   text-align: right;
 }
 

--- a/antora-ui-camel/src/css/footer.css
+++ b/antora-ui-camel/src/css/footer.css
@@ -66,7 +66,7 @@ footer .footer dl dd {
 .edit {
   max-width: var(--static-max-width--desktop);
   position: relative;
-  margin-top: 10em;
+  margin-top: 10rem;
   margin-left: auto;
   margin-right: auto;
   text-align: right;


### PR DESCRIPTION
* It has been observed that for certain pages where the content is minimal, the footer is not fixed to the bottom of the page in the desktop version. 

* Thus, I changed the code such that the footer will remain on the bottom of the page regardless of the minimal text on each webpage.

### Issue Observed 

![Issue: Footer doesn't remain on the bottom of the page](https://user-images.githubusercontent.com/44139348/76924897-cfc48980-68fd-11ea-8ead-ae7c9a24e38f.png)

### Solution Provided

![Solution: Changed margin such that footer remain on the bottom of the page](https://user-images.githubusercontent.com/44139348/76925009-174b1580-68fe-11ea-9e53-5b5d0a6c35f0.png)


