### PR TITLE
fix: nav panel explore toggling on click

### DIFF
--- a/antora-ui-camel/src/js/01-nav.js
+++ b/antora-ui-camel/src/js/01-nav.js
@@ -39,8 +39,10 @@
   })
 
   nav.querySelector('.nav-panel-explore').addEventListener('click', function () {
-    var currentPanel = nav.querySelector('.nav-panel-explore')
-    currentPanel.classList.toggle('is-active')
+    var currentPanel = nav.querySelector('.is-active[data-panel]')
+    var activatePanel = (currentPanel === null || currentPanel.dataset.panel === 'menu') ? 'explore' : 'menu'
+    nav.querySelector(`[data-panel=${activatePanel}]`).classList.toggle('is-active')
+    if (currentPanel !== null) currentPanel.classList.toggle('is-active')
   })
 
   // NOTE prevent text from being selected by double click

--- a/antora-ui-camel/src/js/01-nav.js
+++ b/antora-ui-camel/src/js/01-nav.js
@@ -38,11 +38,9 @@
     }
   })
 
-  nav.querySelector('.context').addEventListener('click', function () {
-    var currentPanel = nav.querySelector('.is-active[data-panel]')
-    var activatePanel = currentPanel.dataset.panel === 'menu' ? 'explore' : 'menu'
+  nav.querySelector('.nav-panel-explore').addEventListener('click', function () {
+    var currentPanel = nav.querySelector('.nav-panel-explore')
     currentPanel.classList.toggle('is-active')
-    nav.querySelector('[data-panel=' + activatePanel + ']').classList.toggle('is-active')
   })
 
   // NOTE prevent text from being selected by double click


### PR DESCRIPTION
* The nav explore menu doesn't trigger on click. So, I resolved with a quick fix. Yet I wanted to an opinion that if the nav-explore-menu is clicked and the menu appears, do you want to disable clicking of any nav-menu items on the panel or not? 