### PR TITLE
FIX: nav-menu items overflow issue

### DIFF
--- a/antora-ui-camel/src/css/nav.css
+++ b/antora-ui-camel/src/css/nav.css
@@ -122,6 +122,7 @@ html.is-clipped--nav {
   padding: 0.5rem 0.75rem;
   line-height: var(--nav-line-height);
   position: relative;
+  word-break: break-word;
 }
 
 .nav-menu h3.title {


### PR DESCRIPTION
Signed-off-by: Agha Saad Fraz <agha.saad04@gmail.com>

## Issue:
Frequently Asked Questions in the nav menu has text that overflows its container and user needs to scroll into x-axis to read the whole text:

![image](https://user-images.githubusercontent.com/36513474/77336685-b41c1180-6d49-11ea-926c-9f3228dd8b7d.png)


## Solution:
The text should be divided into multiple lines instead of overflowing.

![image](https://user-images.githubusercontent.com/36513474/77336571-8767fa00-6d49-11ea-947c-869b00d0e06b.png)
