### PR TITLE
Fixed table first column font size bold

### DIFF
--- a/antora-ui-camel/src/css/doc.css
+++ b/antora-ui-camel/src/css/doc.css
@@ -667,3 +667,7 @@ table.tableblock thead {
   background: var(--color-smoke-90);
   font-weight: var(--body-font-weight-bold);
 }
+
+.doc table.tableblock td:nth-child(1) {
+  font-weight: var(--body-font-weight-bold);
+}

--- a/antora-ui-camel/src/css/doc.css
+++ b/antora-ui-camel/src/css/doc.css
@@ -671,3 +671,7 @@ table.tableblock thead {
 .doc table.tableblock td:nth-child(1) {
   font-weight: var(--body-font-weight-bold);
 }
+
+.doc .sect1 table.tableblock td:nth-child(2) {
+  font-weight: bold;
+}


### PR DESCRIPTION
In this PR, I have changed the design of all table that is present on the website. I have seen some tables the first column is bold or some not. I have changed the first column font size bold to make same UI for all the tables.
**Before:**
![table-before](https://user-images.githubusercontent.com/36660186/78644294-463c2200-78d3-11ea-9623-c96dfed858df.png)
**After:**
![table-after](https://user-images.githubusercontent.com/36660186/78644327-55bb6b00-78d3-11ea-9daa-fe1b85b4ec65.png)
