### PR TITLE
Change right padding for header menu-items with drop-downs

### DIFF
--- a/antora-ui-camel/src/css/header.css
+++ b/antora-ui-camel/src/css/header.css
@@ -321,6 +321,7 @@ body {
 
   .navbar-item.has-dropdown {
     align-items: stretch;
+    padding-right: 2.8rem;
   }
 
   .navbar-item.has-dropdown:last-of-type .navbar-dropdown {


### PR DESCRIPTION
In the header menu, the spacing between Community and Download is less than others, due to the space taken up by the `::after` drop-down arrow.    

![image](https://user-images.githubusercontent.com/32356795/79685248-eccdde80-8254-11ea-9021-df9138608eb5.png)

I've added extra right padding for menu-items having drop-downs so that spacing seems uniform

![image](https://user-images.githubusercontent.com/32356795/79685241-c60fa800-8254-11ea-9f6d-0649d82bfc3b.png)
