### PR TITLE
CAMEL-14952: Better search on the website

### DIFF
--- a/antora-ui-camel/src/js/vendor/algoliasearch.bundle.js
+++ b/antora-ui-camel/src/js/vendor/algoliasearch.bundle.js
@@ -4,8 +4,8 @@
   const algoliasearch = require('algoliasearch/lite')
 
   window.addEventListener('load', () => {
-    const client = algoliasearch('QDOJ4LJQCC', '0fa28c3acc4d5f383b85ae4ad035ac9c')
-    const index = client.initIndex('aashna')
+    const client = algoliasearch('BH4D9OD16A', '16e3a9155a136e4962dc4c206f8278bd')
+    const index = client.initIndex('apache_camel')
     const search = document.querySelector('#search')
     const container = search.parentNode
     const results = document.querySelector('#search_results')
@@ -53,19 +53,15 @@
             const data = hits.reduce((data, hit) => {
               const d = {}
               d.url = hit.url
-              var hierarchy = Object.values(hit.hierarchy).filter((lvl) => lvl !== null)
-              const section = hierarchy[0]
-              var breadcrumbs = hierarchy.slice(1).join(' &raquo; ')
-              if (breadcrumbs !== '') {
-                d.breadcrumbs = breadcrumbs
-              } else {
-                d.breadcrumbs = section
-              }
-              if (hit._snippetResult !== undefined) {
-                d.snippet = hit._snippetResult.content.value
-              } else {
-                d.snippet = ''
-              }
+              var section = hit.hierarchy.lvl1
+              if (hit.hierarchy.lvl0 !== null) section = section + ' [' + hit.hierarchy.lvl0 + ']'
+              var breadcrumbs = Object.values(hit.hierarchy)
+                .slice(2)
+                .filter((lvl) => lvl !== null)
+                .join(' &raquo; ')
+
+              d.breadcrumbs = ((breadcrumbs !== '') ? breadcrumbs : section)
+              d.snippet = hit._snippetResult.content.value + '...'
 
               data[section] = data[section] || []
               data[section].push(d)

--- a/antora-ui-camel/src/js/vendor/algoliasearch.bundle.js
+++ b/antora-ui-camel/src/js/vendor/algoliasearch.bundle.js
@@ -4,8 +4,8 @@
   const algoliasearch = require('algoliasearch/lite')
 
   window.addEventListener('load', () => {
-    const client = algoliasearch('BH4D9OD16A', '16e3a9155a136e4962dc4c206f8278bd')
-    const index = client.initIndex('apache_camel')
+    const client = algoliasearch('QDOJ4LJQCC', '0fa28c3acc4d5f383b85ae4ad035ac9c')
+    const index = client.initIndex('aashna')
     const search = document.querySelector('#search')
     const container = search.parentNode
     const results = document.querySelector('#search_results')
@@ -53,14 +53,13 @@
             const data = hits.reduce((data, hit) => {
               const d = {}
               d.url = hit.url
-              var breadcrumbs = Object.values(hit.hierarchy)
-                .slice(1)
-                .filter((lvl) => lvl !== null)
-                .join(' &raquo; ')
+              var hierarchy = Object.values(hit.hierarchy).filter((lvl) => lvl !== null)
+              const section = hierarchy[0]
+              var breadcrumbs = hierarchy.slice(1).join(' &raquo; ')
               if (breadcrumbs !== '') {
                 d.breadcrumbs = breadcrumbs
               } else {
-                d.breadcrumbs = hit.hierarchy.lvl0
+                d.breadcrumbs = section
               }
               if (hit._snippetResult !== undefined) {
                 d.snippet = hit._snippetResult.content.value
@@ -68,7 +67,6 @@
                 d.snippet = ''
               }
 
-              const section = hit.hierarchy.lvl0
               data[section] = data[section] || []
               data[section].push(d)
 


### PR DESCRIPTION
I have linked my own Algolia index to this PR for now, so that everyone can view the changes in search results. 
- Search results are now grouped by higher level headings eg. "Camel Components" or "User Manual" or "Camel Kafka Connector". 
- For Hugo pages, search results are grouped by H1, because that itself is the highest level of heading eg "Articles" or "Books"
- I wanted to make the config file as simple as possible, and depend on the sitemap instead of the URLs. This is what I'm using :


  "sitemap_urls": [
    "https://camel.apache.org/sitemap.xml"
  ],
  "selectors": {
    "lvl0": ".toolbar ul li:nth-child(1) a",
    "lvl1": ".version-menu a.is-current",
    "lvl2": "article h1",
    "lvl3": "article h2",
    "text": "article p, article li"
  }
