### PR TITLE
Create a sufficient space between the footer-tools and the page

### DIFF
--- a/antora-ui-camel/src/css/blog.css
+++ b/antora-ui-camel/src/css/blog.css
@@ -46,6 +46,7 @@ article.blog p {
   margin-top: 1rem;
   display: flex;
   flex-direction: column;
+  padding-bottom: 2rem;
 }
 
 .blog .post aside .summary {
@@ -145,6 +146,7 @@ article.blog p {
 
   .blog .post {
     flex-direction: row;
+    padding-bottom: 2rem;
   }
 
   .blog .post aside {

--- a/antora-ui-camel/src/css/footer.css
+++ b/antora-ui-camel/src/css/footer.css
@@ -7,6 +7,7 @@ footer {
   line-height: var(--footer-line-height);
   padding: 1.5rem;
   flex-shrink: 0;
+  margin-top: 2rem;
 }
 
 footer .footer {
@@ -76,7 +77,6 @@ footer .footer dl dd {
 
 .footer-tools {
   position: relative;
-  top: -2rem;
   height: 0;
   text-align: right;
 }

--- a/antora-ui-camel/src/css/footer.css
+++ b/antora-ui-camel/src/css/footer.css
@@ -7,7 +7,6 @@ footer {
   line-height: var(--footer-line-height);
   padding: 1.5rem;
   flex-shrink: 0;
-  margin-top: 2rem;
 }
 
 footer .footer {
@@ -79,6 +78,7 @@ footer .footer dl dd {
   position: relative;
   height: 0;
   text-align: right;
+  top: -2rem;
 }
 
 .footer-tools a {

--- a/antora-ui-camel/src/css/footer.css
+++ b/antora-ui-camel/src/css/footer.css
@@ -76,9 +76,9 @@ footer .footer dl dd {
 
 .footer-tools {
   position: relative;
+  top: -2rem;
   height: 0;
   text-align: right;
-  top: -2rem;
 }
 
 .footer-tools a {

--- a/antora-ui-camel/src/css/frontpage.css
+++ b/antora-ui-camel/src/css/frontpage.css
@@ -236,7 +236,7 @@ section.frontpage h2 {
 
 .split {
   flex: 50%;
-  padding: 1rem 0;
+  padding: 1rem 0 2rem 0;
 }
 
 .split img {


### PR DESCRIPTION
* I observed that the space between the end of a paragraph or any text content and the footer details was too less and it gave a cramped-up feeling in smaller screen width. 

* Hence, the changes I proposed resolves that issue and create sufficient space between the footer-related context and the text-content.

### BEFORE 
![footer-margin-before](https://user-images.githubusercontent.com/44139348/78595347-806fda00-7867-11ea-817f-238e92eb1ebc.png)

### AFTER
![footer-margin-after](https://user-images.githubusercontent.com/44139348/78595358-849bf780-7867-11ea-8c77-80a08feb3426.png)
