### PR TITLE
Consistency in title color for blog page

### DIFF
--- a/antora-ui-camel/src/css/doc.css
+++ b/antora-ui-camel/src/css/doc.css
@@ -116,7 +116,7 @@
 }
 
 .doc a {
-  color:#303284;
+  color: #303284;
 }
 
 .doc a:hover {

--- a/antora-ui-camel/src/css/doc.css
+++ b/antora-ui-camel/src/css/doc.css
@@ -116,7 +116,7 @@
 }
 
 .doc a {
-  color: var(--link-font-color);
+  color:#303284;
 }
 
 .doc a:hover {


### PR DESCRIPTION
I was going through the website and I found the title color different for blog's page as compared to the rest of the website.I think there should be consistency in the entire website so I changed the color

The color for titles or link in other pages:

![image](https://user-images.githubusercontent.com/44733143/77005099-0f34b980-6982-11ea-8def-d66ddfdf3ffc.png)

The color for blog was :
![image](https://user-images.githubusercontent.com/44733143/77005158-2a072e00-6982-11ea-8df0-60f07adefdb2.png)

I have changed it to :
![image](https://user-images.githubusercontent.com/44733143/77005269-54f18200-6982-11ea-81a9-b00383223452.png)

