### PR TITLE
fix: toc sidebar width explicitly mentioned

### DIFF
--- a/antora-ui-camel/src/css/main.css
+++ b/antora-ui-camel/src/css/main.css
@@ -21,6 +21,17 @@
 
   aside.toc.sidebar {
     flex: 0 0 var(--toc-width);
+    min-width: 15rem;
+  }
+
+  .toc.sidebar .toc-menu ul {
+    -ms-overflow-style: none; /* Internet Explorer 10+ */
+    scrollbar-width: none; /* Firefox */
+  }
+
+  .toc.sidebar .toc-menu ul::-webkit-scrollbar {
+    width: 0;
+    background: transparent;  /* Chrome/Safari/Webkit */
   }
 }
 


### PR DESCRIPTION
### Issue-1: Width occupied by toc sidebar
![toc-issue-1](https://user-images.githubusercontent.com/44139348/86909747-2d434700-c136-11ea-99d3-4f3b310eea7d.png)

### Resolve-1: Explicitly providing a min-width for the toc sidebar
![toc-resolve-1](https://user-images.githubusercontent.com/44139348/86909804-48ae5200-c136-11ea-95eb-ee55523c8d46.png)

### Issue-2: Unnecessary scrollbar present for a toc sidebar menu. (Uglifies the web page and it isn't required either)
![toc-issue-2](https://user-images.githubusercontent.com/44139348/86909933-7e533b00-c136-11ea-968f-6757ed5732b9.png)

### Resolve-2: Make the scrollbar transparent (browser-specific) so the scrolling will take place without the need to see a scrollbar