### PR TITLE
[CAMEL-13812] Split FAQ into separate page

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -8,6 +8,10 @@ content:
     - url: git@github.com:apache/camel.git
       branches: master
       start_path: docs/user-manual
+# faq
+    - url: git@github.com:apache/camel.git
+      branches: master
+      start_path: docs/faq  
 # eip
     - url: git@github.com:apache/camel.git
       branches: master

--- a/antora-ui-camel/src/partials/nav-menu.hbs
+++ b/antora-ui-camel/src/partials/nav-menu.hbs
@@ -1,7 +1,11 @@
 {{#if page.navigation}}
 <div class="nav-panel-menu is-active" data-panel="menu">
-
+  {{#if (eq page.component.name 'components')}}
   <input class="search" placeholder="Quick lookup">
+  {{/if}}
+  {{#if (eq page.component.name 'faq')}}
+  <input class="search" placeholder="Quick lookup">
+  {{/if}}
   <nav class="nav-menu">
     <h3 class="title"><a href="{{relativize page.url page.componentVersion.url}}">{{page.component.title}}</a></h3>
 {{> nav-tree navigation=page.navigation}}

--- a/antora-ui-camel/src/partials/nav-menu.hbs
+++ b/antora-ui-camel/src/partials/nav-menu.hbs
@@ -1,8 +1,7 @@
 {{#if page.navigation}}
 <div class="nav-panel-menu is-active" data-panel="menu">
-  {{#if (eq page.component.name 'components')}}
+
   <input class="search" placeholder="Quick lookup">
-  {{/if}}
   <nav class="nav-menu">
     <h3 class="title"><a href="{{relativize page.url page.componentVersion.url}}">{{page.component.title}}</a></h3>
 {{> nav-tree navigation=page.navigation}}


### PR DESCRIPTION
Refer to [this JIRA issue](https://issues.apache.org/jira/browse/CAMEL-13812).
The corresponding PR for changes in user manual is [here](https://github.com/apache/camel/pull/3691)

User Manual Menu has entry for FAQ :

![faq-menu](https://user-images.githubusercontent.com/32356795/77859964-f94cb180-7229-11ea-8841-3174a0f2e4c5.png)

FAQ page with its menu :

![camel-faq](https://user-images.githubusercontent.com/32356795/77859987-239e6f00-722a-11ea-957e-83c29cc13d6e.png)
