### PR TITLE
Fix drop-down menu overlap issue on small screens

### DIFF
--- a/antora-ui-camel/src/css/header.css
+++ b/antora-ui-camel/src/css/header.css
@@ -135,7 +135,7 @@ body {
 }
 
 .navbar-dropdown {
-  position: absolute;
+  
   display: none;
   top: calc(100% - 1px);
   background-color: var(--navbar-menu-background);

--- a/antora-ui-camel/src/css/header.css
+++ b/antora-ui-camel/src/css/header.css
@@ -135,7 +135,6 @@ body {
 }
 
 .navbar-dropdown {
-  
   display: none;
   top: calc(100% - 1px);
   background-color: var(--navbar-menu-background);


### PR DESCRIPTION
On smaller screens ,the dropdown menu headings overlapped each other,making navigation difficult.
![image](https://user-images.githubusercontent.com/44733143/78456996-91321b80-76c0-11ea-8ed1-86ad996d22d0.png)


Now this looks like this 
![image](https://user-images.githubusercontent.com/44733143/78456970-719af300-76c0-11ea-8f04-f45a657f8aaa.png)
