### PR TITLE
fix: search results

### DIFF
--- a/antora-ui-camel/src/js/vendor/algoliasearch.bundle.js
+++ b/antora-ui-camel/src/js/vendor/algoliasearch.bundle.js
@@ -53,10 +53,10 @@
             const data = hits.reduce((data, hit) => {
               const d = {}
               d.url = hit.url
-              var section = hit.hierarchy.lvl1
-              if (hit.hierarchy.lvl0 !== null) section = section + ' [' + hit.hierarchy.lvl0 + ']'
+              var section = hit.hierarchy.lvl0
+              if (hit.hierarchy.lvl6 !== null) section = section + ' [' + hit.hierarchy.lvl6 + ']'
               var breadcrumbs = Object.values(hit.hierarchy)
-                .slice(2)
+                .slice(1)
                 .filter((lvl) => lvl !== null)
                 .join(' &raquo; ')
 


### PR DESCRIPTION
The search results for blogs, articles, books, download are showing up like this:

![image](https://user-images.githubusercontent.com/32356795/89121497-0a117a80-d4dd-11ea-8275-db5d90ff7742.png)

The expected behaviour is shown below. I've made [PR #2133](https://github.com/algolia/docsearch-configs/pull/2133) on the Algolia repo to fix changes in the config file. With the changes in the config file + changes in this PR, we will be able to achieve the expected behaviour. 

![image](https://user-images.githubusercontent.com/32356795/89121439-91122300-d4dc-11ea-80f8-6c63a2fa620e.png)
