### PR TITLE
improve projects section on Front Page

### DIFF
--- a/antora-ui-camel/src/css/frontpage.css
+++ b/antora-ui-camel/src/css/frontpage.css
@@ -156,7 +156,7 @@ section.frontpage.projects {
 
 section.frontpage.projects .project {
   display: flex;
-  flex: 1 0 33%;
+  flex: 1 0 30%;
   flex-direction: column;
   align-items: center;
   padding: 1rem;
@@ -291,5 +291,11 @@ section.frontpage h2 {
 
   .box {
     min-width: 51vw;
+  }
+
+  @media screen and (min-width: 627px) {
+    section.frontpage.projects .project {
+      flex: 46%;
+    }
   }
 }


### PR DESCRIPTION
Currently, the projects section on the front page shows :
- 3 projects in a row for wider screens
- 1 project in a row for smaller screens
- But for a lot of intermediate widths, the presentation gets skewed into 2, 3 and 1 projects in a row 

![image](https://user-images.githubusercontent.com/32356795/82950146-71cdb580-9fc2-11ea-8ef6-40158fae6081.png)

I thought it's better to have
- 3 in a row for >1024px screens
- 2 in a row for 627-1023px screens
- 1 in a row for <627px screens