### PR TITLE
chore: add Netlify attribution

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -35,6 +35,9 @@
                 Apache Camel, Camel, Apache, the Apache feather logo, and the Apache Camel project logo are trademarks of
                 The Apache Software Foundation. All other marks mentioned may be trademarks or registered trademarks of
                 their respective owners.
+                {{ if and (not .Page.Section) (eq (getenv "HUGO_ENV") "netlify") }}
+                    <a href="https://netlify.com">This site is powered by Netlify</a>
+                {{ end }}
             </p>
         </div>
     </footer>

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,2 +1,3 @@
 [build]
   command = "(cd antora-ui-camel && yarn --non-interactive --frozen-lockfile install && yarn --non-interactive --frozen-lockfile build) && yarn --non-interactive --frozen-lockfile install && yarn --non-interactive --frozen-lockfile build"
+  environment = { HUGO_ENV = "netlify" }


### PR DESCRIPTION
This adds Netlify attribution when the website is built and served from
Netlify.