### PR TITLE
Align Quarkus extension badges to the left

### DIFF
--- a/antora-ui-camel/src/css/doc.css
+++ b/antora-ui-camel/src/css/doc.css
@@ -670,7 +670,7 @@ table.tableblock thead {
 
 /* Status badges used in Camel Quarkus extension pages */
 div.badges p {
-  text-align: right;
+  text-align: left;
 }
 
 div.badges span {


### PR DESCRIPTION
For me it looks a bit odd to see the Quarkus extension header, then on the next line, a bunch of whitespace and the badges dangling over on the right side.

The pages read / flow better if the badges are left aligned (IMO).