### PR TITLE
Add a search lookup for user-manual page similar to component page

### DIFF
--- a/antora-ui-camel/src/partials/nav-menu.hbs
+++ b/antora-ui-camel/src/partials/nav-menu.hbs
@@ -3,6 +3,9 @@
   {{#if (eq page.component.name 'components')}}
   <input class="search" placeholder="Quick lookup">
   {{/if}}
+  {{#if (eq page.component.name 'manual')}}
+  <input class="search" placeholder="Quick lookup">
+  {{/if}}
   <nav class="nav-menu">
     <h3 class="title"><a href="{{relativize page.url page.componentVersion.url}}">{{page.component.title}}</a></h3>
 {{> nav-tree navigation=page.navigation}}


### PR DESCRIPTION
* It is observed that on the components page, on the side nav panel, there is a lookup search so that the user can easily search within the components list or EIP, based on the query given by the user, the link is easily found instead of dragging through the entire side panel. 

* Thus, for improvement I added the search lookup for the user-manual page as well. Hence, when the user clicks on any sub-topic and based on it searches their query, the particular link is provided making it easy for the user to move through the documents within user-manual.