### PR TITLE
Make modification in README regarding yarn build

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ In case `yarn build` throws the error: **JavaScript heap out of memory**, the is
 
 ```shell
 $ export NODE_OPTIONS="--max_old_space_size=4096"
+```
 This should fetch doc sources for [Camel](https://github.com/apache/camel) and [Camel K](https://github.com/apache/camel-k)
 and generate the website with Hugo. You should see the generated website in the `public` directory.
 

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ To build the website go to the project root directory and run:
     $ yarn build   # to perform the build
 
 In case `yarn build` throws the error: **JavaScript heap out of memory**, make the following change within `package.json` 
-and the issue will be resolved : 
+and the issue will be resolved: 
 ```
 "build": "run-s --max_old_space_size=4096 build:*"
 ```

--- a/README.md
+++ b/README.md
@@ -137,6 +137,12 @@ To build the website go to the project root directory and run:
     $ yarn install # needed only once, or if dependencies change
     $ yarn build   # to perform the build
 
+In case `yarn build` throws the error: **JavaScript heap out of memory**, make the following change within `package.json` 
+and the issue will be resolved : 
+```
+"build": "run-s --max_old_space_size=4096 build:*"
+```
+
 This should fetch doc sources for [Camel](https://github.com/apache/camel) and [Camel K](https://github.com/apache/camel-k)
 and generate the website with Hugo. You should see the generated website in the `public` directory.
 

--- a/README.md
+++ b/README.md
@@ -137,12 +137,10 @@ To build the website go to the project root directory and run:
     $ yarn install # needed only once, or if dependencies change
     $ yarn build   # to perform the build
 
-In case `yarn build` throws the error: **JavaScript heap out of memory**, make the following change within `package.json` 
-and the issue will be resolved: 
-```
-"build": "run-s --max_old_space_size=4096 build:*"
-```
+In case `yarn build` throws the error: **JavaScript heap out of memory**, the issue can be resolved by increasing the memory used by node.js by setting `NODE_OPTIONS` environment variable to include `--max_old_space_size`, for example to increase the old space to 4GB do:
 
+```shell
+$ export NODE_OPTIONS="--max_old_space_size=4096"
 This should fetch doc sources for [Camel](https://github.com/apache/camel) and [Camel K](https://github.com/apache/camel-k)
 and generate the website with Hugo. You should see the generated website in the `public` directory.
 


### PR DESCRIPTION
* I observed that in a few cases when I run `yarn build` within the project directory, it throws the error **Javascript heap out of memory**. Hence, I found a solution and I think it will be better to put it in the README documentation for a better understanding for the users.