### PR TITLE
improve the color contrast for code tag

### DIFF
--- a/antora-ui-camel/src/css/vars.css
+++ b/antora-ui-camel/src/css/vars.css
@@ -17,7 +17,7 @@
   --color-jet-80: #191919;
   --color-black: #000;
   --color-asf-dark-blue: #303284;
-  --color-asf-moderate-blue: #585ac2;
+  --color-asf-moderate-blue: #4f51ae;
   --color-camel-orange: #ed8225;
   --color-highlight: #fffcdd;
   --color-glow: #fff7a3;


### PR DESCRIPTION
## ISSUE 

* The color for the code tag doesn't blend well with the color used for the heading. Hence, I made use of a shade of blue such that the blending is done properly and the accessibility factor for the code tag is improved as well. 

### BEFORE
![color-before](https://user-images.githubusercontent.com/44139348/77911766-0069d300-72af-11ea-9ccf-355693f9b35c.png)
 
### AFTER
![color-after](https://user-images.githubusercontent.com/44139348/77911778-0495f080-72af-11ea-902b-65c6de147658.png)
