### PR TITLE
chore: update links to the FAQ

### DIFF
--- a/antora-ui-camel/src/partials/footer-content.hbs
+++ b/antora-ui-camel/src/partials/footer-content.hbs
@@ -12,7 +12,7 @@
                 <dd><a href="{{siteRootPath}}/components/latest/">Components</a></dd>
                 <dd><a href="{{siteRootPath}}/download/">Download</a></dd>
                 <dd><a href="{{siteRootPath}}/manual/latest/getting-started.html">Getting started</a></dd>
-                <dd><a href="{{siteRootPath}}/manual/latest/faq.html">FAQ</a></dd>
+                <dd><a href="{{siteRootPath}}/manual/latest/faq/index.html">FAQ</a></dd>
             </dl>
             <dl>
                 <dt>Community</dt>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -16,7 +16,7 @@
                 <dd><a href="/components/latest/">Components</a></dd>
                 <dd><a href="/download/">Download</a></dd>
                 <dd><a href="/manual/latest/getting-started.html">Getting started</a></dd>
-                <dd><a href="/manual/latest/faq.html">FAQ</a></dd>
+                <dd><a href="/manual/latest/faq/index.html">FAQ</a></dd>
             </dl>
 
             <dl>


### PR DESCRIPTION
With the split FAQ we need to change the URLs in the footer that point
to the old version of the FAQ in the user manual.

This is a follow up on https://github.com/apache/camel/pull/3693 https://github.com/apache/camel/pull/3708 and https://github.com/apache/camel/pull/3708 we need to merge this once those are merged.