### PR TITLE
Custom Pagination within Blog Section

### DIFF
--- a/antora-ui-camel/src/css/doc.css
+++ b/antora-ui-camel/src/css/doc.css
@@ -368,7 +368,7 @@
 .doc ol,
 .doc ul {
   margin: 0;
-  padding: 0 0 0 2rem;
+  padding: 0 0 0 1rem;
 }
 
 .doc ol.arabic {

--- a/antora-ui-camel/src/css/doc.css
+++ b/antora-ui-camel/src/css/doc.css
@@ -368,7 +368,7 @@
 .doc ol,
 .doc ul {
   margin: 0;
-  padding: 0 0 0 1rem;
+  padding: 0 0 0 2rem;
 }
 
 .doc ol.arabic {

--- a/layouts/blog/list.html
+++ b/layouts/blog/list.html
@@ -18,37 +18,43 @@
             
             {{ $page := .Paginator }}
             {{ if gt $page.TotalPages 1 }}
-            {{ $.Scratch.Set "dot_rendered" false }}
-            <nav aria-label="page navigation">
+            {{ $shouldEllipse := false }}
+            <nav aria-label="page">
                 <ul class="pagination">
-                    <!-- Don't show on 1st and 2nd page -->
-                    {{ if and (ne $page.PageNumber 1) }}
-                    <li class="page-item"><a href="{{ $page.First.URL }}" rel="first" class="page-link">««</a></li>
+                    {{ if ne $page.PageNumber 1 }}
+                    <li class="page-item">
+                        <a href="{{ $page.First.URL }}" class="page-link" aria-label="First"><span aria-hidden="true">&laquo;&laquo;</span></a>
+                    </li>
                     {{ end }}
 
                     {{ if $page.HasPrev  }}
-                    <li class="page-item"><a href="{{ $page.Prev.URL }}" rel="prev" class="page-link">«</a></li>
+                    <li class="page-item">
+                        <a href="{{ $page.Prev.URL }}" class="page-link" aria-label="Previous"><span aria-hidden="true">&laquo;</span></a>
+                    </li>
                     {{ end }}
 
                     {{ range $page.Pagers }}
-                        {{ if eq . $page }} <!-- Current Page -->
+                        {{ if eq . $page }}
                         <li class="page-item active"><a href="{{ .URL }}" class="page-link">{{ .PageNumber }}</a></li>
                         {{ else if and (ge .PageNumber (sub $page.PageNumber 2)) (le .PageNumber (add $page.PageNumber 2)) }}
-                        {{ $.Scratch.Set "dot_rendered" false }} <!-- Render prev 2 page and next 2 pages -->
+                        {{ $shouldEllipse = false }}
                         <li class="page-item"><a href="{{ .URL }}" class="page-link">{{ .PageNumber }}</a></li>
-                        {{ else if eq ($.Scratch.Get "dot_rendered") false }} <!-- render skip pages -->
-                        {{ $.Scratch.Set "dot_rendered" true }}
-                        <li class="page-item disabled"><a class="page-link">...</a></li>
+                        {{ else if eq $shouldEllipse false }}
+                        {{ $shouldEllipse = true }}
+                        <li class="page-item disabled"><a class="page-link">&hellip;</a></li>
                         {{ end }}
                     {{ end }}
 
                     {{ if $page.HasNext }}
-                    <li class="page-item"><a href="{{ $page.Next.URL }}" rel="next" class="page-link">»</a></li>
+                    <li class="page-item">
+                        <a href="{{ $page.Next.URL }}" class="page-link" aria-label="Next"><span aria-hidden="true">&raquo;</span></a>
+                    </li>
                     {{ end }}
 
-                    <!-- Don't show on last and 2nd last page -->
-                    {{ if and (ne $page.PageNumber $page.TotalPages) }}
-                    <li class="page-item"><a href="{{ $page.Last.URL }}" rel="last" class="page-link">»»</a></li>
+                    {{ if ne $page.PageNumber $page.TotalPages }}
+                    <li class="page-item">
+                        <a href="{{ $page.Last.URL }}" class="page-link" aria-label="Last"><span aria-hidden="true">&raquo;&raquo;</span></a>
+                    </li>
                     {{ end }}
                 </ul>
             </nav>

--- a/layouts/blog/list.html
+++ b/layouts/blog/list.html
@@ -15,7 +15,44 @@
             {{ range $pages }}
                 {{ .Render "summary" }}
             {{ end }}
-            {{ template "_internal/pagination.html" . }}
+            
+            {{ $page := .Paginator }}
+            {{ if gt $page.TotalPages 1 }}
+            {{ $.Scratch.Set "dot_rendered" false }}
+            <nav aria-label="page navigation">
+                <ul class="pagination">
+                    <!-- Don't show on 1st and 2nd page -->
+                    {{ if and (ne $page.PageNumber 1) }}
+                    <li class="page-item"><a href="{{ $page.First.URL }}" rel="first" class="page-link">««</a></li>
+                    {{ end }}
+
+                    {{ if $page.HasPrev  }}
+                    <li class="page-item"><a href="{{ $page.Prev.URL }}" rel="prev" class="page-link">«</a></li>
+                    {{ end }}
+
+                    {{ range $page.Pagers }}
+                        {{ if eq . $page }} <!-- Current Page -->
+                        <li class="page-item active"><a href="{{ .URL }}" class="page-link">{{ .PageNumber }}</a></li>
+                        {{ else if and (ge .PageNumber (sub $page.PageNumber 2)) (le .PageNumber (add $page.PageNumber 2)) }}
+                        {{ $.Scratch.Set "dot_rendered" false }} <!-- Render prev 2 page and next 2 pages -->
+                        <li class="page-item"><a href="{{ .URL }}" class="page-link">{{ .PageNumber }}</a></li>
+                        {{ else if eq ($.Scratch.Get "dot_rendered") false }} <!-- render skip pages -->
+                        {{ $.Scratch.Set "dot_rendered" true }}
+                        <li class="page-item disabled"><a class="page-link">...</a></li>
+                        {{ end }}
+                    {{ end }}
+
+                    {{ if $page.HasNext }}
+                    <li class="page-item"><a href="{{ $page.Next.URL }}" rel="next" class="page-link">»</a></li>
+                    {{ end }}
+
+                    <!-- Don't show on last and 2nd last page -->
+                    {{ if and (ne $page.PageNumber $page.TotalPages) }}
+                    <li class="page-item"><a href="{{ $page.Last.URL }}" rel="last" class="page-link">»»</a></li>
+                    {{ end }}
+                </ul>
+            </nav>
+            {{ end }}
         </div>
     </main>
 </div>


### PR DESCRIPTION
I replaced the template of the pagination of Hugo with custom pagination. In this custom pagination, it has the following properties: 

1. Show **<<<<** shortcut if not 1st page

![page-start](https://user-images.githubusercontent.com/44139348/78007688-3d3fd380-735c-11ea-904a-95cf06760502.png)

2. Show **>>>>** shortcut if not the last page.

![page-end](https://user-images.githubusercontent.com/44139348/78007531-0bc70800-735c-11ea-824b-19a3254d964f.png)

3. Show **<<** if there is a previous page
4. Show **>>** if there is the next page
5. Show current page number with the previous 2 pages and next 2 pages. Skip other pages with placeholder ...

![page-middle](https://user-images.githubusercontent.com/44139348/78007544-0f5a8f00-735c-11ea-9c53-deb9e589f022.png)

