### PR TITLE
fix: alignment of the documentation page

### DIFF
--- a/antora-ui-camel/src/css/doc.css
+++ b/antora-ui-camel/src/css/doc.css
@@ -50,12 +50,19 @@
 }
 
 .doc h2:not(.discrete) {
-  border-bottom: 1px solid var(--section-divider-color);
   margin-top: 1rem;
   margin-left: -1rem;
   margin-right: -1rem;
   padding: 0.4rem 1rem 0.1rem;
   overflow-wrap: break-word;
+}
+
+.doc h2:not(.discrete)::after {
+  content: "";
+  display: block;
+  position: relative;
+  height: 1px;
+  background-color: var(--section-divider-color);
 }
 
 .doc h3:not(.discrete) {

--- a/antora-ui-camel/src/css/docs.css
+++ b/antora-ui-camel/src/css/docs.css
@@ -58,7 +58,7 @@
 .project .links {
   align-items: center;
   margin: 1.5rem 0;
-  white-space: nowrap;
+  word-break: break-word;
 }
 
 @media screen and (max-width: 1023px) {
@@ -69,6 +69,10 @@
 }
 
 @media screen and (max-width: 480px) {
+  .docs {
+    padding: 0 1rem 4rem;
+  }
+
   .docs .project {
     padding: 1rem 0.4rem;
   }

--- a/antora-ui-camel/src/css/docs.css
+++ b/antora-ui-camel/src/css/docs.css
@@ -69,12 +69,20 @@
 }
 
 @media screen and (max-width: 480px) {
+  .camel-project {
+    padding: 0 0 1.5rem 0;
+  }
+
+  .camel-project .camel-documentation .links {
+    padding: 1rem;
+  }
+
   .docs {
-    padding: 0 1rem 4rem;
+    padding: 0 0 1.5rem 0;
   }
 
   .docs .project {
-    padding: 1rem 0.4rem;
+    padding: 0;
   }
 }
 


### PR DESCRIPTION
The responsiveness for the documentation page wasn't taken into complete account for the smaller screen width. Hence, this PR resolves it.

### BEFORE
![bug-layout-responsive](https://user-images.githubusercontent.com/44139348/86510427-2605fb80-be0d-11ea-8b52-e6d62817a7dc.png)

### AFTER
![fix-layout-responsive](https://user-images.githubusercontent.com/44139348/86510431-2b634600-be0d-11ea-8e48-25dcced529d8.png)
