### PR TITLE
improvement to projects section alignment in front-page

### DIFF
--- a/antora-ui-camel/src/css/frontpage.css
+++ b/antora-ui-camel/src/css/frontpage.css
@@ -178,6 +178,7 @@ section.frontpage.projects .project a img + img {
 
 section.frontpage.projects .project h1 + p {
   height: 100%;
+  text-align: center;
 }
 
 section.frontpage.apache {


### PR DESCRIPTION
* WIthin the project section on the front-page, the icons, title, and documentation link were all center-aligned except the brief description which gave an odd-like feeling to the project section. 

* Thus, with the changes the brief description is center-aligned as well.

### BEFORE 
![frontpage-projects](https://user-images.githubusercontent.com/44139348/79364028-59e82800-7f66-11ea-8eef-073d24fe67ee.png)

### AFTER
![frontpage-projects-after](https://user-images.githubusercontent.com/44139348/79364053-666c8080-7f66-11ea-9d79-d1b309f94a78.png)
