### PR TITLE
fix: responsiveness for docs section pages

### DIFF
--- a/antora-ui-camel/src/css/docs.css
+++ b/antora-ui-camel/src/css/docs.css
@@ -62,27 +62,19 @@
 }
 
 @media screen and (max-width: 1023px) {
-  .docs .project {
-    width: calc(100% - 3.2rem);
-    margin: 1.5rem;
-  }
-}
-
-@media screen and (max-width: 480px) {
-  .camel-project {
-    padding: 0 0 1.5rem 0;
-  }
-
-  .camel-project .camel-documentation .links {
-    padding: 1rem;
-  }
-
   .docs {
-    padding: 0 0 1.5rem 0;
+    padding: 0 1rem 4rem;
   }
 
+  .camel-project,
   .docs .project {
-    padding: 0;
+    width: calc(100% - 1rem);
+    margin: 1.5rem -1.5rem 1.5rem 0.5rem;
+  }
+
+  .camel-project .project {
+    width: calc(100% - 3rem);
+    margin: 1.5rem;
   }
 }
 


### PR DESCRIPTION
The [docs](https://camel.apache.org/docs/) page has comparatively different padding arrangement for the breakpoint to create a responsive and structured layout for the page however as `docs` is the page section used, the same padding affects its corresponding [building](https://camel.apache.org/docs/building) and [sources](https://camel.apache.org/docs/sources) pages below the breakpoint ( 1024px ) and it creates unresponsiveness for both these pages. 

Hence, I made the required changes that keep the structured layout for the docs pages and fix the responsiveness for both the above-mentioned docs-section pages.

### Issue within responsiveness and presentation of the building page below 1024px 
![building-docs](https://user-images.githubusercontent.com/44139348/87879554-2d322980-ca09-11ea-9484-f96c2beaff31.png)
