### PR TITLE
Alignment of navbar-link:after arrows

### DIFF
--- a/antora-ui-camel/src/css/header.css
+++ b/antora-ui-camel/src/css/header.css
@@ -225,7 +225,7 @@ body {
     transform: rotate(-45deg);
     width: 0.5em;
     right: 0;
-    top: 40%;
+    top: 4.5px;
   }
 }
 
@@ -300,7 +300,7 @@ body {
     margin-top: 0.6em;
     margin-right: 1rem;
     right: 0;
-    top: 40%;
+    top: -2.5px;
   }
 }
 


### PR DESCRIPTION
This is how the arrows look in the mobile screen resolutions. My PR serves to fix this.

![WhatsApp Image 2020-03-29 at 06 58 36](https://user-images.githubusercontent.com/51945896/77837789-da4b1280-718a-11ea-9625-9aa2f7531360.jpeg)



