### PR TITLE
fixed release pages responsive issue

### DIFF
--- a/antora-ui-camel/src/css/release.css
+++ b/antora-ui-camel/src/css/release.css
@@ -16,3 +16,11 @@
 .release .tableblock tbody tr:nth-child(2n) {
   background: var(--color-smoke-50);
 }
+
+/* for mobile screens */
+@media screen and (max-width: 626px) {
+  .release aside {
+    width: 100%;
+    margin: 0 auto;
+  }
+}


### PR DESCRIPTION
In this PR, I have fixed the release pages responsive issue in mobile view. I have noticed that in release pages some of the text is being cut from the left side, so I have fixed it.
**Before:**
![release-before](https://user-images.githubusercontent.com/36660186/78531742-a499cf80-7803-11ea-9b4a-38a854c2144d.png)
**After:**
![release-after](https://user-images.githubusercontent.com/36660186/78531767-b2e7eb80-7803-11ea-90e2-f2e19f57d225.png)
