### PR TITLE
Fix redirecting to anchor tags

### DIFF
--- a/antora-ui-camel/src/css/base.css
+++ b/antora-ui-camel/src/css/base.css
@@ -3,6 +3,7 @@ body {
   height: 100%;
   display: flex;
   flex-direction: column;
+  scroll-padding-top: var(--body-top);
 }
 
 *,

--- a/antora-ui-camel/src/css/vars.css
+++ b/antora-ui-camel/src/css/vars.css
@@ -125,8 +125,8 @@
   --navbar-height: calc(73 / var(--rem-base) * 1rem);
   --toolbar-height: calc(45 / var(--rem-base) * 1rem);
   --drawer-height: var(--toolbar-height);
-  --body-top: var(--navbar-height);
-  --body-min-height: calc(100vh - var(--body-top));
+  --body-top: calc(var(--navbar-height) + 1rem);
+  --body-min-height: calc(100vh - var(--navbar-height));
   --nav-height: calc(var(--body-min-height) - var(--toolbar-height));
   --nav-height--desktop: var(--body-min-height);
   --nav-panel-height: calc(var(--nav-height) - var(--drawer-height));


### PR DESCRIPTION
If we redirect to URLs with anchor tags, the upper portion gets hidden behind the header nav-bar.
Example, try redirecting from https://camel.apache.org/blog/GSoC-2020-announced/ to one of the camel-projects https://camel.apache.org/projects/#apache-camel-k or https://camel.apache.org/projects/#apache-camel-extensions-for-quarkus. The heading is not visible.

As far as my understanding goes, the fragment-jumper file aims at doing this task only. I'm not completely sure about what else the code in the file does, so I haven't deleted it, but the code snippet I have added will take care of all anchor redirections. 