### PR TITLE
Issue/Fixed Quick lookup input box width

### DIFF
--- a/antora-ui-camel/src/css/nav.css
+++ b/antora-ui-camel/src/css/nav.css
@@ -98,9 +98,9 @@ html.is-clipped--nav {
 
 .nav-panel-menu input.search {
   position: absolute;
-  width: 14.3rem;
+  width: 100%;
   border: 1px solid var(--nav-background);
-  padding: 0.5rem 1.23rem 0.5rem 1.7rem;
+  padding: 0.6rem 1.23rem 0.5rem 1.7rem;
   margin: 0;
   background: var(--nav-background) no-repeat 0.3rem/1.2rem url(../img/search.svg);
   z-index: var(--z-index-nav-search);


### PR DESCRIPTION
Quick lookup has a fixed width, it affects the menu text in mobile view and iPad view. Half of the menu text gets displayed after this input box which doesn't look good. It should have full width.

CC: @zregvart 