### PR TITLE
chore: customized scrollbar for table and code snippets

### DIFF
--- a/antora-ui-camel/src/css/doc.css
+++ b/antora-ui-camel/src/css/doc.css
@@ -111,6 +111,25 @@
   overflow-x: auto;
 }
 
+.doc .table-wrapper::-webkit-scrollbar {
+  height: 8px;
+}
+
+.doc .table-wrapper::-webkit-scrollbar-track {
+  background: #c4c4c4;
+  border-radius: 50px;
+}
+
+.doc .table-wrapper::-webkit-scrollbar-thumb {
+  background: rgb(151, 151, 151);
+  border-radius: 50px;
+}
+
+.doc .table-wrapper::-webkit-scrollbar-thumb:hover,
+.doc .table-wrapper::-webkit-scrollbar-thumb:active {
+  background: rgb(107, 107, 107);
+}
+
 .doc .table-wrapper table {
   width: 100%;
 }
@@ -530,6 +549,25 @@
   display: block;
   overflow-x: auto;
   padding: 0.75rem;
+}
+
+.doc pre.highlight code::-webkit-scrollbar {
+  height: 8px;
+}
+
+.doc pre.highlight code::-webkit-scrollbar-track {
+  background: #c4c4c4;
+  border-radius: 50px;
+}
+
+.doc pre.highlight code::-webkit-scrollbar-thumb {
+  background: rgb(151, 151, 151);
+  border-radius: 50px;
+}
+
+.doc pre.highlight code::-webkit-scrollbar-thumb:hover,
+.doc pre.highlight code::-webkit-scrollbar-thumb:active {
+  background: rgb(107, 107, 107);
 }
 
 /* NOTE assume pre.highlight contains code[data-lang] */

--- a/antora-ui-camel/src/css/doc.css
+++ b/antora-ui-camel/src/css/doc.css
@@ -112,17 +112,17 @@
 }
 
 .doc .table-wrapper::-webkit-scrollbar {
-  height: 0.42rem;
+  height: var(--scrollbar-thickness);
 }
 
 .doc .table-wrapper::-webkit-scrollbar-track {
   background: var(--scrollbar-track-color);
-  border-radius: 3.125rem;
+  border-radius: var(--scrollbar-radius);
 }
 
 .doc .table-wrapper::-webkit-scrollbar-thumb {
   background: var(--scrollbar-thumb-color);
-  border-radius: 3.125rem;
+  border-radius: var(--scrollbar-radius);
 }
 
 .doc .table-wrapper::-webkit-scrollbar-thumb:hover,
@@ -552,17 +552,17 @@
 }
 
 .doc pre.highlight code::-webkit-scrollbar {
-  height: 0.42rem;
+  height: var(--scrollbar-thickness);
 }
 
 .doc pre.highlight code::-webkit-scrollbar-track {
   background: var(--scrollbar-track-color);
-  border-radius: 3.125rem;
+  border-radius: var(--scrollbar-radius);
 }
 
 .doc pre.highlight code::-webkit-scrollbar-thumb {
   background: var(--scrollbar-thumb-color);
-  border-radius: 3.125rem;
+  border-radius: var(--scrollbar-radius);
 }
 
 .doc pre.highlight code::-webkit-scrollbar-thumb:hover,

--- a/antora-ui-camel/src/css/doc.css
+++ b/antora-ui-camel/src/css/doc.css
@@ -112,22 +112,22 @@
 }
 
 .doc .table-wrapper::-webkit-scrollbar {
-  height: 8px;
+  height: 0.42rem;
 }
 
 .doc .table-wrapper::-webkit-scrollbar-track {
-  background: #c4c4c4;
-  border-radius: 50px;
+  background: var(--scrollbar-track-color);
+  border-radius: 3.125rem;
 }
 
 .doc .table-wrapper::-webkit-scrollbar-thumb {
-  background: rgb(151, 151, 151);
-  border-radius: 50px;
+  background: var(--scrollbar-thumb-color);
+  border-radius: 3.125rem;
 }
 
 .doc .table-wrapper::-webkit-scrollbar-thumb:hover,
 .doc .table-wrapper::-webkit-scrollbar-thumb:active {
-  background: rgb(107, 107, 107);
+  background: var(--scrollbar-thumb-active-color);
 }
 
 .doc .table-wrapper table {
@@ -552,22 +552,22 @@
 }
 
 .doc pre.highlight code::-webkit-scrollbar {
-  height: 8px;
+  height: 0.42rem;
 }
 
 .doc pre.highlight code::-webkit-scrollbar-track {
-  background: #c4c4c4;
-  border-radius: 50px;
+  background: var(--scrollbar-track-color);
+  border-radius: 3.125rem;
 }
 
 .doc pre.highlight code::-webkit-scrollbar-thumb {
-  background: rgb(151, 151, 151);
-  border-radius: 50px;
+  background: var(--scrollbar-thumb-color);
+  border-radius: 3.125rem;
 }
 
 .doc pre.highlight code::-webkit-scrollbar-thumb:hover,
 .doc pre.highlight code::-webkit-scrollbar-thumb:active {
-  background: rgb(107, 107, 107);
+  background: var(--scrollbar-thumb-active-color);
 }
 
 /* NOTE assume pre.highlight contains code[data-lang] */

--- a/antora-ui-camel/src/css/nav.css
+++ b/antora-ui-camel/src/css/nav.css
@@ -119,17 +119,17 @@ html.is-clipped--nav {
 }
 
 .nav-menu::-webkit-scrollbar {
-  width: 0.42rem;
+  width: var(--scrollbar-thickness);
 }
 
 .nav-menu::-webkit-scrollbar-track {
   background: var(--scrollbar-track-color);
-  border-radius: 3.125rem;
+  border-radius: var(--scrollbar-radius);
 }
 
 .nav-menu::-webkit-scrollbar-thumb {
   background: var(--scrollbar-thumb-color);
-  border-radius: 3.125rem;
+  border-radius: var(--scrollbar-radius);
 }
 
 .nav-menu::-webkit-scrollbar-thumb:hover,

--- a/antora-ui-camel/src/css/vars.css
+++ b/antora-ui-camel/src/css/vars.css
@@ -150,6 +150,8 @@
   --doc-max-width--desktop: calc(1366 / var(--rem-base) * 1rem);
   --static-max-width: calc(720 / var(--rem-base) * 1rem);
   --static-max-width--desktop: calc(1366 / var(--rem-base) * 1rem);
+  --scrollbar-thickness: calc(7.56 / var(--rem-base) * 1rem);
+  --scrollbar-radius: calc(56.25 / var(--rem-base) * 1rem);
   /* stacking */
   --z-index-nav: 1;
   --z-index-toolbar: 2;

--- a/antora-ui-camel/src/css/vars.css
+++ b/antora-ui-camel/src/css/vars.css
@@ -41,6 +41,8 @@
   --scrollbar-track-color: var(--color-gray-10);
   --scrollbar-thumb-color: var(--color-gray-30);
   --scrollbar-thumb-active-color: var(--color-gray-50);
+  --scrollbar-thickness: 0.425em; /* 6.8px */
+  --scrollbar-radius: 3.125em; /* 50px */
   /* navbar */
   --navbar-background: var(--color-white);
   --navbar-font-color: var(--color-camel-orange);
@@ -150,8 +152,6 @@
   --doc-max-width--desktop: calc(1366 / var(--rem-base) * 1rem);
   --static-max-width: calc(720 / var(--rem-base) * 1rem);
   --static-max-width--desktop: calc(1366 / var(--rem-base) * 1rem);
-  --scrollbar-thickness: calc(7.56 / var(--rem-base) * 1rem);
-  --scrollbar-radius: calc(56.25 / var(--rem-base) * 1rem);
   /* stacking */
   --z-index-nav: 1;
   --z-index-toolbar: 2;


### PR DESCRIPTION
* The default scrollbar didn't amount to the design of the webpage, hence I added a custom scrollbar using WebKit for all the table layouts and code snippets.

### Table Layout Before 
![table-scrollbar-before](https://user-images.githubusercontent.com/44139348/82728036-ab28cb80-9d0b-11ea-9910-a675eca9f860.png)

### Table Layout After 
![table-scrollbar-after](https://user-images.githubusercontent.com/44139348/82728043-afed7f80-9d0b-11ea-8335-7d7efd55dbcb.png)
<hr />

### Code Layout Before 
![code-context-before](https://user-images.githubusercontent.com/44139348/82728092-d7444c80-9d0b-11ea-8508-39d7c3f77530.png)

### Code Layout After
![code-context-after](https://user-images.githubusercontent.com/44139348/82728072-c267b900-9d0b-11ea-82dd-0b6824cc4fad.png)
