### PR TITLE
update:show correct microdata for different documentation versions

### DIFF
--- a/antora-ui-camel/src/partials/breadcrumbs-microdata.hbs
+++ b/antora-ui-camel/src/partials/breadcrumbs-microdata.hbs
@@ -12,13 +12,19 @@
         "@type": "ListItem",
         "position": 2,
         "name": "{{{page.component.title}}}",
+        "item": "{{{add site.url page.component.url}}}"
+        },
+        {
+        "@type": "ListItem",
+        "position": 3,
+        "name": "{{{page.componentVersion.displayVersion}}}",
         "item": "{{{add site.url page.componentVersion.url}}}"
         },
         {{#if page.breadcrumbs}}
         {{#each page.breadcrumbs}}
         {
         "@type": "ListItem",
-        "position": {{add @index 3}},
+        "position": {{add @index 4}},
         "name": "{{{ ./content }}}",
         {{~#if (and ./url (eq ./urlType 'internal'))~}}
         "item": "{{{add ../site.url ./url}}}"


### PR DESCRIPTION
When we do a google search for 
> aws-cw-component

we get two results which user may get confused

![Screenshot from 2020-05-28 00-17-44](https://user-images.githubusercontent.com/25351304/83060571-48239580-a079-11ea-90b0-b1f35461cf32.png)

these results show as
> Apache Camel -> Camel Components -> Components -> AWS CloudWatch

New google search results will show
> Apache Camel -> Camel Components -> 2.x -> Components -> AWS CloudWatch

 for 
[https://camel.apache.org/components/2.x/aws-cw-component.html](https://camel.apache.org/components/2.x/aws-cw-component.html)

and 
> Apache Camel -> Camel Components -> latest -> Components -> AWS CloudWatch

 for 
[https://camel.apache.org/components/latest/aws-cw-component.html](https://camel.apache.org/components/latest/aws-cw-component.html)