### PR TITLE
Fix the nav-dropdown for small screens

### DIFF
--- a/antora-ui-camel/src/css/header.css
+++ b/antora-ui-camel/src/css/header.css
@@ -180,6 +180,8 @@ body {
 
   .has-dropdown.is-active > .navbar-dropdown {
     display: block;
+    position: relative;
+    border: none;
   }
 
   .has-dropdown.is-active > .navbar-link::after {
@@ -237,10 +239,6 @@ body {
     padding: 1rem 2rem;
   }
 
-  .navbar-dropdown {
-    display: none;
-  }
-
   .has-dropdown:not(.is-active) > .navbar-dropdown {
     display: none;
   }
@@ -251,6 +249,8 @@ body {
 
   .has-dropdown.is-active > .navbar-dropdown {
     display: block;
+    position: relative;
+    border: none;
   }
 
   .has-dropdown.is-active > .navbar-link::after {


### PR DESCRIPTION
The problem in drop-down menus for small screens :

![WhatsApp Image 2020-04-06 at 2 23 50 PM](https://user-images.githubusercontent.com/32356795/78560496-cb6ffa00-7833-11ea-81d0-43100d2149bc.jpeg)

I think the changes I have made should suffice for now. Menu for small screens looks like this :

![small-menu](https://user-images.githubusercontent.com/32356795/78559673-6f58a600-7832-11ea-8138-72f1ea3953bc.png)

I feel that the mobile-menu could do with some improvement on the design front, but I want to work on that in a different PR. 