### PR TITLE
Fixes CAMEL-14967: upgrade antora etc

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -71,5 +71,4 @@ asciidoc:
     - ./extensions/inline-styles.js
     - "@djencks/asciidoctor-antora-indexer"
   attributes:
-    camel-quarkus-last-release: 1.0.0-M6
     eip-vc: latest@components

--- a/package.json
+++ b/package.json
@@ -15,13 +15,13 @@
     "checks": "run-s check:*"
   },
   "devDependencies": {
-    "@antora/asciidoc-loader": "2.3.0-beta.2",
-    "@antora/cli": "2.3.0-beta.2",
-    "@antora/content-aggregator": "2.3.0-beta.2",
-    "@antora/content-classifier": "2.3.0-beta.2",
-    "@antora/document-converter": "2.3.0-beta.2",
-    "@antora/playbook-builder": "2.3.0-beta.2",
-    "@antora/site-generator-default": "2.3.0-beta.2",
+    "@antora/asciidoc-loader": "2.3.0",
+    "@antora/cli": "2.3.0",
+    "@antora/content-aggregator": "2.3.0",
+    "@antora/content-classifier": "2.3.0",
+    "@antora/document-converter": "2.3.0",
+    "@antora/playbook-builder": "2.3.0",
+    "@antora/site-generator-default": "2.3.0",
     "@antora/xref-validator": "gitlab:antora/xref-validator",
     "@djencks/asciidoctor-antora-indexer": "^0.0.2",
     "escape-string-regexp": "~2.0",
@@ -33,13 +33,6 @@
     "npm-run-all": "~4.1",
     "opal-runtime": "1.0.11",
     "toml": "~3.0"
-  },
-  "resolutions": {
-    "@antora/asciidoc-loader": "2.3.0-beta.2",
-    "@antora/content-aggregator": "2.3.0-beta.2",
-    "@antora/content-classifier": "2.3.0-beta.2",
-    "@antora/document-converter": "2.3.0-beta.2",
-    "@antora/playbook-builder": "2.3.0-beta.2"
   },
   "installConfig": {
     "pnp": true

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,25 +2,26 @@
 # yarn lockfile v1
 
 
-"@antora/asciidoc-loader@2.3.0-beta.2":
-  version "2.3.0-beta.2"
-  resolved "https://registry.yarnpkg.com/@antora/asciidoc-loader/-/asciidoc-loader-2.3.0-beta.2.tgz#62612b055eaa6576426b45495df7679bf6e08274"
-  integrity sha512-AHQIQfBaPjjWR27LllnzfAwRrwE6a03v9/bBjoLIaswA0XrSQ0UZXXvS8DRIWIG0ySxkpsCIcrJQp5WkQFsKTQ==
+"@antora/asciidoc-loader@2.3.0":
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/@antora/asciidoc-loader/-/asciidoc-loader-2.3.0.tgz#e9917dd0a61ede76b337f32ac59abc27d3398f8f"
+  integrity sha512-mncSlmkk6rYH5SGplZtHjuieG3ve5bhm4x0f9WIFE+GhqajIogDjxTBNWNr9B2dVA4bMves7Sy+c5h+f9V3iVw==
   dependencies:
     asciidoctor.js "1.5.9"
+    opal-runtime "1.0.11"
 
-"@antora/cli@2.3.0-beta.2":
-  version "2.3.0-beta.2"
-  resolved "https://registry.yarnpkg.com/@antora/cli/-/cli-2.3.0-beta.2.tgz#bfa77269e0576e15221c84f8423a4c5074daee44"
-  integrity sha512-bL2ZvGVxdvNWS+LlYV0MQp+8hEiIgMN/qK4mMJRuoiGFPXRk5HVa2Gks84A1vcMr4o0ZWAypkxq/D1TMcBGu9w==
+"@antora/cli@2.3.0":
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/@antora/cli/-/cli-2.3.0.tgz#e8bc5509fa7742249c338ec49ad28582c3765e35"
+  integrity sha512-YiAP7Ib4zhAE+owOKg1/cJ+1AQX4BGfvaMnGkHaSf6srutoLLCRIbD0InpSNobf+ouSMqqk6fiLmBVt/cu03og==
   dependencies:
-    "@antora/playbook-builder" "2.3.0-beta.2"
+    "@antora/playbook-builder" "2.3.0"
     commander "~5.0"
 
-"@antora/content-aggregator@2.3.0-beta.2":
-  version "2.3.0-beta.2"
-  resolved "https://registry.yarnpkg.com/@antora/content-aggregator/-/content-aggregator-2.3.0-beta.2.tgz#da4e43e9371e6b4bae9c27ca9d048b672b8c3a17"
-  integrity sha512-IWhvzCRlMGvNk9gIx5IKCQ9qdqWqeY1Vd2+nKJwMv13SrIFA+eIZk+01rA7VMsKKupt5dMlXaZVK0HgjtIExhw==
+"@antora/content-aggregator@2.3.0":
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/@antora/content-aggregator/-/content-aggregator-2.3.0.tgz#a2a2d0d38b4ebb65cef834aa510ac01fe131fa2b"
+  integrity sha512-LbH65Hw5uk3QCX8sCsJGnIVapQbtkxgyaDAfxYJlXnBI4jjd92391k0vitFL7f+9dzEvSdzxUHJU/lPyi9eB6g==
   dependencies:
     "@antora/expand-path-helper" "~1.0"
     braces "~3.0"
@@ -37,45 +38,45 @@
     vinyl "~2.2"
     vinyl-fs "~3.0"
 
-"@antora/content-classifier@2.3.0-beta.2":
-  version "2.3.0-beta.2"
-  resolved "https://registry.yarnpkg.com/@antora/content-classifier/-/content-classifier-2.3.0-beta.2.tgz#b696f40be27b8c2923ebb0976302047ff61fe032"
-  integrity sha512-9j4ITnHz9dEAvWlWYgD57BWldChQsFmHySfoXoLHTOPb8TdzOZM5aU/a8eQgmw6bXBbbhKulZU0b+MFNNTri4A==
+"@antora/content-classifier@2.3.0":
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/@antora/content-classifier/-/content-classifier-2.3.0.tgz#c0312b739a30346b6c06a664043a7627ffbbaa1f"
+  integrity sha512-x/GUrm62+zSA8uQYaPG1y8NDALSDeKKl+um0CrxV5nt8c6vEO80KODN4YEPqoC0tOq8zdT99J6ElYblpkxrW6Q==
   dependencies:
-    "@antora/asciidoc-loader" "2.3.0-beta.2"
+    "@antora/asciidoc-loader" "2.3.0"
     vinyl "~2.2"
 
-"@antora/document-converter@2.3.0-beta.2":
-  version "2.3.0-beta.2"
-  resolved "https://registry.yarnpkg.com/@antora/document-converter/-/document-converter-2.3.0-beta.2.tgz#9bc0a91eac02fbb3088242fd9bf1adfd38f9e3ac"
-  integrity sha512-wy0+czRQC/yoOR75jw+Za4LlWTdlNmni/tap726dqUbf2A5/fHTc5OkNaVnUdWiQMnB9UBelp56GXJoa0UChOQ==
+"@antora/document-converter@2.3.0":
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/@antora/document-converter/-/document-converter-2.3.0.tgz#ac6c4a659bcc573806469949ecf75bf6c4570506"
+  integrity sha512-RMvdqBIz+pXf5znuyVeR7GF8qw/zLfaRMmEzMzywYa+8Cappxy+pgs+BuAuH1TdAnsFzpPrIO211c2FE1OxXBg==
   dependencies:
-    "@antora/asciidoc-loader" "2.3.0-beta.2"
+    "@antora/asciidoc-loader" "2.3.0"
 
 "@antora/expand-path-helper@~1.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@antora/expand-path-helper/-/expand-path-helper-1.0.0.tgz#3bfd6938ab86d4709af8d869cbf3bb17b8fe8912"
   integrity sha512-hg3y6M3OvRTb7jtLAnwwloYDxafbyKYttcf16kGCXvP7Wqosh7c+Ag+ltaZ7VSebpzpphO/umb/BXdpU7rxapw==
 
-"@antora/navigation-builder@2.3.0-beta.2":
-  version "2.3.0-beta.2"
-  resolved "https://registry.yarnpkg.com/@antora/navigation-builder/-/navigation-builder-2.3.0-beta.2.tgz#33da7b67d3ba542944916256c83584b83558850f"
-  integrity sha512-3ooL9zZ8zTSB4UQzuv1H+gtOj68pynQ6tOOuc3Ip40WuG35RoxqWtOr5DLdP8EzJnqBiutejx0AWyQBCv6nanA==
+"@antora/navigation-builder@2.3.0":
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/@antora/navigation-builder/-/navigation-builder-2.3.0.tgz#b94bc0eb48d373ca3308ad9265cb07315e7965c3"
+  integrity sha512-bpdT50pUW8IbRHAwlwaRdMlqwdTCOGdh0novW2Z6uBi6KKKbl6K3BdbaVs/jwXalESWqkYHcyBpinMivsX4bBA==
   dependencies:
-    "@antora/asciidoc-loader" "2.3.0-beta.2"
+    "@antora/asciidoc-loader" "2.3.0"
 
-"@antora/page-composer@2.3.0-beta.2":
-  version "2.3.0-beta.2"
-  resolved "https://registry.yarnpkg.com/@antora/page-composer/-/page-composer-2.3.0-beta.2.tgz#36faebf227f15f33183ea21a14ab3a85353f830f"
-  integrity sha512-pKPdNnqTILzka9YoxMP8XxxZNeVc51OmkXfJjsPWkzDUIQR1C6frNrmYZNpCFwM7kugRrZz1jFFlNAJ3f6Ay5Q==
+"@antora/page-composer@2.3.0":
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/@antora/page-composer/-/page-composer-2.3.0.tgz#1446934f4ae033b8230aac6f2f08b3270f7613b1"
+  integrity sha512-ve4h3uColNuqGehSJ2qUw5dar1Ls3i+RBYh2HyVZZ84qjLoOjPGAALFYzRVJnYlEX6nAswNFhh5ll/hIuaxuHQ==
   dependencies:
     handlebars "~4.7"
     require-from-string "~2.0"
 
-"@antora/playbook-builder@2.3.0-beta.2":
-  version "2.3.0-beta.2"
-  resolved "https://registry.yarnpkg.com/@antora/playbook-builder/-/playbook-builder-2.3.0-beta.2.tgz#ad8932064886573a7946cb2a8d316e5b96e0e304"
-  integrity sha512-yRA0VPWnqOKBP2erIqXawxGLQHrsX4x3NkD1ZWBu4pisanJ9+vtjhpQGOZOQ2sb5HFboc0rMJTCZYo5zb/In/A==
+"@antora/playbook-builder@2.3.0":
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/@antora/playbook-builder/-/playbook-builder-2.3.0.tgz#b43bcd5fe5d3dc506082a821e9a161f61ffa5b7c"
+  integrity sha512-zuuTqY5dDXYhu4LfmFW3qzdFXSrXSo9NCDX9eBJ6MCXsuj64PqdOljzv4rWNy3HvmKOSCupfWCashJS0vuH2Dw==
   dependencies:
     "@iarna/toml" "~2.2"
     camelcase-keys "~6.2"
@@ -84,43 +85,43 @@
     js-yaml "~3.13"
     json5 "~2.1"
 
-"@antora/redirect-producer@2.3.0-beta.2":
-  version "2.3.0-beta.2"
-  resolved "https://registry.yarnpkg.com/@antora/redirect-producer/-/redirect-producer-2.3.0-beta.2.tgz#07c6d3ac795f8806e7607d04fe55849d2c8cfebd"
-  integrity sha512-9rIjax0pG9/tZNEWOkicvr8G5FwTpxdwtI8b8r48V8GgtrAIkWWibSLxPJqFbu9DkV+zDuqtdoyz3+toJ/3YJg==
+"@antora/redirect-producer@2.3.0":
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/@antora/redirect-producer/-/redirect-producer-2.3.0.tgz#0a0516cde38ba97f339182553d99842aa6a95719"
+  integrity sha512-/632VZlkpFIh5KlV3A9LqE4yGtYyQ+1vOb5A9yajYWsCnhqNfEMslMWuoLoQk4gzs3Ju+hz5MrAXp8sn1vbRvg==
   dependencies:
-    "@antora/asciidoc-loader" "2.3.0-beta.2"
+    "@antora/asciidoc-loader" "2.3.0"
     vinyl "~2.2"
 
-"@antora/site-generator-default@2.3.0-beta.2":
-  version "2.3.0-beta.2"
-  resolved "https://registry.yarnpkg.com/@antora/site-generator-default/-/site-generator-default-2.3.0-beta.2.tgz#02199399683a4606f1d5cab23c826d7f01f6fadc"
-  integrity sha512-jwW/LFND3RGhXeWdKf/AqBVvRXTmjUYINts14WmMPzkGs2V1uyIoF/vkoHoaQDXKRnUgJSwQxof97OW9xsJK+w==
+"@antora/site-generator-default@2.3.0":
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/@antora/site-generator-default/-/site-generator-default-2.3.0.tgz#ec011218d99639dd5f88a402f797c3e892531b95"
+  integrity sha512-swDQeAEnC/ClmhHJ50UNJppUSAneOp2cHwZiRr3zUQ9+5+mvOrDEdHbyxH7mIwkoeiIcQ/UVw00bg4MwmQ0M0g==
   dependencies:
-    "@antora/asciidoc-loader" "2.3.0-beta.2"
-    "@antora/content-aggregator" "2.3.0-beta.2"
-    "@antora/content-classifier" "2.3.0-beta.2"
-    "@antora/document-converter" "2.3.0-beta.2"
-    "@antora/navigation-builder" "2.3.0-beta.2"
-    "@antora/page-composer" "2.3.0-beta.2"
-    "@antora/playbook-builder" "2.3.0-beta.2"
-    "@antora/redirect-producer" "2.3.0-beta.2"
-    "@antora/site-mapper" "2.3.0-beta.2"
-    "@antora/site-publisher" "2.3.0-beta.2"
-    "@antora/ui-loader" "2.3.0-beta.2"
+    "@antora/asciidoc-loader" "2.3.0"
+    "@antora/content-aggregator" "2.3.0"
+    "@antora/content-classifier" "2.3.0"
+    "@antora/document-converter" "2.3.0"
+    "@antora/navigation-builder" "2.3.0"
+    "@antora/page-composer" "2.3.0"
+    "@antora/playbook-builder" "2.3.0"
+    "@antora/redirect-producer" "2.3.0"
+    "@antora/site-mapper" "2.3.0"
+    "@antora/site-publisher" "2.3.0"
+    "@antora/ui-loader" "2.3.0"
 
-"@antora/site-mapper@2.3.0-beta.2":
-  version "2.3.0-beta.2"
-  resolved "https://registry.yarnpkg.com/@antora/site-mapper/-/site-mapper-2.3.0-beta.2.tgz#f02c075df45332e87b802dc9d03c1215c686a30b"
-  integrity sha512-rWgi9+aCOg/kn0KD/g3jxQhGFU9bP1wEo93PH7XLvqvR2DHuo9mQv8KPyF+buFFodCTT7EwS4kRyB3JF82shKg==
+"@antora/site-mapper@2.3.0":
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/@antora/site-mapper/-/site-mapper-2.3.0.tgz#08c75114e679512f4298db34709836fd38c779a9"
+  integrity sha512-XzIoYKJQXgOzsDeUlL/edVR9B9aaCYUHADvzYqDc1S5/czFQxpqIIgMfYCiYYc7pHk6nmj5rgx/6HfvDImv87w==
   dependencies:
-    "@antora/content-classifier" "2.3.0-beta.2"
+    "@antora/content-classifier" "2.3.0"
     vinyl "~2.2"
 
-"@antora/site-publisher@2.3.0-beta.2":
-  version "2.3.0-beta.2"
-  resolved "https://registry.yarnpkg.com/@antora/site-publisher/-/site-publisher-2.3.0-beta.2.tgz#8836d16eb3e5335adf6b54651c82b79e9cdc2370"
-  integrity sha512-XpmfxTGhvzZuNROTXc04o5ea+fdKPqipMv0UFPpDgkefJ/OfVROBgk5Hi0xCAprDPqKetKqIYlGtmJxmcp5wNA==
+"@antora/site-publisher@2.3.0":
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/@antora/site-publisher/-/site-publisher-2.3.0.tgz#16f66d0133cee5cb2d77e806e9c58817c7e45a45"
+  integrity sha512-2qC0fDE70VKtyttPpRx9glPWL4M5x7HYVCs1K6+GmpuISmljO3c/09L+ExPsJiSVVFarnWmMu0w+76XqSRHlog==
   dependencies:
     "@antora/expand-path-helper" "~1.0"
     fs-extra "~8.1"
@@ -128,10 +129,10 @@
     vinyl "~2.2"
     vinyl-fs "~3.0"
 
-"@antora/ui-loader@2.3.0-beta.2":
-  version "2.3.0-beta.2"
-  resolved "https://registry.yarnpkg.com/@antora/ui-loader/-/ui-loader-2.3.0-beta.2.tgz#9b73f23c37edadd39dfdcc28ea9cfa7836c224b7"
-  integrity sha512-JgDooQGUQ0e6uzxlbd9TbHT0IVCDhMFQyTcvSZi5gJXyi86a3REnLluxUpiZr/xZdgWtlm8W0Pech7EPIvqUSg==
+"@antora/ui-loader@2.3.0":
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/@antora/ui-loader/-/ui-loader-2.3.0.tgz#3282e28576234d9ad7ad135188c1e2a82640ed33"
+  integrity sha512-EcBUwd4ImWI/BH0dZpH6CfDzBnAtQ2qUPChaeqVbmfCNpBvH6t09YYRVA713no21ypAF3AwBs3FGU1+vR6T/IQ==
   dependencies:
     "@antora/expand-path-helper" "~1.0"
     bl "~4.0"


### PR DESCRIPTION
Updates antora to 2.3.0
Simplifies xref-check dependencies
Removes unneeded attribute for camel-quarkus latest version (already moved to component descriptor).