### PR TITLE
fix: provide padding between text field and the cancel button

### DIFF
--- a/antora-ui-camel/src/css/header.css
+++ b/antora-ui-camel/src/css/header.css
@@ -398,7 +398,7 @@ body {
   border: 1px solid var(--nav-panel-divider-color);
   border-radius: 4px 4px;
   margin-top: 0.75rem;
-  padding: 0.5rem 0.5rem 0.5rem 1.9rem;
+  padding: 0.5rem 1.5rem 0.5rem 1.9rem;
   font-family: Open Sans, sans-serif;
   caret-color: #ed8225;
   background: no-repeat 0.4rem/1rem url(../img/search.svg);


### PR DESCRIPTION
* Previously, when long text is written within the search bar input it hides behind the cancel button.

![searchbar-prev](https://user-images.githubusercontent.com/44139348/85859045-3cdb9b00-b7da-11ea-835a-13d1ac8eb7ed.png)

* Fixed it by added sufficient padding to avoid this issue.

![searchbar-next](https://user-images.githubusercontent.com/44139348/85859175-714f5700-b7da-11ea-8108-53f651b68691.png)
