### PR TITLE
feat: add github action for image optimization

### DIFF
--- a/.github/workflows/calibreapp-image-actions.yml
+++ b/.github/workflows/calibreapp-image-actions.yml
@@ -16,5 +16,5 @@ jobs:
           jpegProgressive: false
           pngQuality: "80"
           webpQuality: "80"
-          ignorePaths: "node_modules/**,build"
+          ignorePaths: "static"
           

--- a/.github/workflows/calibreapp-image-actions.yml
+++ b/.github/workflows/calibreapp-image-actions.yml
@@ -1,0 +1,20 @@
+name: Compress images
+on: pull_request
+jobs:
+  build:
+    name: calibreapp/image-actions
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@master
+
+      - name: Compress Images
+        uses: calibreapp/image-actions@master
+        with:
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+          jpegQuality: "80"
+          jpegProgressive: false
+          pngQuality: "80"
+          webpQuality: "80"
+          ignorePaths: "node_modules/**,build"
+          


### PR DESCRIPTION
* The performance due to lack of image compression lowers for the webpage. Gulp Imagemin wasn't showing the results as expected thus I chose to use a GitHub action which is easy, effective, and does lossless compression.

* This will be triggered each time a PR is created. The compression for the current status of the branch is shown in the snippet of the image below. ( More files were edited than the ones shown in the image )
![github-action](https://user-images.githubusercontent.com/44139348/88032887-3b448f00-cb5c-11ea-819a-84b61c5180f9.png)

* However, I require clarification on whether the images from the **public** folder only need to be compressed or from the **static** folder as well?
