### PR TITLE
Sorting of Camel Video languages

### DIFF
--- a/content/community/articles.md
+++ b/content/community/articles.md
@@ -2,50 +2,43 @@
 title: "Articles"
 ---
 
-### Camel Videos
+### Camel Videos(Lang: EN(GLISH), FRENCH, Norwegian, Russian, Spannish)
 
-*   [Camel Riders in the Cloud](https://developers.redhat.com/video/youtube/zuEYtMvHN6g/) - A 30 minute video from March 2018 where Claus presents using Camel with microservices and containers as cloud native applications, and the best practices around this.
-*   [Agile Integration with Apache Camel microservices in containers on Kubernetes](https://www.youtube.com/watch?v=9FN4DuBJy8M) - A 45 minute video from fall 2017 where Claus presents at CodeEurope in Poland.
-*   [Containerised Integration with Apache Camel](https://www.youtube.com/watch?v=Xkg_AGLV32A&feature=youtu.be) - A 70 minute video from August 2017 where Claus Ibsen present how developers can get started with Kubernetes/OpenShift on a local cluster and build and run Camel microservices in the cluster.
-*   [Apache Camel - The Integration Library](https://www.youtube.com/watch?v=fxpS9pf6TVk&list=PLUDjw7NbNcoyOyhrIIw9cChAHWdaCxIob&index=17) - A 50 minute video from September 2016 where Claus Ibsen presents Apache Camel at the JDKIO 2016 conference.
-*   [Apache Camel First Steps](https://www.youtube.com/watch?v=jZE-YSHK_gw&sns=tw) - A 10 minute video from December 2015 where Vivian van Zyl gives a high level overview of Apache Camel and demonstrates how to start using Camel with live code demo.
-*   [Fabric8 Camel Microservices for Docker and Kubernetes](https://www.youtube.com/watch?v=ouJ3SQHnQ6I&feature=youtu.be&a) - A 55 minute video from [Riga Dev Day](http://rigadevday.lv/#/index) 2016 conference where Claus Ibsen talks about developing Camel microservices ready for the container platforms.
-*   [Developing Microservices with Apache Camel](https://www.youtube.com/watch?v=91UiQgazt3g) - Video from November 2015 at the MSA Day in New York where Claus Ibsen talks developing Camel based microservices for docker containers running on Kubernetes. [Slides are here](http://www.slideshare.net/davsclaus/developing-microservices-with-apache-camel).
-*   [JavaOne 2015 Riding a Camel through the JEEHara](https://www.youtube.com/watch?v=nqQaR7vUxfg&index=13&list=PLPIzp-E1msrZz6RNdbDiK0nKuxAUZPs77) - Video from JavaOne 2015 where Markus Eisele introduces Apache Camel and how to use it with JEE.
-*   [Apache Camel in the clouds](https://www.youtube.com/watch?v=jbj1TJ_2XBQ&feature=youtu.be&a) - Video from Devnexus 2015 where Markus Eisele talk about Apache Camel in the clouds running on openshift
-*   [GeeCON 2015: Markus Eisele - Wild Flies and a Camel - Java EE Integration](https://vimeo.com/130993910) - Video from GeeCon 2015 where Markus Eisele talks about Apache Camel and how Camel can work with Wildfly
-*   [Hvordan få en kamel til å danse (September 2014)](https://vimeo.com/105743314) by Per Jørgen Walstrøm & Audun Fauchald Strand - (JavaZone 2014) in Norwegian
-*   [Integration using Apache Camel and Groovy (June 2014)](http://www.youtube.com/watch?v=_pEwoztbfYI&feature=youtu.be&a) by Claus Ibsen, presenting Camel, Groovy, and [hawtio](http://hawt.io/) at [gr8conf](http://gr8conf.eu/#/) 2014.
-*   [Effective System Integrations with Apache Camel (March 2014)](https://skillsmatter.com/skillscasts/5074-effective-system-integrations-with-apache-camel) by Jakub Korab
-*   [Getting started with Apache Camel video from BarcelonaJUG (January 2014)](http://www.youtube.com/watch?v=lOxUs_JleSs&feature=youtu.be&a) by Claus Ibsen
-*   [Camel in the cloud demo from CamelOne 2013](http://vimeo.com/68442425) - Video presentation from CamelOne 2013 demonstrating Camel in the cloud using [Fuse Fabric](https://fabric8.io/) and [hawtio](http://hawt.io/)
-*   [Apache Camel Essential Components](https://blog.christianposta.com/webinar/camel-essential-components-webinar/) _by Christian Posta_ (January 2013)
-*   [Leverage Enterprise Integration Patterns with Apache Camel and Twitter](https://mnclip.info/w8WtDnZz8ac-leverage-eips-with-apache-camel-and-twitter.html) _by Bruno Borges_ (JavaOne 2012)
-*   [Riding the Apache Camel into the cloud](http://www.infoq.com/presentations/Riding-Apache-Camel-Cloud) _James Strachan_ (QCon 2012)
-*   [Migrating akka-camel module to Akka 2.x](http://skillsmatter.com/podcast/scala/akka-2-x) _by Peter Gabryanczy_ (ScalaDays 2012)
-*   [Confident Data Transfers with Apache Camel Security](http://www.youtube.com/watch?v=YiG5_rGLapU) _by Dominik Schadow_ (JavaOne 2012)
-*   [CamelOne 2012 Videos](http://camelone.org/camelone-2012/) - All the videos from the [CamelOne 2012 conference](http://fusesource.com/apache-camel-conference-2012) (May 2012)
-*   [JavaOne 2012 - Leverage Enterprise Integration Patterns with Apache Camel and Twitter](http://java.dzone.com/articles/leverage-enterprise) _by Bruno Borges_ (JavaOne 2012)
-*   [Using Apache Camel and Java EE in an OSGi World](http://www.java-tv.com/2012/02/28/using-apache-camel-and-java-ee-in-an-osgi-world/) _by Jeff Genender and Johan Edstrom_ (JavaOne 2011)
-*   [Er Apache Camel riktig valg for deg? Lytt til erfarne Camel spotters](http://vimeo.com/28760446)  _by Rune Peter Bjørnstad, and Bjørn Nordlund_(September 2011)
-*   [In the brain of James Strachan, riding the Camel](http://skillsmatter.com/podcast/design-architecture/riding-camel/JS-2327) - _by_ _[James Strachan](http://macstrac.blogspot.com/)_ (August 2011)
-*   [CamelOne 2011 conference](http://camelone.org/camelone-2012/) (May 2011)
-*   [What Riding the Camel can make integration easier for you](http://vimeo.com/28760458) _by_ _[Claus Ibsen](http://davsclaus.blogspot.com)_ (September 2011)
-*   [Un plongeon dans les frameworks d'intégration Java: Apache Camel et Spring Integration](https://www.youtube.com/watch?v=gkUzmbwJr8k) _by Guillaume Giamarchi and Grégory Boissinot_ (October 2013)
-*   [JEEConf 2011 - What riding the Camel can do to make integration easier for you](http://jeeconf.com/program/camel/) _by Claus Ibsen_ (May 2011).
-*   [Introduction to messaging with ActiveMQ](http://www.java-tv.com/2009/07/24/introduction-to-messaging-with-apache-activemq/) at [Øredev 2008 conference](https://oredev.org/) _by_ _[Bruce Snyder](http://bsnyderblog.blogspot.com/)_
+*   [Camel Riders in the Cloud](https://developers.redhat.com/video/youtube/zuEYtMvHN6g/)(EN) - A 30 minute video from March 2018 where Claus presents using Camel with microservices and containers as cloud native applications, and the best practices around this.
+*   [Agile Integration with Apache Camel microservices in containers on Kubernetes](https://www.youtube.com/watch?v=9FN4DuBJy8M)(EN) - A 45 minute video from fall 2017 where Claus presents at CodeEurope in Poland.
+*   [Containerised Integration with Apache Camel](https://www.youtube.com/watch?v=Xkg_AGLV32A&feature=youtu.be)(EN) - A 70 minute video from August 2017 where Claus Ibsen present how developers can get started with Kubernetes/OpenShift on a local cluster and build and run Camel microservices in the cluster.
+*   [Apache Camel - The Integration Library](https://www.youtube.com/watch?v=fxpS9pf6TVk&list=PLUDjw7NbNcoyOyhrIIw9cChAHWdaCxIob&index=17)(EN) - A 50 minute video from September 2016 where Claus Ibsen presents Apache Camel at the JDKIO 2016 conference.
+*   [Apache Camel First Steps](https://www.youtube.com/watch?v=jZE-YSHK_gw&sns=tw)(EN) - A 10 minute video from December 2015 where Vivian van Zyl gives a high level overview of Apache Camel and demonstrates how to start using Camel with live code demo.
+*   [Fabric8 Camel Microservices for Docker and Kubernetes](https://www.youtube.com/watch?v=ouJ3SQHnQ6I&feature=youtu.be&a)(EN) - A 55 minute video from [Riga Dev Day](http://rigadevday.lv/#/index) 2016 conference where Claus Ibsen talks about developing Camel microservices ready for the container platforms.
+*   [Developing Microservices with Apache Camel](https://www.youtube.com/watch?v=91UiQgazt3g)(EN) - Video from November 2015 at the MSA Day in New York where Claus Ibsen talks developing Camel based microservices for docker containers running on Kubernetes. [Slides are here](http://www.slideshare.net/davsclaus/developing-microservices-with-apache-camel).
+*   [JavaOne 2015 Riding a Camel through the JEEHara](https://www.youtube.com/watch?v=nqQaR7vUxfg&index=13&list=PLPIzp-E1msrZz6RNdbDiK0nKuxAUZPs77)(EN) - Video from JavaOne 2015 where Markus Eisele introduces Apache Camel and how to use it with JEE.
+*   [Apache Camel in the clouds](https://www.youtube.com/watch?v=jbj1TJ_2XBQ&feature=youtu.be&a)(EN) - Video from Devnexus 2015 where Markus Eisele talk about Apache Camel in the clouds running on openshift
+*   [GeeCON 2015: Markus Eisele - Wild Flies and a Camel - Java EE Integration](https://vimeo.com/130993910)(EN) - Video from GeeCon 2015 where Markus Eisele talks about Apache Camel and how Camel can work with Wildfly
+*   [Hvordan få en kamel til å danse (September 2014)](https://vimeo.com/105743314)(Norwegian) by Per Jørgen Walstrøm & Audun Fauchald Strand - (JavaZone 2014) in Norwegian
+*   [Integration using Apache Camel and Groovy (June 2014)](http://www.youtube.com/watch?v=_pEwoztbfYI&feature=youtu.be&a)(EN) by Claus Ibsen, presenting Camel, Groovy, and [hawtio](http://hawt.io/) at [gr8conf](http://gr8conf.eu/#/) 2014.
+*   [Effective System Integrations with Apache Camel (March 2014)](https://skillsmatter.com/skillscasts/5074-effective-system-integrations-with-apache-camel)(EN) by Jakub Korab
+*   [Getting started with Apache Camel video from BarcelonaJUG (January 2014)](http://www.youtube.com/watch?v=lOxUs_JleSs&feature=youtu.be&a)(EN) by Claus Ibsen
+*   [Camel in the cloud demo from CamelOne 2013](http://vimeo.com/68442425)(EN) - Video presentation from CamelOne 2013 demonstrating Camel in the cloud using [Fuse Fabric](https://fabric8.io/) and [hawtio](http://hawt.io/)
+*   [Riding the Apache Camel into the cloud](http://www.infoq.com/presentations/Riding-Apache-Camel-Cloud)(EN) _James Strachan_ (QCon 2012)
+*   [Migrating akka-camel module to Akka 2.x](http://skillsmatter.com/podcast/scala/akka-2-x)(EN) _by Peter Gabryanczy_ (ScalaDays 2012)
+*   [Confident Data Transfers with Apache Camel Security](http://www.youtube.com/watch?v=YiG5_rGLapU)(EN) _by Dominik Schadow_ (JavaOne 2012)
+*   [Using Apache Camel and Java EE in an OSGi World](http://www.java-tv.com/2012/02/28/using-apache-camel-and-java-ee-in-an-osgi-world/)(EN) _by Jeff Genender and Johan Edstrom_ (JavaOne 2011)
+*   [Er Apache Camel riktig valg for deg? Lytt til erfarne Camel spotters](http://vimeo.com/28760446)(Norwegian)  _by Rune Peter Bjørnstad, and Bjørn Nordlund_(September 2011)
+*   [In the brain of James Strachan, riding the Camel](http://skillsmatter.com/podcast/design-architecture/riding-camel/JS-2327)(EN) - _by_ _[James Strachan](http://macstrac.blogspot.com/)_ (August 2011)
+*   [What Riding the Camel can make integration easier for you](http://vimeo.com/28760458)(EN) _by_ _[Claus Ibsen](http://davsclaus.blogspot.com)_ (September 2011)
+*   [Un plongeon dans les frameworks d'intégration Java: Apache Camel et Spring Integration](https://www.youtube.com/watch?v=gkUzmbwJr8k)(FRENCH) _by Guillaume Giamarchi and Grégory Boissinot_ (October 2013)
+*   [Introduction to messaging with ActiveMQ](http://www.java-tv.com/2009/07/24/introduction-to-messaging-with-apache-activemq/)(EN) at [Øredev 2008 conference](https://oredev.org/) _by_ _[Bruce Snyder](http://bsnyderblog.blogspot.com/)_
 *   ScreenCast: an introduction to [Apache Camel](http://activemq.apache.org/camel/) and the use of [Enterprise Integration Patterns](http://activemq.apache.org/camel/enterprise-integration-patterns.html) in [Jame's Blog](http://macstrac.blogspot.com/2013/06/introducing-apache-camel-based-open.html) _by_ _[James Strachan](http://macstrac.blogspot.com/)_
-*   [Taking Camel for a ride](http://bsnyderblog.blogspot.com/2008/05/activemq-and-servicemix-at-apachecon-us.html) _by Bruce Snyder_
 *   [Videos de las charlas de la 9a reunión de JavaMexico (**Spanish**)](http://www.springhispano.org/?q=node/564) _by Domingo Suarez_
-*   [Facebook integration Apache Camel](https://www.youtube.com/watch?v=evx5y1BnT8c) - 15 min screenshot showing how to integrate Camel with Facebook. This screenshot is part of a series, with new videos coming up.
-*   [Advanced AEM Search - Consuming External Content and Enriching Content with Apache Camel](https://www.gastongonzalez.com/tech-blog/2016/8/1/advanced-aem-search-consuming-external-content-and-enriching-content-with-apache-camel) - 45 min video from 2016 by Gaston Gonzales.
-*   [How to use Heroku and Apache Camel to create open source integrations with SalesForce](https://www.youtube.com/watch?v=8yHM1J9qHWw) - 30 min video from 2017.
-*   [Camel microservices with Spring Boot and Kubernetes](https://www.youtube.com/watch?v=dSROap0arRE&feature=youtu.be) - 55 min video from JPoint Moscow 2018, where Claus gave a presentation.
-*   [Camel microservices with Spring Boot and Kubernetes](https://www.youtube.com/watch?v=I5jdLFdWi6w) - 45 min video from JEEConf Kiev 2018, where Claus gave a presentation.
-*   [Spring Tips - Apache Camel](https://spring.io/blog/2018/05/23/spring-tips-apache-camel) - 1 hour video from May 2018 by [Josh Long](https://twitter.com/starbuxman) from Pivotal, whom take a look at using Apache Camel on Spring Boot.
-*   [A Look Back at Enterprise Integration Patterns and Their Use into Today's Serverless Cloud Computing](https://www.youtube.com/watch?v=EbTZ5nSJQwI) - 1h video from Devoxx Poland 2018 by Bruno Borges with l<span style="color: rgb(20,23,26);">ots of demos on **Apache Camel**<span style="color: rgb(20,23,26);">, Azure Functions, and quick look into Kafka and Azure Event Hubs.
-*   [Camel microservices with Spring Boot and Kubernetes](https://vimeo.com/289646198) - 6o min video from JavaZone (September 2018) where Claus gave a presentation. Source code and slides are [available here](https://github.com/davsclaus/camel-riders-in-the-cloud/tree/javazone).
-*   [Camel microservices with Spring Boot and Kubernetes](https://www.youtube.com/watch?v=G8h7oCGsTVQ&t=10s) - 50 min video from Voxxed Days Ticino (October 2018) where Claus gave a presentation. Source code and slides are [available here](https://github.com/davsclaus/camel-riders-in-the-cloud/tree/ticino).
+*   [Facebook integration Apache Camel](https://www.youtube.com/watch?v=evx5y1BnT8c)(EN) - 15 min screenshot showing how to integrate Camel with Facebook. This screenshot is part of a series, with new videos coming up.
+*   [Advanced AEM Search - Consuming External Content and Enriching Content with Apache Camel](https://www.gastongonzalez.com/tech-blog/2016/8/1/advanced-aem-search-consuming-external-content-and-enriching-content-with-apache-camel)(EN) - 45 min video from 2016 by Gaston Gonzales.
+*   [How to use Heroku and Apache Camel to create open source integrations with SalesForce](https://www.youtube.com/watch?v=8yHM1J9qHWw)(EN) - 30 min video from 2017.
+*   [Camel microservices with Spring Boot and Kubernetes](https://www.youtube.com/watch?v=dSROap0arRE&feature=youtu.be)(EN) - 55 min video from JPoint Moscow 2018, where Claus gave a presentation.
+*   [Camel microservices with Spring Boot and Kubernetes](https://www.youtube.com/watch?v=I5jdLFdWi6w)(EN) - 45 min video from JEEConf Kiev 2018, where Claus gave a presentation.
+*   [Spring Tips - Apache Camel](https://spring.io/blog/2018/05/23/spring-tips-apache-camel)(EN) - 1 hour video from May 2018 by [Josh Long](https://twitter.com/starbuxman) from Pivotal, whom take a look at using Apache Camel on Spring Boot.
+*   [A Look Back at Enterprise Integration Patterns and Their Use into Today's Serverless Cloud Computing](https://www.youtube.com/watch?v=EbTZ5nSJQwI)(EN) - 1h video from Devoxx Poland 2018 by Bruno Borges with l<span style="color: rgb(20,23,26);">ots of demos on **Apache Camel**<span style="color: rgb(20,23,26);">, Azure Functions, and quick look into Kafka and Azure Event Hubs.
+*   [Camel microservices with Spring Boot and Kubernetes](https://vimeo.com/289646198)(EN) - 6o min video from JavaZone (September 2018) where Claus gave a presentation. Source code and slides are [available here](https://github.com/davsclaus/camel-riders-in-the-cloud/tree/javazone).
+*   [Camel microservices with Spring Boot and Kubernetes](https://www.youtube.com/watch?v=G8h7oCGsTVQ&t=10s)(EN) - 50 min video from Voxxed Days Ticino (October 2018) where Claus gave a presentation. Source code and slides are [available here](https://github.com/davsclaus/camel-riders-in-the-cloud/tree/ticino).
 
 ### Articles
 
@@ -56,6 +49,9 @@ Articles are divided into several sections. As the lists grow, further sectionin
 *   [Open Source Integration with Apache Camel](http://java.dzone.com/articles/open-source-integration-apache) _by Jonathan Anstey_
 *   [Tutorial: Integrating with Apache Camel](https://jaxenter.com/tutorial-integrating-with-apache-camel-106759.html) _by_ _[Charles Moulliard](https://twitter.com/cmoulliard)_
 *   [Simple DSL OSGi bundle example](http://www.andrejkoelewijn.com/blog/2008/10/19/simple-camel-dsl-osgi-bundle-example/) _by_ _[Andrej Koelewijn](http://www.andrejkoelewijn.com/)_
+*   [CamelOne 2012 leature series](http://camelone.org/camelone-2012/) - All the videos from the [CamelOne 2012 conference](http://fusesource.com/apache-camel-conference-2012) (May 2012) 
+*  [JEEConf 2011 - What riding the Camel can do to make integration easier for you](http://jeeconf.com/program/camel/)(Russian) _by Claus Ibsen_ (May 2011).
+*  [CamelOne 2011 conference](http://camelone.org/camelone-2012/) (May 2011)
 *   [Realization of EAI Patterns with Apache Camel](https://www.researchgate.net/publication/37686328_Realization_of_EAI_Patterns_with_Apache_Camel) _by Pascal Kolb_
 *   [Navigating the Integration Landscape - Claus Ibsen on Apache Camel](http://java.dzone.com/articles/interview-claus-ibsen-about) Claus Ibsen was interviewed at DZone discussing the integration landscape
 *   [Enterprise Integration Pattern with Apache Camel 2.0](http://onjavahell.blogspot.com/2009/05/taking-apache-camel-for-ride.html) _by Julien Dechmann_
@@ -278,6 +274,7 @@ These examples show Camel combined with several tools (e.g. IDE), ESBs, Applicat
 ### Presentations on Apache Camel
 
 *   [Implementing Enterprise Integration Patterns with Apache Camel](http://alt.java-forum-stuttgart.de/jfs/2008/folien/E3.pdf) presentation _by Eduard Hildebrandt_
+*   [Taking Camel for a ride](https://www.slideshare.net/bruce.snyder/takingapachecamelforaride/) _by Bruce Snyder_
 *   [Dead Simple Integration with Apache Camel](https://chariotsolutions.com/presentation/dead-simple-integration-with-apache-camel/) _by Aaron Mulder_
 *   [Claus Ibsen's](http://www.slideshare.net/davsclaus/fuse-community-day-london-2010-apache-camel-presentation) Apache Camel presentation at the [FUSE](https://www.redhat.com/fr/technologies/jboss-middleware/fuse) community day in London 2010.
 *   [FuseSource presentations](https://www.slideshare.net/fusesource/introduction-to-apache-camel) on Camel and other related Apache projects


### PR DESCRIPTION
Hi @zregvart 
As outreachy applicant for content organisation, i discovered that some camel videos were in another languages other than English.  I took my time to watch those videos to confirm their various languages. This lead to my discovery of some broken video links which reported. I also search for them on archive.org as suggested to confirm their non existence. Below are the broken video links:

*   [Apache Camel Essential Components](https://blog.christianposta.com/webinar/camel-essential-components-webinar/) _by Christian Posta_ (January 2013)(No more available)

*   [Leverage Enterprise Integration Patterns with Apache Camel and Twitter](https://mnclip.info/w8WtDnZz8ac-leverage-eips-with-apache-camel-and-twitter.html) _by Bruno Borges_ (JavaOne 2012)(No more available)

[JavaOne 2012 - Leverage Enterprise Integration Patterns with Apache Camel and Twitter](http://java.dzone.com/articles/leverage-enterprise) _by Bruno Borges_ (JavaOne 2012)

I also move 3 links to article section where they rightly belong and one link to presentation section

Having completed the changes,  I propose for the file change. I will be glad to correct what need to be corrected.