### PR TITLE
Fix the broken header menu

### DIFF
--- a/antora-ui-camel/src/css/header.css
+++ b/antora-ui-camel/src/css/header.css
@@ -128,6 +128,11 @@ body {
   position: relative;
 }
 
+.navbar-item {
+  flex: none;
+  padding: 1rem 2rem 1rem 0;
+}
+
 .navbar-item .icon {
   width: 1.1rem;
   height: 1.1rem;

--- a/antora-ui-camel/src/css/header.css
+++ b/antora-ui-camel/src/css/header.css
@@ -161,7 +161,7 @@ body {
 
   .navbar-dropdown {
     background-color: var(--navbar-menu-background);
-    top: 100%;
+    top: 98%;
     left: 0;
     min-width: 100%;
   }
@@ -361,10 +361,6 @@ body {
     left: 0;
     min-width: 100%;
     position: absolute;
-  }
-
-  .navbar-item.has-dropdown.is-hoverable:hover {
-    background: var(--color-white);
   }
 
   .navbar-dropdown .navbar-item {

--- a/antora-ui-camel/src/css/header.css
+++ b/antora-ui-camel/src/css/header.css
@@ -128,11 +128,6 @@ body {
   position: relative;
 }
 
-.navbar-item {
-  flex: none;
-  padding: 1rem 2rem 1rem 0;
-}
-
 .navbar-item .icon {
   width: 1.1rem;
   height: 1.1rem;
@@ -366,6 +361,10 @@ body {
     left: 0;
     min-width: 100%;
     position: absolute;
+  }
+
+  .navbar-item.has-dropdown.is-hoverable:hover {
+    background: var(--color-white);
   }
 
   .navbar-dropdown .navbar-item {


### PR DESCRIPTION
As observed in PR #207 the submenus don't start from below the line. I think there was a PR about shifting the menu text to align with the other elements which caused this change. 
- Instead of the margin, I have added padding. Padding left is 0 so that the drop-downs are aligned with the starting of the text
- Added some padding to the down-arrow button, which seemed too close to the text.   

I think the problem in #207 should also be solved with this.

![menu-fixed](https://user-images.githubusercontent.com/32356795/77824554-91af3d00-7129-11ea-91b6-b790d071ed25.png)

