### PR TITLE
chnaged alignment of headings under packed with fuctionality section

### DIFF
--- a/antora-ui-camel/src/css/frontpage.css
+++ b/antora-ui-camel/src/css/frontpage.css
@@ -206,6 +206,10 @@ section.frontpage h1 {
   text-align: center;
 }
 
+section.frontpage h2 {
+  text-align:center;
+}
+
 .box {
   flex: 50%;
   padding: 1.2rem 0;


### PR DESCRIPTION
I changed the alignment of headings under "packed with functionality" section for better UI

Preview :
(Destop view):
![p1](https://user-images.githubusercontent.com/43489853/78062041-b9add300-73ab-11ea-94b9-df027eb7ae07.png)

(Mobile view):
![p2](https://user-images.githubusercontent.com/43489853/78062108-d0ecc080-73ab-11ea-9247-e02d679e43f3.png)

