### PR TITLE
make the split in Apache & opensource look neat on front-page

### DIFF
--- a/antora-ui-camel/src/css/frontpage.css
+++ b/antora-ui-camel/src/css/frontpage.css
@@ -235,7 +235,7 @@ section.frontpage h1 {
 @media screen and (max-width: 626px) {
   .split {
     flex: 100%;
-    margin: 3%;
+    margin-left: 0.75rem;
   }
 
   section.frontpage.columns,

--- a/antora-ui-camel/src/css/frontpage.css
+++ b/antora-ui-camel/src/css/frontpage.css
@@ -235,6 +235,7 @@ section.frontpage h1 {
 @media screen and (max-width: 626px) {
   .split {
     flex: 100%;
+    margin: 3%;
   }
 
   section.frontpage.columns,


### PR DESCRIPTION
* Within the **Apache & Opensource** section on the front page, the paragraph written doesn't have any margin surrounding it making the design look unstructured for the mobile view. 

* Thus, I added a margin surrounding the split session for the front page to look structured and neat for the mobile view.

### BEFORE 
![before-design](https://user-images.githubusercontent.com/44139348/77741697-520a2780-703b-11ea-9b6d-8ae42fd0d328.png)

### AFTER
![responsive](https://user-images.githubusercontent.com/44139348/77741716-5a626280-703b-11ea-819e-fc67c6601097.png)

