### PR TITLE
chore: migrate to new CI server

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,8 +28,6 @@ pipeline {
             logRotator(artifactNumToKeepStr: '5', numToKeepStr: '10')
         )
 
-        timestamps()
-
         ansiColor('xterm')
 
         checkoutToSubdirectory('camel-website')


### PR DESCRIPTION
We need to migrate to managed Jenkins instance at ci-builds.apache.org.
The timestamp pipeline plugin is not installed there so we need to
remove it.