### PR TITLE
Remove unused CSS class from table.html

### DIFF
--- a/layouts/shortcodes/table.html
+++ b/layouts/shortcodes/table.html
@@ -1,3 +1,3 @@
 {{ $htmlTable := .Inner | markdownify }}
-{{ $htmlTable := replace $htmlTable "<table>" "<table class=\"tableblock frame-all grid-all stretch\">" }}
+{{ $htmlTable := replace $htmlTable "<table>" "<table class=\"tableblock stretch\">" }}
 {{ $htmlTable | safeHTML }}


### PR DESCRIPTION
This removes the unused CSS classes in the layout\shortcodes\table.html  file

BEFORE;

![table](https://user-images.githubusercontent.com/49795064/78081009-6174d200-73a7-11ea-89ab-605249bfa2f7.PNG)

AFTER:

![table2](https://user-images.githubusercontent.com/49795064/78081062-836e5480-73a7-11ea-97e2-a60d5901c6ce.PNG)

