### PR TITLE
Replicate Antora styling for overlapping of navbar over menu panel

### DIFF
--- a/antora-ui-camel/src/css/header.css
+++ b/antora-ui-camel/src/css/header.css
@@ -160,13 +160,12 @@ body {
   .navbar-menu.is-active {
     display: block;
     position: absolute;
-    height: 100vh;
+    height: 50vh;
     box-shadow: 0 16px 16px 0 rgba(10, 10, 10, 0.1);
     overflow-y: auto;
     top: 4rem;
     left: 0;
     right: 0;
-    margin-left: 50%;
     padding: 1rem 2rem;
   }
 

--- a/antora-ui-camel/src/js/04-mobile-navbar.js
+++ b/antora-ui-camel/src/js/04-mobile-navbar.js
@@ -13,6 +13,7 @@ document.addEventListener('DOMContentLoaded', function () {
   var menuDropDowns = Array.prototype.slice.call(document.querySelectorAll('.has-dropdown'), 0)
   menuDropDowns.forEach(function (el) {
     el.addEventListener('click', function (e) {
+      e.stopPropagation()
       el.classList.toggle('is-active')
     })
   })


### PR DESCRIPTION
### ISSUES
1.  When clicked on the menu panel within smaller screen width and at the same time, the navbar was clicked it created quite a cluster and looked messy. 
![issue-mutation](https://user-images.githubusercontent.com/44139348/83413561-a796f200-a439-11ea-8d74-187808b6028d.png)

2. When the menu panel was active and when the dropdown button within the navbar was clicked, the menu panel would become inactive and that isn't user-friendly. 

### SOLUTION
1.  Replicated the way an antora performs this. The navbar takes the entire width while covering 50% of viewport height and shows a higher hierarchy over the menu panel item. 
![resolve-mutation](https://user-images.githubusercontent.com/44139348/83413663-d44b0980-a439-11ea-9b9d-c25d831ff711.png)

2. `e.stopPropagation()` was used after the click of the dropdown item to resolve this issue.
