### PR TITLE
CAMEL-14732: Position footer to be fixed on the bottom of the screen

### DIFF
--- a/antora-ui-camel/src/css/base.css
+++ b/antora-ui-camel/src/css/base.css
@@ -1,6 +1,8 @@
 html,
 body {
   height: 100%;
+  display: flex;
+  flex-direction: column;
 }
 
 *,

--- a/antora-ui-camel/src/css/body.css
+++ b/antora-ui-camel/src/css/body.css
@@ -1,5 +1,6 @@
 @media screen and (min-width: 1024px) {
   .body {
     display: flex;
+    flex: auto;
   }
 }

--- a/antora-ui-camel/src/css/footer.css
+++ b/antora-ui-camel/src/css/footer.css
@@ -6,6 +6,7 @@ footer {
   font-size: calc(15 / var(--rem-base) * 1rem);
   line-height: var(--footer-line-height);
   padding: 1.5rem;
+  flex-shrink: 0;
 }
 
 footer .footer {
@@ -66,6 +67,18 @@ footer .footer dl dd {
   max-width: var(--static-max-width--desktop);
   margin: auto;
   text-align: right;
+  flex: initial;
+  margin-left: 80%;
+}
+
+@media screen and (max-width: 640px) {
+  .edit {
+    max-width: var(--static-max-width--desktop);
+    margin: auto;
+    text-align: right;
+    flex: initial;
+    margin-right: 0;
+  }
 }
 
 .edit a {


### PR DESCRIPTION
* It has been observed that for certain pages where the content is minimal, the footer is not fixed to the bottom of the page in the desktop version.

* Thus, I changed the code such that the footer will remain on the bottom of the page regardless of the minimal text on each webpage.

### BEFORE 
![before](https://user-images.githubusercontent.com/44139348/77446139-fd389800-6e13-11ea-8a53-fb2ba02467d1.png)

### AFTER
![after](https://user-images.githubusercontent.com/44139348/77446160-06296980-6e14-11ea-9629-130df5575f6f.png)
