### PR TITLE
feat: change frontpage swoosh animation

### DIFF
--- a/antora-ui-camel/src/css/frontpage.css
+++ b/antora-ui-camel/src/css/frontpage.css
@@ -84,13 +84,15 @@ header.frontpage svg {
 
 header.frontpage svg path {
   fill: none;
-  animation: sparkle 2s ease alternate infinite;
+  stroke-linecap: round;
+  animation: transmission 10s ease alternate infinite;
 }
 
 header.frontpage svg path:nth-child(1) {
   stroke: #ffebcc;
   stroke-width: 10;
   stroke-opacity: 0.9;
+  stroke-dasharray: 100;
 }
 
 header.frontpage svg path:nth-child(2) {
@@ -98,6 +100,7 @@ header.frontpage svg path:nth-child(2) {
   stroke-width: 10;
   stroke-opacity: 0.3;
   animation-delay: -1s;
+  stroke-dasharray: 200;
 }
 
 header.frontpage svg path:nth-child(3) {
@@ -105,6 +108,7 @@ header.frontpage svg path:nth-child(3) {
   stroke-width: 15;
   stroke-opacity: 0.6;
   animation-delay: -3.5s;
+  stroke-dasharray: 150;
 }
 
 header.frontpage svg path:nth-child(4) {
@@ -112,6 +116,7 @@ header.frontpage svg path:nth-child(4) {
   stroke-width: 5;
   stroke-opacity: 0.4;
   animation-delay: -3s;
+  stroke-dasharray: 300;
 }
 
 header.frontpage svg path:nth-child(5) {
@@ -119,15 +124,12 @@ header.frontpage svg path:nth-child(5) {
   stroke-width: 5;
   stroke-opacity: 0.6;
   animation-delay: -6s;
+  stroke-dasharray: 200;
 }
 
-@keyframes sparkle {
-  0% {
-    stroke-opacity: 0.2;
-  }
-
+@keyframes transmission {
   100% {
-    stroke-opacity: 0.6;
+    stroke-dashoffset: 1000;
   }
 }
 


### PR DESCRIPTION
To freshen up the frontpage a bit, and perhaps to be more representative
of the integration nature of Camel, this changes the swoosh animation to
a "transmission" animation. By using dash pattern of the same SVG paths
we can simulate "messages" traveling from left and right edges of the
screen.