### PR TITLE
footer font color

### DIFF
--- a/antora-ui-camel/src/css/vars.css
+++ b/antora-ui-camel/src/css/vars.css
@@ -117,8 +117,8 @@
   /* footer */
   --footer-line-height: var(--doc-line-height);
   --footer-background: var(--color-smoke-90);
-  --footer-font-color: var(--color-gray-70);
-  --footer-link-font-color: var(--color-jet-80);
+  --footer-font-color: var(--color-jet-80;);
+  --footer-link-font-color: var(--color-black);
   /* dimensions */
   --navbar-height: calc(73 / var(--rem-base) * 1rem);
   --toolbar-height: calc(45 / var(--rem-base) * 1rem);


### PR DESCRIPTION
In the footer section, the background colour of the footer is light and font colour is also light so the visibility of footer is so dull. In this PR I have changed the font colour in dark colour.
Previous Footer:
![previous-footer](https://user-images.githubusercontent.com/36660186/76935816-ccd69280-6917-11ea-838e-0e6b700387ab.png)

Changed Footer:
![changed-footer](https://user-images.githubusercontent.com/36660186/76935834-d65ffa80-6917-11ea-8c0a-36b4a7529165.png)
