### PR TITLE
Change category-wise blog layout and format the code within blog

### DIFF
--- a/layouts/_default/taxonomy.html
+++ b/layouts/_default/taxonomy.html
@@ -1,10 +1,28 @@
 {{ partial "header.html" . }}
 
 <div class="body">
-    <main role="main">
-        {{ range .Pages }}
+    <div class="toolbar" role="navigation">
+        <button class="nav-toggle">
+        </button>
+    </div>
+    <main role="main" class="nav-container doc blog list">
+        <aside class="nav">
+            <h3>Categories</h3>
+            <ul>
+                {{ range .Site.Taxonomies.categories.Alphabetical }}
+                <li><a class="category"
+                        href="{{ "/categories/" | relURL }}{{ .Name | urlize }}/">{{ .Name | upper }}<span>{{ .Count }}</span></a>
+                </li>
+                {{ end }}
+            </ul>
+        </aside>
+    </main>
+    <main role="main" class="doc blog list">
+        <div>
+            {{ range .Pages }}
             {{ .Render "summary" }}
-        {{ end }}
+            {{ end }}
+        </div>
     </main>
 </div>
 

--- a/layouts/blog/list.html
+++ b/layouts/blog/list.html
@@ -1,7 +1,7 @@
 {{ partial "header.html" . }}
 
 <div class="body">
-    <div class="toolbar" role="navigation"> 
+    <div class="toolbar" role="navigation">
         <button class="nav-toggle">
         </button>
     </div>
@@ -9,19 +9,21 @@
         <aside class="nav">
             <h3>Categories</h3>
             <ul>
-            {{ range .Site.Taxonomies.categories.Alphabetical }}
-                <li><a class="category" href="{{ "/categories/" | relURL }}{{ .Name | urlize }}/">{{ .Name | upper }}<span>{{ .Count }}</span></a></li>
-            {{ end }}
+                {{ range .Site.Taxonomies.categories.Alphabetical }}
+                <li><a class="category"
+                        href="{{ "/categories/" | relURL }}{{ .Name | urlize }}/">{{ .Name | upper }}<span>{{ .Count }}</span></a>
+                </li>
+                {{ end }}
             </ul>
         </aside>
     </main>
-        <main role="main" class="doc blog list">
+    <main role="main" class="doc blog list">
         <div>
             {{ $pages := ($.Paginator 3).Pages }}
             {{ range $pages }}
-                {{ .Render "summary" }}
+            {{ .Render "summary" }}
             {{ end }}
-            
+
             {{ $page := .Paginator }}
             {{ if gt $page.TotalPages 1 }}
             {{ $shouldEllipse := false }}
@@ -29,37 +31,41 @@
                 <ul class="pagination">
                     {{ if ne $page.PageNumber 1 }}
                     <li class="page-item">
-                        <a href="{{ $page.First.URL }}" class="page-link" aria-label="First"><span aria-hidden="true">&laquo;&laquo;</span></a>
+                        <a href="{{ $page.First.URL }}" class="page-link" aria-label="First"><span
+                                aria-hidden="true">&laquo;&laquo;</span></a>
                     </li>
                     {{ end }}
 
                     {{ if $page.HasPrev  }}
                     <li class="page-item">
-                        <a href="{{ $page.Prev.URL }}" class="page-link" aria-label="Previous"><span aria-hidden="true">&laquo;</span></a>
+                        <a href="{{ $page.Prev.URL }}" class="page-link" aria-label="Previous"><span
+                                aria-hidden="true">&laquo;</span></a>
                     </li>
                     {{ end }}
 
                     {{ range $page.Pagers }}
-                        {{ if eq . $page }}
-                        <li class="page-item active"><a href="{{ .URL }}" class="page-link">{{ .PageNumber }}</a></li>
-                        {{ else if and (ge .PageNumber (sub $page.PageNumber 2)) (le .PageNumber (add $page.PageNumber 2)) }}
-                        {{ $shouldEllipse = false }}
-                        <li class="page-item"><a href="{{ .URL }}" class="page-link">{{ .PageNumber }}</a></li>
-                        {{ else if eq $shouldEllipse false }}
-                        {{ $shouldEllipse = true }}
-                        <li class="page-item disabled"><a class="page-link">&hellip;</a></li>
-                        {{ end }}
+                    {{ if eq . $page }}
+                    <li class="page-item active"><a href="{{ .URL }}" class="page-link">{{ .PageNumber }}</a></li>
+                    {{ else if and (ge .PageNumber (sub $page.PageNumber 2)) (le .PageNumber (add $page.PageNumber 2)) }}
+                    {{ $shouldEllipse = false }}
+                    <li class="page-item"><a href="{{ .URL }}" class="page-link">{{ .PageNumber }}</a></li>
+                    {{ else if eq $shouldEllipse false }}
+                    {{ $shouldEllipse = true }}
+                    <li class="page-item disabled"><a class="page-link">&hellip;</a></li>
+                    {{ end }}
                     {{ end }}
 
                     {{ if $page.HasNext }}
                     <li class="page-item">
-                        <a href="{{ $page.Next.URL }}" class="page-link" aria-label="Next"><span aria-hidden="true">&raquo;</span></a>
+                        <a href="{{ $page.Next.URL }}" class="page-link" aria-label="Next"><span
+                                aria-hidden="true">&raquo;</span></a>
                     </li>
                     {{ end }}
 
                     {{ if ne $page.PageNumber $page.TotalPages }}
                     <li class="page-item">
-                        <a href="{{ $page.Last.URL }}" class="page-link" aria-label="Last"><span aria-hidden="true">&raquo;&raquo;</span></a>
+                        <a href="{{ $page.Last.URL }}" class="page-link" aria-label="Last"><span
+                                aria-hidden="true">&raquo;&raquo;</span></a>
                     </li>
                     {{ end }}
                 </ul>

--- a/layouts/blog/post.html
+++ b/layouts/blog/post.html
@@ -2,38 +2,45 @@
 
     <header>
         {{ if .Params.categories }}
-            {{ range .Params.categories }}<a class="category" href="{{ "/categories/" | relURL }}{{ . | urlize }}/">{{ upper . }}</a>{{ end }}
+        {{ range .Params.categories }}<a class="category"
+            href="{{ "/categories/" | relURL }}{{ . | urlize }}/">{{ upper . }}</a>{{ end }}
         {{ end }}
         <h1>{{ .Title }}</h1>
     </header>
     <div class="post">
         <aside>
             <div class="summary">{{ .Params.preview }}</div>
-            Posted on <time itemprop="published" datetime="{{ dateFormat "2006-01-02" .PublishDate }}" title="{{ dateFormat "Monday, January 2, 2006" .PublishDate }}">{{ dateFormat "January 2, 2006" .PublishDate }}</time>, by {{ range $author := .Params.authors }}
-                {{ with getJSON "https://api.github.com/users/" $author }}
-                    <figure>
-                        <img src="{{ .avatar_url }}" alt="{{ .name }}"><figcaption rel="author">{{ .name }}</figcaption>
-                    </figure>
-                {{ end }}
+            Posted on <time itemprop="published" datetime="{{ dateFormat "2006-01-02" .PublishDate }}"
+                title="{{ dateFormat "Monday, January 2, 2006" .PublishDate }}">{{ dateFormat "January 2, 2006" .PublishDate }}</time>,
+            by {{ range $author := .Params.authors }}
+            {{ with getJSON "https://api.github.com/users/" $author }}
+            <figure>
+                <img src="{{ .avatar_url }}" alt="{{ .name }}">
+                <figcaption rel="author">{{ .name }}</figcaption>
+            </figure>
+            {{ end }}
             {{ end }}
             <p>
-            {{ if .PrevInSection }}
-            <a class="arrow prev" href="{{ .PrevInSection.RelPermalink }}" title="Previous post: {{ .PrevInSection.Title }}">&#10094;</a>
-            {{ end }}
-            {{ if .NextInSection }}
-            <a class="arrow next" href="{{ .NextInSection.RelPermalink }}" title="Next post: {{ .NextInSection.Title }}">&#10095;</a>
-            {{ end }}
+                {{ if .PrevInSection }}
+                <a class="arrow prev" href="{{ .PrevInSection.RelPermalink }}"
+                    title="Previous post: {{ .PrevInSection.Title }}">&#10094;</a>
+                {{ end }}
+                {{ if .NextInSection }}
+                <a class="arrow next" href="{{ .NextInSection.RelPermalink }}"
+                    title="Next post: {{ .NextInSection.Title }}">&#10095;</a>
+                {{ end }}
             </p>
         </aside>
         <div class="post-content">
             {{ $featured := (.Resources.ByType "image").GetMatch "*featured*" }}
             {{ with $featured }}
-              {{ if ne $featured.MediaType.SubType "svg" }}
-                  {{ $featured := .Resize "800x q95 Gaussian" }}
-                  <img class="featured" alt="Blog post featured image" src="{{ $featured.RelPermalink }}" width="{{ $featured.Width }}" height="{{ $featured.Height }}">
-              {{ else }}
-                  <img class="featured" alt="Blog post featured image" src="{{ $featured.RelPermalink }}" width="800">
-              {{ end }}
+            {{ if ne $featured.MediaType.SubType "svg" }}
+            {{ $featured := .Resize "800x q95 Gaussian" }}
+            <img class="featured" alt="Blog post featured image" src="{{ $featured.RelPermalink }}"
+                width="{{ $featured.Width }}" height="{{ $featured.Height }}">
+            {{ else }}
+            <img class="featured" alt="Blog post featured image" src="{{ $featured.RelPermalink }}" width="800">
+            {{ end }}
             {{ end }}
             {{ .Content }}
         </div>


### PR DESCRIPTION
* Within the blog layout, when a user clicked on a particular category it would move to a category-wise based page. However, if the user wanted to check from some other category, it would be difficult, thus reducing the accessibility and easiness of reading the blogs. 

* Hence, I thought that for each category-wise based page, all the categories must be included to so easy navigation can be performed thus increasing the accessibility for different blogs. 

* The code wasn't formatted, hence I made a few changes to that as well.