### PR TITLE
Display Category Tags on blog pages for small screens

### DIFF
--- a/antora-ui-camel/src/css/blog.css
+++ b/antora-ui-camel/src/css/blog.css
@@ -176,13 +176,6 @@ article.blog p {
   }
 }
 
-/* for mobile screens */
-@media screen and (max-width: 1023px) {
-  .blog.list aside {
-    display: none;
-  }
-}
-
 .blog ul,
 .blog ol {
   padding-bottom: 1rem;

--- a/layouts/blog/list.html
+++ b/layouts/blog/list.html
@@ -1,8 +1,12 @@
 {{ partial "header.html" . }}
 
 <div class="body">
-    <main role="main" class="doc blog list">
-        <aside>
+    <div class="toolbar" role="navigation"> 
+        <button class="nav-toggle">
+        </button>
+    </div>
+    <main role="main" class="nav-container doc blog list">
+        <aside class="nav">
             <h3>Categories</h3>
             <ul>
             {{ range .Site.Taxonomies.categories.Alphabetical }}
@@ -10,6 +14,8 @@
             {{ end }}
             </ul>
         </aside>
+    </main>
+        <main role="main" class="doc blog list">
         <div>
             {{ $pages := ($.Paginator 3).Pages }}
             {{ range $pages }}

--- a/layouts/blog/list.html
+++ b/layouts/blog/list.html
@@ -7,8 +7,8 @@
     </div>
     <main role="main" class="nav-container doc blog list">
         <aside class="nav">
-            <h3>Categories</h3>
             <ul>
+                <h3>Categories</h3>
             {{ range .Site.Taxonomies.categories.Alphabetical }}
                 <li><a class="category" href="{{ "/categories/" | relURL }}{{ .Name | urlize }}/">{{ .Name | upper }}<span>{{ .Count }}</span></a></li>
             {{ end }}


### PR DESCRIPTION
When we opened the blog page from mobile, it was difficult to directly open a specific category blog as the tags were not visible on mobile screens.This made navigation on mobile phones difficult.
Now I have made the following changes :
Added a burger button for category on smaller screens using the existing css classes i.e nav-container and nav-toggle.On click the side menu is opened and category tags are displayed.
Now the pages looks like:
![image](https://user-images.githubusercontent.com/44733143/79461368-8310c300-800f-11ea-9c99-f0df60ce52f9.png)
![image](https://user-images.githubusercontent.com/44733143/79461406-92900c00-800f-11ea-8bdd-11facaae328c.png)
