### PR TITLE
Fix issues with search results

### DIFF
--- a/antora-ui-camel/src/css/header.css
+++ b/antora-ui-camel/src/css/header.css
@@ -462,6 +462,11 @@ body {
   padding-top: 0.3rem;
 }
 
+.no_search_results {
+  padding: 0.5rem 1rem;
+  font-weight: bold;
+}
+
 .algolia-docsearch-suggestion--highlight {
   font-weight: bold;
   color: var(--color-jet-50);

--- a/antora-ui-camel/src/js/vendor/algoliasearch.bundle.js
+++ b/antora-ui-camel/src/js/vendor/algoliasearch.bundle.js
@@ -46,7 +46,12 @@
           const data = hits.reduce((data, hit) => {
             const d = {}
             d.url = hit.url
-            d.breadcrumbs = Object.values(hit.hierarchy).slice(1).filter((lvl) => lvl !== null).join(' &raquo; ')
+            var breadcrumbs = Object.values(hit.hierarchy).slice(1).filter((lvl) => lvl !== null).join(' &raquo; ')
+            if (breadcrumbs !== '') {
+              d.breadcrumbs = breadcrumbs
+            } else {
+              d.breadcrumbs = hit.hierarchy.lvl0
+            }
             if (hit._snippetResult !== undefined) {
               d.snippet = hit._snippetResult.content.value
             } else {
@@ -65,7 +70,7 @@
         .then((data) => {
           if (Object.entries(data).length === 0 && data.constructor === Object) {
             return `
-              <header>Nothing Found</header>
+              <header class="no_search_results">Nothing Found</header>
               `
           } else {
             return `


### PR DESCRIPTION
I noticed a couple of issues :

1) "Nothing found" box is very cramped.
![no_results_old](https://user-images.githubusercontent.com/32356795/78793179-a9ab7a00-79cf-11ea-9e96-3cf0c286c6f0.png)

Fix:
![no_results_new](https://user-images.githubusercontent.com/32356795/78793163-a4e6c600-79cf-11ea-8f51-3182122d21ae.png)

2) I noticed there's excess space in some search results. For example, try searching for "Book", or "Camel" or "Article". I realised that there were some empty search results being displayed here. As shown in screenshots below, the URL for them exists, but heading & summary doesn't, because these are actually "section names" which match with the query. 

![search_results_fix](https://user-images.githubusercontent.com/32356795/78793422-04dd6c80-79d0-11ea-80c3-f66a849fcedc.png)

![search_example_2](https://user-images.githubusercontent.com/32356795/78793405-ff802200-79cf-11ea-8cf9-fca40616c5ac.png)

Fix : I thought of two ways we can go about it - either we don't display these empty results, or we show the section names in their place. Second one seemed apt to me, since all such "missing content" cases that I could find were links to sections. Maybe we can attach links to the section headings and do away with the empty results - but I still thought that if the section-name is matching the query, it should be displayed separately.

![search-fix](https://user-images.githubusercontent.com/32356795/78793834-96e57500-79d0-11ea-9e57-adf06b347c54.png)
 
 Please let me know if we would prefer to fix this in some other way.