### PR TITLE
CAMEL-14904: Nav pane does not show current page

### DIFF
--- a/antora-ui-camel/src/js/01-nav.js
+++ b/antora-ui-camel/src/js/01-nav.js
@@ -91,6 +91,9 @@
     var navStyle = window.getComputedStyle(nav)
     if (navStyle.position === 'sticky') effectiveHeight -= (rect.top - parseFloat(navStyle.top))
     panel.scrollTop = Math.max(0, (el.getBoundingClientRect().height - effectiveHeight) * 0.5 + el.offsetTop)
+    var topPixels = Math.max(0, (el.getBoundingClientRect().height - effectiveHeight) * 0.5 + el.offsetTop)
+    var navMenu = document.getElementsByClassName('nav-menu')[0]
+    navMenu.scrollBy(0, topPixels)
   }
 
   function find (from, selector) {

--- a/antora-ui-camel/src/js/01-nav.js
+++ b/antora-ui-camel/src/js/01-nav.js
@@ -91,9 +91,6 @@
     var navStyle = window.getComputedStyle(nav)
     if (navStyle.position === 'sticky') effectiveHeight -= (rect.top - parseFloat(navStyle.top))
     panel.scrollTop = Math.max(0, (el.getBoundingClientRect().height - effectiveHeight) * 0.5 + el.offsetTop)
-    var topPixels = Math.max(0, (el.getBoundingClientRect().height - effectiveHeight) * 0.5 + el.offsetTop)
-    var navMenu = document.getElementsByClassName('nav-menu')[0]
-    navMenu.scrollBy(0, topPixels)
   }
 
   function find (from, selector) {

--- a/antora-ui-camel/src/partials/nav-menu.hbs
+++ b/antora-ui-camel/src/partials/nav-menu.hbs
@@ -1,9 +1,9 @@
 {{#if page.navigation}}
-<div class="nav-panel-menu is-active" data-panel="menu">
+<div class="nav-panel-menu is-active">
   {{#if (eq page.component.name 'components')}}
   <input class="search" placeholder="Quick lookup">
   {{/if}}
-  <nav class="nav-menu">
+  <nav class="nav-menu" data-panel="menu">
     <h3 class="title"><a href="{{relativize page.url page.componentVersion.url}}">{{page.component.title}}</a></h3>
 {{> nav-tree navigation=page.navigation}}
   </nav>


### PR DESCRIPTION
### Issue Observed
* The Antora default UI highlights and makes sure the nav list item for the current page remains visible.  The Camel components list does not do this, always scrolling to the top when you click on an item.  This makes it very hard to use.

### Solution Offered 
* As the `panel.scrollTop` has been used to calculate the mid-point for the `current-page-item` on the nav menu panel, I have written code such that when the navigation happens, it find the midpoint distance for that page item in the menu panel, and scrolls to that immediately.