### PR TITLE
CAMEL-15161: Modify the design for functionality section on frontpage

### DIFF
--- a/antora-ui-camel/src/css/frontpage.css
+++ b/antora-ui-camel/src/css/frontpage.css
@@ -201,7 +201,7 @@ section.frontpage h2 {
   flex-direction: column;
   margin: 1rem;
   padding: 1.2rem 0.75rem;
-  border: 1px solid #e1e1e1;
+  border: 1px solid var(--color-smoke-90);
 }
 
 .frontpage .box div {

--- a/antora-ui-camel/src/css/frontpage.css
+++ b/antora-ui-camel/src/css/frontpage.css
@@ -144,7 +144,7 @@ section.frontpage.columns {
   display: flex;
   flex-wrap: wrap;
   border-top: 1px solid var(--color-smoke-50);
-  padding-top: 3rem;
+  padding: 1rem 0 0;
 }
 
 section.frontpage.projects {
@@ -197,12 +197,14 @@ section.frontpage h2 {
 }
 
 .frontpage .box {
-  flex: 50%;
-  padding: 1.2rem 0;
+  flex: 33%;
+  flex-direction: column;
+  margin: 1rem;
+  padding: 1.2rem 0.75rem;
+  border: 1px solid #e1e1e1;
 }
 
 .frontpage .box div {
-  padding: 1.8rem;
   text-align: center;
   margin: 1rem;
   height: 100%;

--- a/antora-ui-camel/src/css/vars.css
+++ b/antora-ui-camel/src/css/vars.css
@@ -117,7 +117,7 @@
   /* static */
   --static-margin: 0 auto;
   /* frontpage */
-  --frontpage-max-width: calc(1350 / var(--rem-base) * 1rem);
+  --frontpage-max-width: calc(1366 / var(--rem-base) * 1rem);
   /* footer */
   --footer-line-height: var(--doc-line-height);
   --footer-background: var(--color-smoke-90);

--- a/antora-ui-camel/src/css/vars.css
+++ b/antora-ui-camel/src/css/vars.css
@@ -117,7 +117,7 @@
   /* static */
   --static-margin: 0 auto;
   /* frontpage */
-  --frontpage-max-width: calc(1140 / var(--rem-base) * 1rem);
+  --frontpage-max-width: calc(1350 / var(--rem-base) * 1rem);
   /* footer */
   --footer-line-height: var(--doc-line-height);
   --footer-background: var(--color-smoke-90);


### PR DESCRIPTION
* In JIRA Issue 15161, the issue mentioned was that on the front page then the 4 panels for patterns, components, runtimes, data formats take up too much space. 

* Thus, I modified such that the design for the panel is similar to that of the project section on the frontpage, it gives a minimalist and consistent effect and takes less space also. 

### BEFORE
![old-functionality](https://user-images.githubusercontent.com/44139348/84773009-684fd000-aff9-11ea-9c68-a94996c8ff1d.png)

### AFTER
![new-functionality](https://user-images.githubusercontent.com/44139348/84773048-77cf1900-aff9-11ea-9bf4-2f354d294286.png)

