### PR TITLE
Consistency in title color for blog page 

### DIFF
--- a/layouts/blog/summary.html
+++ b/layouts/blog/summary.html
@@ -1,7 +1,7 @@
 <article class="blog doc">
 
     <header>
-        <h1><a href="{{.Page.RelPermalink}}">{{ .Title }}</a></h1>
+        <h1>{{ .Title }}</h1>
     </header>
     <p>{{ .Summary }}</p>
     <p><a class="continue" href="{{ .RelPermalink }}">Continue reading &#10095;</a></p>


### PR DESCRIPTION
I have removed the links from the blog page to add color consistency to the headings.
![image](https://user-images.githubusercontent.com/44733143/77708191-2e1df600-6fe9-11ea-9f45-c6d04301c575.png)

