### PR TITLE
CAMEL 15296: Create sitemap for Camel website

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -6,7 +6,7 @@ site:
 content:
   sources:
 
-    - url: git@github.com:apache/camel.git
+    - url: git@github.com:aashnajena/camel.git
       branches: master
       start_paths:
         # manual
@@ -19,7 +19,7 @@ content:
         # main components doc
         - docs/components
         
-    - url: git@github.com:apache/camel.git
+    - url: git@github.com:aashnajena/camel.git
       branches: camel-3.4.x
       start_paths:
         # eip
@@ -30,7 +30,7 @@ content:
         # main components doc
         - docs/components
 
-    - url: git@github.com:apache/camel.git
+    - url: git@github.com:aashnajena/camel.git
       branches: camel-2.x
       start_paths:
         # main components doc

--- a/antora-ui-camel/src/css/site.css
+++ b/antora-ui-camel/src/css/site.css
@@ -8,7 +8,7 @@
 @import 'toolbar.css';
 @import 'breadcrumbs.css';
 @import 'page-versions.css';
-@import "toc.css";
+@import 'toc.css';
 @import 'doc.css';
 @import 'static.css';
 @import 'header.css';
@@ -23,3 +23,4 @@
 @import 'misc.css';
 @import 'community.css';
 @import 'docs.css';
+@import 'sitemap.css'

--- a/antora-ui-camel/src/css/sitemap.css
+++ b/antora-ui-camel/src/css/sitemap.css
@@ -1,0 +1,16 @@
+.sitemap > ul > li > ul,
+ul.sitemap-list {
+  list-style-type: disc;
+  -webkit-columns: 2;
+  -moz-columns: 2;
+  columns: 2;
+  column-gap: 25%;
+  padding-top: 1rem;
+}
+
+@media screen and (max-width: 626px) {
+  .sitemap > ul > li > ul,
+  ul.sitemap-list {
+    columns: 1;
+  }
+}

--- a/antora-ui-camel/src/layouts/sitemap.hbs
+++ b/antora-ui-camel/src/layouts/sitemap.hbs
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+{{> head defaultPageTitle="Untitled"}}
+  </head>
+  <body class="article{{#with (or page.attributes.role page.role)}} {{{this}}}{{/with}}">
+    {{> header}}
+    <div class="body">
+        <main role="main" class="nav-container doc blog list">
+                        <aside class="nav">
+                            <div class="nav-category">
+                                <h3>Sitemaps</h3>
+                                <ul>
+                                    <li><a class="category" href="/sitemap/">Camel Website</a></li>
+                                    <li><a class="category" href="/manual/latest/sitemap.html">User Manual</a></li>
+                                    <li><a class="category" href="/components/latest/sitemap.html">Components</a></li>
+                                    <li><a class="category">Camel K</a></li>
+                                    <li><a class="category">Camel Quarkus</a></li>
+                                    <li><a class="category">Camel Kafka</a></li>
+                                    <li><a class="category">Camel Spring Boot</a></li>
+                                    <li><a class="category">Camel Karaf</a></li>
+                                </ul>
+                            </div>
+                        </aside>
+                    </main>  
+        <main class="article">
+            <div class="content">
+                <article class="doc">       
+                    {{#with page.title}}
+                    <h1 class="page">{{{this}}}</h1>
+                    {{/with}}
+                    <div class="sitemap">
+                    {{#each page.navigation}}
+                        {{> sitemap-tree navigation=./items level=1}}
+                    {{/each}}
+                    </div>
+                </article>
+            </div>
+        </main>
+    </div>
+    {{> footer}}
+  </body>
+</html>

--- a/antora-ui-camel/src/partials/sitemap-tree.hbs
+++ b/antora-ui-camel/src/partials/sitemap-tree.hbs
@@ -1,0 +1,28 @@
+{{#if navigation.length}}
+<ul>
+  {{#each navigation}}
+    <li data-depth="{{or ../level 0}}">
+        {{#if ./content}}
+            {{#if (eq ../level 1)}}
+                {{#if ./url}}
+                    <h2><a href="
+                    {{~#if (eq ./urlType 'internal')}}{{{relativize ./url}}}
+                    {{~else}}{{{./url}}}{{~/if}}">{{{./content}}}</a></h2>
+                {{else}}
+                    <h2>{{{./content}}}</h2>
+                {{/if}}
+            {{else}}
+                {{#if ./url}}
+                    <a href="
+                    {{~#if (eq ./urlType 'internal')}}{{{relativize ./url}}}
+                    {{~else}}{{{./url}}}{{~/if}}">{{{./content}}}</a>
+                {{else}}
+                    <p>{{{./content}}}</p>
+                {{/if}}
+            {{/if}}
+        {{/if}}
+        {{> sitemap-tree navigation=./items level=(increment ../level)}}
+    </li>
+  {{/each}}
+</ul>
+{{/if}}

--- a/content/docs/_index.md
+++ b/content/docs/_index.md
@@ -1,4 +1,5 @@
 ---
+title : "Documentation"
 ---
 
 {{< div "camel-project" >}}

--- a/content/sitemap/_index.md
+++ b/content/sitemap/_index.md
@@ -1,0 +1,3 @@
+---
+title: "Camel Website Sitemap"
+---

--- a/layouts/sitemap/sitemap.html
+++ b/layouts/sitemap/sitemap.html
@@ -1,0 +1,55 @@
+{{ partial "header.html" . }}
+
+<div class="body">
+        <main role="main" class="nav-container doc blog list">
+            <aside class="nav">
+                <div class="nav-category">
+                    <h3>Sitemaps</h3>
+                    <ul>
+                        <li><a class="category" href="/sitemap/">Camel Website</a></li>
+                        <li><a class="category" href="/manual/latest/sitemap.html">User Manual</a></li>
+                        <li><a class="category" href="/components/latest/sitemap.html">Components</a></li>
+                        <li><a class="category">Camel K</a></li>
+                        <li><a class="category">Camel Quarkus</a></li>
+                        <li><a class="category">Camel Kafka</a></li>
+                        <li><a class="category">Camel Spring Boot</a></li>
+                        <li><a class="category">Camel Karaf</a></li>
+                    </ul>
+                </div>
+            </aside>
+        </main>
+        <main class="article">
+                <div class="content">
+                    <article class="doc"> 
+            <h1 class="page">{{ .Title }} </h1>
+            {{ range .Site.Sections }}
+                <a href = "{{ .Permalink }}" >
+                    <h2> {{ .Title }} </h2>
+                </a>
+                {{with .Site.GetPage "section" .Section }}
+                    {{ if eq .Section "blog"}}
+                        {{ range .Site.Taxonomies.categories.Alphabetical }}
+                            <h4>{{ .Name }}</h4> 
+                            <ul>
+                            {{range .Pages}}
+                                <li><a href = "{{ .Permalink }}" >{{ .Title }}</a></li>
+                            {{end}}
+                            </ul>
+                        {{ end }}
+                    {{ else }}
+                        <ul class="sitemap-list">
+                            <li><a href = "{{ .Permalink }}" >{{ .Title }}</a></li>
+                            {{range .Pages}}
+                                <li><a href = "{{ .Permalink }}" >{{ .Title }}</a></li>
+                            {{end}}
+                        </ul>
+                    {{ end }}  
+                {{ end }}
+            {{ end }}
+            
+        </article>
+    </div>
+    </main>
+</div>
+
+{{ partial "footer.html" . }}


### PR DESCRIPTION
This is the first draft for adding sitemaps to the website. On the preview, please go to `/sitemap/` to view the sitemaps, since there's no direct link to it present anywhere as of now. Also, I have linked my fork of the Camel repo, so that you view sitemaps for user manual and components. We will have to add a sitemap.adoc file in each of the sub-projects as well. sitemap.adoc in each repo would just have the title and page-layout attribute, no content.