### PR TITLE
Status badges CSS for Camel Quarkus extension pages

### DIFF
--- a/antora-ui-camel/src/css/doc.css
+++ b/antora-ui-camel/src/css/doc.css
@@ -667,3 +667,36 @@ table.tableblock thead {
   background: var(--color-smoke-90);
   font-weight: var(--body-font-weight-bold);
 }
+
+/* Status badges used in Camel Quarkus extension pages */
+div.badges p {
+  text-align: right;
+}
+
+div.badges span {
+  color: var(--color-white);
+  padding: 0.15rem 0.3rem 0.15rem 0.3rem;
+  font-weight: normal;
+  font-style: normal;
+  font-size: 0.8rem;
+}
+
+div.badges span.badge-key {
+  background-color: var(--color-gray-60);
+  border-radius: 0.2rem 0 0 0.2rem;
+}
+
+div.badges span.badge-version {
+  background-color: var(--note-color);
+  border-radius: 0 0.2rem 0.2rem 0;
+}
+
+div.badges span.badge-supported {
+  background-color: var(--tip-color);
+  border-radius: 0 0.2rem 0.2rem 0;
+}
+
+div.badges span.badge-unsupported {
+  background-color: var(--important-color);
+  border-radius: 0 0.2rem 0.2rem 0;
+}


### PR DESCRIPTION
This allows to have badges for since version, JVM and Native on Camel Quarkus Extension pages, like the following:
![image](https://user-images.githubusercontent.com/1826249/82669158-38e8b600-9c3b-11ea-98b2-618517e30e86.png)

Can be tested together with https://github.com/apache/camel-quarkus/pull/1260