### PR TITLE
make table in security page responsive

### DIFF
--- a/layouts/security/list.html
+++ b/layouts/security/list.html
@@ -5,35 +5,36 @@
         <article class="static doc">
 
             {{ .Content }}
-
-            <table class="tableblock frame-all grid-all stretch">
-              <caption>Security advisories by year</caption>
-              <thead>
-                <tr>
-                  <td>Reference</td>
-                  <td>Affected</td>
-                  <td>Fixed</td>
-                  <td>CVSS score</td>
-                  <td>Description</td>
-                </tr>
-              </thead>
-              <tbody>
-            {{ range .Pages.GroupByDate "2006" "desc" }}
-                <tr>
-                  <th colspan="5" scope="row"><strong>{{ .Key }}</strong></th>
-                </tr>
-                {{ range .Pages }}
-                <tr>
-                  <td><a href="{{ .RelPermalink }}">{{ .Params.cve }}</a></td>
-                  <td>{{ .Params.affected }}</td>
-                  <td>{{ .Params.fixed }}</td>
-                  <td>{{ .Params.severity }}</td>
-                  <td>{{ .Params.summary }}</td>
-                </tr>
-                {{ end }}
-            {{ end }}
-              </tbody>
-            </table>
+            <div class="table-wrapper">
+              <table class="tableblock frame-all grid-all stretch">
+                <caption>Security advisories by year</caption>
+                <thead>
+                  <tr>
+                    <td>Reference</td>
+                    <td>Affected</td>
+                    <td>Fixed</td>
+                    <td>CVSS score</td>
+                    <td>Description</td>
+                  </tr>
+                </thead>
+                <tbody>
+              {{ range .Pages.GroupByDate "2006" "desc" }}
+                  <tr>
+                    <th colspan="5" scope="row"><strong>{{ .Key }}</strong></th>
+                  </tr>
+                  {{ range .Pages }}
+                  <tr>
+                    <td><a href="{{ .RelPermalink }}">{{ .Params.cve }}</a></td>
+                    <td>{{ .Params.affected }}</td>
+                    <td>{{ .Params.fixed }}</td>
+                    <td>{{ .Params.severity }}</td>
+                    <td>{{ .Params.summary }}</td>
+                  </tr>
+                  {{ end }}
+              {{ end }}
+                </tbody>
+              </table>
+            </div>
 
         </article>
     </main>


### PR DESCRIPTION
* The table within the security table wasn't responsive in the mobile design. 
* The table is now contained within a **table-wrapper** which makes it responsive in the mobile view with the changes in this PR.