### PR TITLE
Add script to remove over lapping of nav-panel menu with context

### DIFF
--- a/antora-ui-camel/src/js/06-nav-toggle.js
+++ b/antora-ui-camel/src/js/06-nav-toggle.js
@@ -1,0 +1,39 @@
+;(function () {
+  'use strict'
+
+  var MutationObserver = window.MutationObserver
+  var width = window.innerWidth
+  var navToggle = document.getElementsByClassName('nav-toggle')[0]
+  var toggleObserver = new MutationObserver(toggleWidthChange)
+  var config = {
+    attributes: true,
+    childList: true,
+  }
+
+  if (width >= 975 && width < 1024) {
+    if (navToggle) toggleObserver.observe(navToggle, config)
+  } else if (width < 975) {
+    var nav = document.getElementsByClassName('nav')[0]
+    if (navToggle) {
+      navToggle.addEventListener('click', function () {
+        nav.style.width = width.toString() + 'px'
+      })
+    }
+  }
+
+  function toggleWidthChange (mutations, _) {
+    var target = mutations[0].target
+    var className = target.getAttribute('class')
+    var condn = className.indexOf('is-active')
+    var el = document.getElementsByClassName('doc')[0]
+    condn > -1 ? openToggle(el) : closeToggle(el)
+  }
+
+  function openToggle (el) {
+    el.style.marginRight = '2rem'
+  }
+
+  function closeToggle (el) {
+    el.style.marginRight = 'auto'
+  }
+})()


### PR DESCRIPTION
1. Less than 1024 px, when clicked on the nav-toggle, it overlaps the context and doesn't look sophisticated. Hence, I made the following changes: 

* 975px <= width < 1024px: When the `nav-toggle is-active` is observed, the context moves to provide a clear line between the nav panel and the context. When the state is back to `nav-toggle`, the default `margin-right: auto` appears. 

* width < 975px: For such less screen width, on click of the **nav-toggle**, the **nav-panel-menu** covers the width of the screen.

### Suggestion
In width > 1024px, would it be better to include a box-shadow beneath the quick lookup similar to that of the toolbar? 
