### PR TITLE
Color consistency in headings of blog page

### DIFF
--- a/layouts/blog/post.html
+++ b/layouts/blog/post.html
@@ -4,7 +4,7 @@
         {{ if .Params.categories }}
             {{ range .Params.categories }}<a class="category" href="{{ "/categories/" | relURL }}{{ . | urlize }}/">{{ upper . }}</a>{{ end }}
         {{ end }}
-        <h1><a href="{{.Page.Permalink}}">{{ .Title }}</a></h1>
+        <h1>{{ .Title }}</h1>
     </header>
     <div class="post">
         <aside>

--- a/layouts/blog/summary.html
+++ b/layouts/blog/summary.html
@@ -1,7 +1,7 @@
 <article class="blog doc">
 
     <header>
-        <h1><a href="{{.Page.RelPermalink}}">{{ .Title }}</a></h1>
+        <h1>{{ .Title }}</h1>
     </header>
     <p>{{ .Summary }}</p>
     <p><a class="continue" href="{{ .RelPermalink }}">Continue reading &#10095;</a></p>


### PR DESCRIPTION
I have removed the link of the headings  on blog page to make color consistent
![image](https://user-images.githubusercontent.com/44733143/77709029-966dd700-6feb-11ea-9a01-d777c3d1b9cd.png)

Furthermore, when we opened individual blog page , the page's heading was a link however it  redirected us to the same page.So I have removed the unnecessary link from those headings as well.
![image](https://user-images.githubusercontent.com/44733143/77709157-fbc1c800-6feb-11ea-90c5-206d02257725.png)
The heading shown in the above image redirected to the same page.
Now it looks like this :
![image](https://user-images.githubusercontent.com/44733143/77709203-23b12b80-6fec-11ea-878c-0c482e531f1f.png)
