### PR TITLE
Change break-all to break-word in release notes

### DIFF
--- a/antora-ui-camel/src/css/release.css
+++ b/antora-ui-camel/src/css/release.css
@@ -10,7 +10,7 @@
 .release dd {
   grid-column-start: 2;
   margin-left: 1rem;
-  word-break: break-all;
+  word-break: break-word;
 }
 
 .release .tableblock tbody tr:nth-child(2n) {


### PR DESCRIPTION
In the tables present on release pages, the words should not break when screen size decreases (see the right column). This makes it harder to read the information. The break should be at word boundaries.
 
![image](https://user-images.githubusercontent.com/32356795/80395951-91919100-88d1-11ea-9dc0-ce16929689be.png)
