### PR TITLE
CAMEL-15337: create toc for hugo based content

### DIFF
--- a/antora-ui-camel/src/css/main.css
+++ b/antora-ui-camel/src/css/main.css
@@ -27,12 +27,12 @@
   }
 
   .toc.sidebar .toc-menu ul,
-  .toc-sidebar .toc-hugo ul {
+  .toc-sidebar .toc-menu ul {
     scrollbar-width: thin; /* Firefox */
   }
 
   .toc.sidebar .toc-menu ul::-webkit-scrollbar,
-  .toc-sidebar .toc-hugo ul::-webkit-scrollbar {
+  .toc-sidebar .toc-menu ul::-webkit-scrollbar {
     width: var(--scrollbar-thickness); /* Chrome/Safari/Webkit */
   }
 

--- a/antora-ui-camel/src/css/main.css
+++ b/antora-ui-camel/src/css/main.css
@@ -26,7 +26,8 @@
     min-width: 15rem;
   }
 
-  .toc.sidebar .toc-menu ul {
+  .toc.sidebar .toc-menu ul,
+  .toc-sidebar .toc-hugo ul {
     scrollbar-width: thin; /* Firefox */
   }
 

--- a/antora-ui-camel/src/css/main.css
+++ b/antora-ui-camel/src/css/main.css
@@ -1,5 +1,6 @@
 @media screen and (max-width: 1023px) {
-  aside.toc.sidebar {
+  aside.toc.sidebar,
+  aside.toc-sidebar {
     display: none;
   }
 }
@@ -19,7 +20,8 @@
     display: none;
   }
 
-  aside.toc.sidebar {
+  aside.toc.sidebar,
+  aside.toc-sidebar {
     flex: 0 0 var(--toc-width);
     min-width: 15rem;
   }
@@ -28,7 +30,8 @@
     scrollbar-width: thin; /* Firefox */
   }
 
-  .toc.sidebar .toc-menu ul::-webkit-scrollbar {
+  .toc.sidebar .toc-menu ul::-webkit-scrollbar,
+  .toc-sidebar .toc-hugo ul::-webkit-scrollbar {
     width: var(--scrollbar-thickness); /* Chrome/Safari/Webkit */
   }
 
@@ -49,7 +52,8 @@
 }
 
 @media screen and (min-width: 1216px) {
-  aside.toc.sidebar {
+  aside.toc.sidebar,
+  aside.toc-sidebar {
     flex-basis: var(--toc-width--widescreen);
   }
 }

--- a/antora-ui-camel/src/css/static.css
+++ b/antora-ui-camel/src/css/static.css
@@ -1,6 +1,11 @@
 .static {
   margin: var(--static-margin);
-  max-width: var(--static-max-width--desktop);
+}
+
+@media screen and (min-width: 1024px) {
+  .static {
+    max-width: var(--static-max-width--desktop);
+  }
 }
 
 /* Antora markup is wrapped in <div>, we need to emulate the same */

--- a/antora-ui-camel/src/css/toc.css
+++ b/antora-ui-camel/src/css/toc.css
@@ -1,17 +1,15 @@
-.toc-menu,
-.toc-hugo {
+.toc-menu {
   color: var(--toc-font-color);
 }
 
 .toc.sidebar .toc-menu,
-.toc-sidebar .toc-hugo {
+.toc-sidebar .toc-menu {
   margin-right: 0.75rem;
   position: sticky;
   top: var(--toc-top);
 }
 
-.toc .toc-menu h3,
-.toc .toc-hugo h3 {
+.toc .toc-menu h3 {
   color: var(--toc-heading-font-color);
   font-size: calc(16 / var(--rem-base) * 1rem);
   font-weight: var(--body-font-weight-bold);
@@ -21,15 +19,14 @@
 }
 
 .toc.sidebar .toc-menu h3,
-.toc-sidebar .toc-hugo h3 {
+.toc-sidebar .toc-menu h3 {
   display: flex;
   flex-direction: column;
   height: 2.5rem;
   justify-content: flex-end;
 }
 
-.toc .toc-menu ul,
-.toc .toc-hugo ul {
+.toc .toc-menu ul {
   font-size: calc(15 / var(--rem-base) * 1rem);
   line-height: var(--toc-line-height);
   list-style: none;
@@ -38,30 +35,27 @@
 }
 
 .toc.sidebar .toc-menu ul,
-.toc-sidebar .toc-hugo ul {
+.toc-sidebar .toc-menu ul {
   max-height: var(--toc-height);
   overflow-y: auto;
 }
 
 @media screen and (min-width: 1024px) {
-  .toc .toc-menu h3,
-  .toc .toc-hugo h3 {
+  .toc .toc-menu h3 {
     font-size: calc(15 / var(--rem-base) * 1rem);
   }
 
-  .toc .toc-menu ul,
-  .toc .toc-hugo ul {
+  .toc .toc-menu ul {
     font-size: calc(13.5 / var(--rem-base) * 1rem);
   }
 }
 
-.toc .toc-menu li,
-.toc .toc-hugo li {
+.toc .toc-menu li {
   margin: 0;
 }
 
 .toc .toc-menu li[data-level="2"] a,
-.toc .toc-hugo ul li ul li ul li a {
+.toc .toc-menu ul li ul li ul li a {
   padding-left: 1.25rem;
 }
 
@@ -69,8 +63,7 @@
   padding-left: 2rem;
 }
 
-.toc .toc-menu a,
-.toc .toc-hugo a {
+.toc .toc-menu a {
   color: inherit;
   border-left: 2px solid var(--toc-border-color);
   display: inline-block;
@@ -83,19 +76,17 @@
   outline: none;
 }
 
-.toc .toc-menu a:hover,
-.toc .toc-hugo a:hover {
+.toc .toc-menu a:hover {
   color: var(--link-font-color);
 }
 
-.toc .toc-menu a.is-active,
-.toc .toc-hugo a.is-active {
+.toc .toc-menu a.is-active {
   border-left-color: var(--link-font-color);
   color: var(--doc-font-color);
 }
 
 .sidebar.toc .toc-menu a:focus,
-.toc-sidebar .toc-hugo a:focus {
+.toc-sidebar .toc-menu a:focus {
   background: var(--panel-background);
 }
 

--- a/antora-ui-camel/src/css/toc.css
+++ b/antora-ui-camel/src/css/toc.css
@@ -43,20 +43,6 @@
   overflow-y: auto;
 }
 
-.toc .toc-hugo ul {
-  padding: 0 0 0 2rem;
-}
-
-.toc .toc-hugo ul:first-child {
-  padding: 0;
-  border-left: 2px solid var(--toc-border-color);
-}
-
-.toc .toc-hugo li ul:nth-child(1) {
-  padding-left: 0.25rem;
-  border-left: none;
-}
-
 @media screen and (min-width: 1024px) {
   .toc .toc-menu h3,
   .toc .toc-hugo h3 {
@@ -74,7 +60,8 @@
   margin: 0;
 }
 
-.toc .toc-menu li[data-level="2"] a {
+.toc .toc-menu li[data-level="2"] a,
+.toc .toc-hugo li[data-level="2"] a {
   padding-left: 1.25rem;
 }
 
@@ -91,10 +78,6 @@
   text-decoration: none;
 }
 
-.toc .toc-hugo a {
-  border-left: none;
-}
-
 .sidebar.toc .toc-menu a {
   display: block;
   outline: none;
@@ -105,12 +88,14 @@
   color: var(--link-font-color);
 }
 
-.toc .toc-menu a.is-active {
+.toc .toc-menu a.is-active,
+.toc .toc-hugo a.is-active {
   border-left-color: var(--link-font-color);
   color: var(--doc-font-color);
 }
 
-.sidebar.toc .toc-menu a:focus {
+.sidebar.toc .toc-menu a:focus,
+.toc-sidebar .toc-hugo a:focus {
   background: var(--panel-background);
 }
 

--- a/antora-ui-camel/src/css/toc.css
+++ b/antora-ui-camel/src/css/toc.css
@@ -1,14 +1,17 @@
-.toc-menu {
+.toc-menu,
+.toc-hugo {
   color: var(--toc-font-color);
 }
 
-.toc.sidebar .toc-menu {
+.toc.sidebar .toc-menu,
+.toc-sidebar .toc-hugo {
   margin-right: 0.75rem;
   position: sticky;
   top: var(--toc-top);
 }
 
-.toc .toc-menu h3 {
+.toc .toc-menu h3,
+.toc .toc-hugo h3 {
   color: var(--toc-heading-font-color);
   font-size: calc(16 / var(--rem-base) * 1rem);
   font-weight: var(--body-font-weight-bold);
@@ -17,14 +20,16 @@
   padding-bottom: 0.25rem;
 }
 
-.toc.sidebar .toc-menu h3 {
+.toc.sidebar .toc-menu h3,
+.toc-sidebar .toc-hugo h3 {
   display: flex;
   flex-direction: column;
   height: 2.5rem;
   justify-content: flex-end;
 }
 
-.toc .toc-menu ul {
+.toc .toc-menu ul,
+.toc .toc-hugo ul {
   font-size: calc(15 / var(--rem-base) * 1rem);
   line-height: var(--toc-line-height);
   list-style: none;
@@ -32,22 +37,40 @@
   padding: 0;
 }
 
-.toc.sidebar .toc-menu ul {
+.toc.sidebar .toc-menu ul,
+.toc-sidebar .toc-hugo ul {
   max-height: var(--toc-height);
   overflow-y: auto;
 }
 
+.toc .toc-hugo ul {
+  padding: 0 0 0 2rem;
+}
+
+.toc .toc-hugo ul:first-child {
+  padding: 0;
+  border-left: 2px solid var(--toc-border-color);
+}
+
+.toc .toc-hugo li ul:nth-child(1) {
+  padding-left: 0.25rem;
+  border-left: none;
+}
+
 @media screen and (min-width: 1024px) {
-  .toc .toc-menu h3 {
+  .toc .toc-menu h3,
+  .toc .toc-hugo h3 {
     font-size: calc(15 / var(--rem-base) * 1rem);
   }
 
-  .toc .toc-menu ul {
+  .toc .toc-menu ul,
+  .toc .toc-hugo ul {
     font-size: calc(13.5 / var(--rem-base) * 1rem);
   }
 }
 
-.toc .toc-menu li {
+.toc .toc-menu li,
+.toc .toc-hugo li {
   margin: 0;
 }
 
@@ -59,7 +82,8 @@
   padding-left: 2rem;
 }
 
-.toc .toc-menu a {
+.toc .toc-menu a,
+.toc .toc-hugo a {
   color: inherit;
   border-left: 2px solid var(--toc-border-color);
   display: inline-block;
@@ -67,12 +91,17 @@
   text-decoration: none;
 }
 
+.toc .toc-hugo a {
+  border-left: none;
+}
+
 .sidebar.toc .toc-menu a {
   display: block;
   outline: none;
 }
 
-.toc .toc-menu a:hover {
+.toc .toc-menu a:hover,
+.toc .toc-hugo a:hover {
   color: var(--link-font-color);
 }
 

--- a/antora-ui-camel/src/css/toc.css
+++ b/antora-ui-camel/src/css/toc.css
@@ -61,7 +61,7 @@
 }
 
 .toc .toc-menu li[data-level="2"] a,
-.toc .toc-hugo li[data-level="2"] a {
+.toc .toc-hugo ul li ul li ul li a {
   padding-left: 1.25rem;
 }
 

--- a/antora-ui-camel/src/css/toolbar.css
+++ b/antora-ui-camel/src/css/toolbar.css
@@ -12,7 +12,7 @@
   z-index: var(--z-index-toolbar);
 }
 
-.toolbar.hugo {
+.static.toolbar {
   box-shadow: none;
 }
 

--- a/antora-ui-camel/src/css/toolbar.css
+++ b/antora-ui-camel/src/css/toolbar.css
@@ -12,6 +12,10 @@
   z-index: var(--z-index-toolbar);
 }
 
+.toolbar.hugo {
+  box-shadow: none;
+}
+
 @media screen and (max-width: 1023px) {
   .toolbar {
     top: var(--navbar-mobile-height);

--- a/antora-ui-camel/src/js/98-hugo-on-this-page.js
+++ b/antora-ui-camel/src/js/98-hugo-on-this-page.js
@@ -1,21 +1,13 @@
 ;(function () {
   'use strict'
 
-  var parent
-  var child = []
-  var lastActiveLink = null
-  var selector = document.querySelector('.toolbar')
   var headings = Array.from(document.querySelectorAll('article.doc h1, article.doc h2, article.doc h3'))
   var links = Array.from(document.querySelectorAll('aside.toc-sidebar .toc-hugo a'))
-  var width = document.querySelector('.navbar').offsetWidth
-  var parentSelector = document.querySelectorAll('.toc-hugo li ul:first-child')
-
-  var topValMin = selector.getBoundingClientRect().top + selector.getBoundingClientRect().height - 5
-  var topValMax = topValMin + 20
-  var lastActiveFragment = headings[0]
-  var activeFragment = lastActiveFragment
-  var detectedFragment = false
-  var fragmentIndex = 0
+  var selectorRange = document.querySelector('.toolbar.hugo')
+  var minRange = selectorRange.getBoundingClientRect().top + selectorRange.getBoundingClientRect().height
+  var maxRange = minRange + 20
+  var prevLink = null
+  var activeFragment = null
 
   headings.some((heading, idx) => {
     if (heading.innerText === 'Contents') {
@@ -23,69 +15,36 @@
       return true
     }
   })
-  createDataLevel()
-  function createDataLevel () {
-    if (parentSelector) {
-      parent = (width < 1024) ? Array.from(parentSelector[0].children) : Array.from(parentSelector[1].children)
-      parent.forEach(function (subParent) {
-        var subParentSelector = subParent.querySelector('ul')
-        if (subParentSelector) child = Array.from(subParentSelector.children)
-        if (child.length >= 1) {
-          child.forEach(function (base) {
-            base.setAttribute('data-level', '2')
-          })
-        }
-      })
-    }
-  }
 
-  window.addEventListener('load', function () {
-    onScroll()
-    window.addEventListener('scroll', onScroll)
+  links.forEach((link) => {
+    link.addEventListener('click', function (e) {
+      if (prevLink !== null && prevLink !== link) prevLink.classList.remove('is-active')
+      e.stopPropagation()
+      link.classList.add('is-active')
+      prevLink = link
+    })
   })
 
-  function onScroll () {
-    headings.some((heading, idx) => {
-      detectedFragment = false
-      var topVal = Math.ceil(heading.getBoundingClientRect().top)
-      if (topVal >= topValMin && topVal <= topValMax) {
-        detectedFragment = true
-        lastActiveFragment = activeFragment
-        activeFragment = heading
-        fragmentIndex = idx
+  window.addEventListener('load', function () {
+    onscroll()
+    window.addEventListener('scroll', onscroll)
+  })
+
+  function onscroll () {
+    headings.some((heading) => {
+      var topVal = heading.getBoundingClientRect().top
+      if (topVal >= minRange && topVal <= maxRange) {
+        activeFragment = heading.id
         return true
       }
     })
-    if (!detectedFragment) {
-      if (Math.ceil(headings[fragmentIndex].getBoundingClientRect().top) > topValMax) {
-        if (fragmentIndex !== 0) {
-          lastActiveFragment = headings[fragmentIndex]
-          --fragmentIndex
-          activeFragment = headings[fragmentIndex]
-        }
-        fragmentIndex = headings.indexOf(activeFragment)
-      } else {
-        lastActiveFragment = activeFragment
+
+    links.forEach((link) => {
+      if (activeFragment !== null && link.href.toString().split('#')[1] === activeFragment) {
+        if (prevLink !== null && prevLink !== link) prevLink.classList.remove('is-active')
+        link.classList.add('is-active')
+        prevLink = link
       }
-    }
-    if (window.pageYOffset + window.innerHeight + 2 >= document.documentElement.scrollHeight) {
-      ++fragmentIndex
-      lastActiveFragment = activeFragment
-      activeFragment = headings[fragmentIndex]
-    }
-    if (fragmentIndex !== 0) {
-      links.some((link) => {
-        var linkId = link.href.toString().split('#')[1]
-        if (activeFragment.id === linkId) {
-          if (lastActiveLink !== null && lastActiveLink !== link) lastActiveLink.classList.remove('is-active')
-          lastActiveLink = link
-          link.classList.add('is-active')
-          return true
-        }
-      })
-    }
-    if (fragmentIndex === 0 && lastActiveLink !== null) {
-      lastActiveLink.classList.remove('is-active')
-    }
+    })
   }
 })()

--- a/antora-ui-camel/src/js/98-hugo-on-this-page.js
+++ b/antora-ui-camel/src/js/98-hugo-on-this-page.js
@@ -2,8 +2,8 @@
   'use strict'
 
   var headings = Array.from(document.querySelectorAll('article.doc h1, article.doc h2, article.doc h3'))
-  var links = Array.from(document.querySelectorAll('aside.toc-sidebar .toc-hugo a'))
-  var selectorRange = document.querySelector('.toolbar.hugo')
+  var links = Array.from(document.querySelectorAll('aside.toc-sidebar .toc-menu a'))
+  var selectorRange = document.querySelector('.static.toolbar')
   if (selectorRange) {
     var minRange = selectorRange.getBoundingClientRect().top + selectorRange.getBoundingClientRect().height - 5
     var maxRange = minRange + 25

--- a/antora-ui-camel/src/js/98-hugo-on-this-page.js
+++ b/antora-ui-camel/src/js/98-hugo-on-this-page.js
@@ -4,46 +4,55 @@
   var headings = Array.from(document.querySelectorAll('article.doc h1, article.doc h2, article.doc h3'))
   var links = Array.from(document.querySelectorAll('aside.toc-sidebar .toc-hugo a'))
   var selectorRange = document.querySelector('.toolbar.hugo')
-  var minRange = selectorRange.getBoundingClientRect().top + selectorRange.getBoundingClientRect().height
-  var maxRange = minRange + 20
-  var prevLink = null
-  var activeFragment = null
+  if (selectorRange) {
+    var minRange = selectorRange.getBoundingClientRect().top + selectorRange.getBoundingClientRect().height - 5
+    var maxRange = minRange + 25
+    var prevLink = null
+    var activeFragment = null
+    var fragmentIndex
 
-  headings.some((heading, idx) => {
-    if (heading.innerText === 'Contents') {
-      headings.splice(idx, 1)
-      return true
-    }
-  })
-
-  links.forEach((link) => {
-    link.addEventListener('click', function (e) {
-      if (prevLink !== null && prevLink !== link) prevLink.classList.remove('is-active')
-      e.stopPropagation()
-      link.classList.add('is-active')
-      prevLink = link
-    })
-  })
-
-  window.addEventListener('load', function () {
-    onscroll()
-    window.addEventListener('scroll', onscroll)
-  })
-
-  function onscroll () {
-    headings.some((heading) => {
-      var topVal = heading.getBoundingClientRect().top
-      if (topVal >= minRange && topVal <= maxRange) {
-        activeFragment = heading.id
+    headings.some((heading, idx) => {
+      if (heading.innerText === 'Contents') {
+        headings.splice(idx, 1)
         return true
       }
     })
 
-    links.forEach((link) => {
-      if (activeFragment !== null && link.href.toString().split('#')[1] === activeFragment) {
+    window.addEventListener('load', function () {
+      onscroll()
+      window.addEventListener('scroll', onscroll)
+    })
+  }
+
+  function onscroll () {
+    headings.some((heading, idx) => {
+      var topVal = Math.ceil(heading.getBoundingClientRect().top)
+      if (topVal >= minRange && topVal <= maxRange) {
+        activeFragment = heading
+        fragmentIndex = idx
+        return true
+      }
+      if (activeFragment !== null && topVal < minRange && topVal > activeFragment.getBoundingClientRect().top) {
+        activeFragment = heading
+        fragmentIndex = idx
+      }
+    })
+
+    if (activeFragment !== null && Math.ceil(headings[fragmentIndex].getBoundingClientRect().top) > maxRange) {
+      --fragmentIndex
+      activeFragment = headings[fragmentIndex]
+      if (fragmentIndex === -1) {
+        activeFragment = null
+      }
+    }
+    links.some((link) => {
+      if (activeFragment != null && activeFragment.id === link.href.toString().split('#')[1]) {
         if (prevLink !== null && prevLink !== link) prevLink.classList.remove('is-active')
         link.classList.add('is-active')
         prevLink = link
+      }
+      if ((activeFragment === null || fragmentIndex === 0) && prevLink !== null) {
+        prevLink.classList.remove('is-active')
       }
     })
   }

--- a/antora-ui-camel/src/js/98-hugo-on-this-page.js
+++ b/antora-ui-camel/src/js/98-hugo-on-this-page.js
@@ -1,0 +1,91 @@
+;(function () {
+  'use strict'
+
+  var parent
+  var child = []
+  var lastActiveLink = null
+  var selector = document.querySelector('.toolbar')
+  var headings = Array.from(document.querySelectorAll('article.doc h1, article.doc h2, article.doc h3'))
+  var links = Array.from(document.querySelectorAll('aside.toc-sidebar .toc-hugo a'))
+  var width = document.querySelector('.navbar').offsetWidth
+  var parentSelector = document.querySelectorAll('.toc-hugo li ul:first-child')
+
+  var topValMin = selector.getBoundingClientRect().top + selector.getBoundingClientRect().height - 5
+  var topValMax = topValMin + 20
+  var lastActiveFragment = headings[0]
+  var activeFragment = lastActiveFragment
+  var detectedFragment = false
+  var fragmentIndex = 0
+
+  headings.some((heading, idx) => {
+    if (heading.innerText === 'Contents') {
+      headings.splice(idx, 1)
+      return true
+    }
+  })
+  createDataLevel()
+  function createDataLevel () {
+    if (parentSelector) {
+      parent = (width < 1024) ? Array.from(parentSelector[0].children) : Array.from(parentSelector[1].children)
+      parent.forEach(function (subParent) {
+        var subParentSelector = subParent.querySelector('ul')
+        if (subParentSelector) child = Array.from(subParentSelector.children)
+        if (child.length >= 1) {
+          child.forEach(function (base) {
+            base.setAttribute('data-level', '2')
+          })
+        }
+      })
+    }
+  }
+
+  window.addEventListener('load', function () {
+    onScroll()
+    window.addEventListener('scroll', onScroll)
+  })
+
+  function onScroll () {
+    headings.some((heading, idx) => {
+      detectedFragment = false
+      var topVal = Math.ceil(heading.getBoundingClientRect().top)
+      if (topVal >= topValMin && topVal <= topValMax) {
+        detectedFragment = true
+        lastActiveFragment = activeFragment
+        activeFragment = heading
+        fragmentIndex = idx
+        return true
+      }
+    })
+    if (!detectedFragment) {
+      if (Math.ceil(headings[fragmentIndex].getBoundingClientRect().top) > topValMax) {
+        if (fragmentIndex !== 0) {
+          lastActiveFragment = headings[fragmentIndex]
+          --fragmentIndex
+          activeFragment = headings[fragmentIndex]
+        }
+        fragmentIndex = headings.indexOf(activeFragment)
+      } else {
+        lastActiveFragment = activeFragment
+      }
+    }
+    if (window.pageYOffset + window.innerHeight + 2 >= document.documentElement.scrollHeight) {
+      ++fragmentIndex
+      lastActiveFragment = activeFragment
+      activeFragment = headings[fragmentIndex]
+    }
+    if (fragmentIndex !== 0) {
+      links.some((link) => {
+        var linkId = link.href.toString().split('#')[1]
+        if (activeFragment.id === linkId) {
+          if (lastActiveLink !== null && lastActiveLink !== link) lastActiveLink.classList.remove('is-active')
+          lastActiveLink = link
+          link.classList.add('is-active')
+          return true
+        }
+      })
+    }
+    if (fragmentIndex === 0 && lastActiveLink !== null) {
+      lastActiveLink.classList.remove('is-active')
+    }
+  }
+})()

--- a/content/community/articles.md
+++ b/content/community/articles.md
@@ -2,7 +2,7 @@
 title: "Articles"
 ---
 
-### Camel Videos
+## Camel Videos
 
 *   [Camel 3 : Integration in the Kubernetes and Serverless era | BarcelonaJUG](https://www.crowdcast.io/e/camel-3--integration-in/1) - 90 min webinar from July 2020, by Claus and Andrea giving overview of Camel 3, and focusing on the most exicing innovations with CamelK, Camel Quarkus and Camel Kafka Connector with live demos, and QA at the end.
 *   [Event-driven serverless applications with Camel K | DevNation Tech Talk](https://www.youtube.com/watch?v=hlUzLC71nAM) - 40 min video from July 2020, by Luca and Nicola presenting Camel K and how Camel fits in the event driven & serverless world with a live demo that shows this all together. 
@@ -44,11 +44,11 @@ title: "Articles"
 *   [Videos de las charlas de la 9a reunión de JavaMexico (**Spanish**)](http://www.springhispano.org/?q=node/564) _by Domingo Suarez_
 
 
-### Articles
+## Articles
 
 Articles are divided into several sections. As the lists grow, further sectioning refinements may be necessary.
 
-#### General Articles
+### General Articles
 
 *   [Open Source Integration with Apache Camel](http://java.dzone.com/articles/open-source-integration-apache) _by Jonathan Anstey_
 *   [Tutorial: Integrating with Apache Camel](https://jaxenter.com/tutorial-integrating-with-apache-camel-106759.html) _by_ _[Charles Moulliard](https://twitter.com/cmoulliard)_
@@ -176,11 +176,11 @@ These examples show usage of several different components and other concepts suc
 *   [Enterprise integration for Ethereum](https://medium.com/@bibryam/enterprise-integration-for-ethereum-fa67a1577d43) from July 2018 by Bilgin Ibryam explains the Ethereum eco-system and where you can use Camel with the bit-coin and block-chain technologies.
 *   [Camel Aggregation Strategies](http://blog.joshdreagan.com/2018/08/30/camel_aggregation_strategies/) from August 2018 by Josh Reagan whom blogs about how to aggregate data using Camel's AggregationStrategy when using EIPs such as Content Enricher, Splitter or the Aggregator. 
 
-#### Camel K
+### Camel K
 
 * [Why Camel K](https://dzone.com/articles/why-camel-k) by Saravanakumar Selvaraj from June 2020 where he briefly hightlights 5 key elements of Camel K 
 
-#### Tooling / Combination with other Products
+### Tooling / Combination with other Products
 
 These examples show Camel combined with several tools (e.g. IDE), ESBs, Application Services, and other middleware products such as messaging or OSGi container.
 
@@ -231,7 +231,7 @@ These examples show Camel combined with several tools (e.g. IDE), ESBs, Applicat
 *   [Using Jaeger to trace an Apache Camel application](https://medium.com/jaegertracing/using-jaeger-to-trace-an-apache-camel-application-2b8118efbb4d) (August 2018) blog post from Gary Brown showing how to use camel-opentracing and Jaeger to do distributed traces and visualize them in Jaeger UI.
 *   [Quick Integration with Apache Camel and IBM MQ](https://dzone.com/articles/quickly-integrate-apache-camel-and-ibm-mq) article from May 2020 by Chandra Shekhar Pandey showing how to use Apache Camel running on Spring Boot to integrate with IBM MQ and testing it with Docker containers.
 
-#### Camel and Groovy
+### Camel and Groovy
 
 *   [A Groovy ride on Camel](http://groovy.dzone.com/articles/groovy-ride-camel) _by Jack Hung_ (December 2009)
 *   [Using Groovy and Camel to pool Google Analyst email reports](http://mrhaki.blogspot.com/2009/04/handle-google-analytics-scheduled-e.html) _by Mr. Haki_ (April 2009)
@@ -239,7 +239,7 @@ These examples show Camel combined with several tools (e.g. IDE), ESBs, Applicat
 *   [Send mail with Apache Camel from Grails](http://mrhaki.blogspot.com/2009/04/send-mail-with-apache-camel-from-grails.html) _by Mr. Haki_ (April 2009)
 *   [Groovy and Grape - easiest way to send gtalk message with Apache Camel](http://www.andrejkoelewijn.com/blog/2009/02/28/groovy-and-grape-easiest-way-to-send-gtalk-message-with-apache-camel/) _by Andrej Koelewijn_ (February 2009)
 
-#### Camel and Scala
+### Camel and Scala
 
 *   [Interview with Martin Krasser about camel-scalaz](http://jaxenter.com/scalaz-camel-fully-leveraging-what-scala-and-scalaz-offers-for-functional-programming-34717.html) from Jaxcenter. Scalaz-Camel: fully leveraging 'what Scala and Scalaz offers for functional programming.'
 *   [Apache Camel and Scala](http://www.kai-waehner.de/blog/2011/06/23/apache-camel-and-scala-a-powerful-combination/): A powerful Combination _by Kai Wähner_
@@ -249,11 +249,11 @@ These examples show Camel combined with several tools (e.g. IDE), ESBs, Applicat
 *   [Apache Camel with Scala testing styles](http://siliconsenthil.in/blog/2013/07/07/apache-camel-with-scala-testing-styles/) - A blog post on different approaches of camel testing with ScalaTest.
 *   [Apache Camel with Scala: Extending DSL](http://siliconsenthil.in/blog/2013/07/11/apache-camel-with-scala-extending-dsl/) - A blog post extending the Camel Scala DSL
 
-#### Camel and Clojure
+### Camel and Clojure
 
 *   [Using Apache Camel from Clojure](http://codeabout.blogspot.com/2010/06/using-apache-camel-from-clojure.html)_by Jason Whitlark_ (June 2010)
 
-#### Camel and the IoT (Internet of Things)
+### Camel and the IoT (Internet of Things)
 
 *   [Make Your IoT Gateway WiFi-Aware Using Camel and Kura](http://java.dzone.com/articles/make-your-iot-gateway-wifi) - DZone article by Henryk Konsek (2015)
 *   [IoT gateway dream team - Eclipse Kura and Apache Camel](http://www.slideshare.net/hekonsek/io-t-gateway-dream-team-eclipse-kura-and-apache-camel) - slides from the Henryk Konsek talk for Eclipse IoT Virtual Meetup (2015)
@@ -264,13 +264,13 @@ These examples show Camel combined with several tools (e.g. IDE), ESBs, Applicat
 *   [Open Source IoT Gateway: A Tale Of Eclipse Kura, Apache Camel, And Rhiot](https://www.youtube.com/watch?v=DPiD7bnnaJk) - video from the Henryk Konsek talk at DevNation 2016.
 *   [Getting started with Apache Camel and Internet of Things](https://developers.redhat.com/blog/2016/11/17/getting-started-with-apache-camel-and-the-internet-of-things/) - article from Joseph Butler from February 2017.
 
-#### Camel and Microservices/Cloud
+### Camel and Microservices/Cloud
 
 *   [A Camel running in the Clouds (Part 2)](https://www.linkedin.com/redir/redirect?url=https%3A%2F%2Flburgazzoli%2Egithub%2Eio%2F2017%2F04%2F12%2FA-camel-running-in-the-clouds-part-2%2Ehtml&urlhash=JHUN&_t=tracking_anet) by Luca Burgazzoli (April 2017)
 
 *   [A Camel running in the Clouds](https://lburgazzoli.github.io/2016/12/21/A-camel-running-in-the-clouds.html) by Luca Burgazzoli (December 2016)
 
-#### Comparison to Camel's Competitors
+### Comparison to Camel's Competitors
 
 *   [Apache Camel and other ESBs (Camel vs Mule)](https://stackoverflow.com/questions/3792519/apache-camel-and-other-esb-products) - A question on Stackoverflow originally from 2010 but with a great showcase of what is the status 5 years later according to [Raul's answer](https://stackoverflow.com/questions/3792519/apache-camel-and-other-esb-products/34818263#34818263), and [follow up comments from Claus](http://www.davsclaus.com/2016/01/apache-camel-and-other-esb-products.html).
 *   [Mule vs Spring Integration vs Apache Camel compared by Black Duck Open Hub](http://www.davsclaus.com/2015/12/mule-vs-spring-integration-vs-apache.html) - by Clays Ibsen (December 2015) - How to use Open Hub to compare these projects side by side.
@@ -282,7 +282,7 @@ These examples show Camel combined with several tools (e.g. IDE), ESBs, Applicat
 *   [Spring Integration and Apache Camel](http://java.dzone.com/articles/spring-integration-and-apache) _by Biju Kunjummen_ (December 2009)
 *   [Apache Camel alternatives](http://hillert.blogspot.com/2009/10/apache-camel-alternatives.html) _by Gunnar Hillert_ (October 2009)
 
-### Presentations on Apache Camel
+## Presentations on Apache Camel
 
 *   [Implementing Enterprise Integration Patterns with Apache Camel](http://alt.java-forum-stuttgart.de/jfs/2008/folien/E3.pdf) presentation _by Eduard Hildebrandt_
 *   [Dead Simple Integration with Apache Camel](https://chariotsolutions.com/presentation/dead-simple-integration-with-apache-camel/) _by Aaron Mulder_
@@ -306,7 +306,7 @@ These examples show Camel combined with several tools (e.g. IDE), ESBs, Applicat
 *   [The Forgotten Route: Making Apache Camel Work for You](https://www.youtube.com/watch?v=7r183fGwllg&feature=youtu.be) - Video from ApacheCon 2017 presented by John Saboe. Apache Camel is eight years old, and some say it's effectiveness as the glue between components has diminished. John Saboe says, "Not so!"
 *   [Integrating Applications: The Reactive Way](https://www.youtube.com/watch?v=1JtdUhLf5pE) - Video from JBCNConf presented by Nicola Ferraro. 
 
-### Podcasts
+## Podcasts
 
 *   [James Strachan](http://macstrac.blogspot.com/) was [interviewed](http://briefingsdirect.blogspot.com/2007/08/apache-camel-addresses-need-for.html) _by_ _[Dana Gardner](http://www.zoominfo.com/Search/PersonDetail.aspx?PersonID=338181&QueryID=0b37845a-9e13-492a-92e6-7ac8ac9707b7)_
 *   [Episode 35 - A few beers with Chariot's Open Source Integration Experts](http://techcast.chariotsolutions.com/index.php?post_id=503319) - Chariot TechCast Episode 35 where they talk about: ServiceMix, Camel, FUSE, Mule, Spring Integration, EIP, ESB etc.
@@ -317,7 +317,7 @@ These examples show Camel combined with several tools (e.g. IDE), ESBs, Applicat
 *   [JBoss Asylum #47 - What do you call a Camel with 3 humps](https://asylum.libsyn.com/podcast-46-what-do-you-call-a-camel-with-3-humps) Claus Ibsen and Luca Burgazzoli sits down and talk about what is coming in Camel 3 on topics like Camel K and Camel Quarkus.
 
 
-### [Books](/community/books/)
+## Books
 
 *   Camel Design Patterns by Bilgin Ibryam (LeanPub, January 2016)
 *   Apache Camel Developer's Cookbook _by Scott Cranton and Jakub Korab_ (Packt Publishing, December 2013)
@@ -326,7 +326,7 @@ These examples show Camel combined with several tools (e.g. IDE), ESBs, Applicat
 *   Camel in Action _by Claus Ibsen and Jonathan Anstey_ (Manning, December 2010)
 *   Enterprise Integration Patterns _by Gregor Hohpe and Bobby Woolf_ (Addison Wesley, October 2003)
 
-### Online Training
+## Online Training
 
 *   [Introduction to Apache Camel](http://www.pluralsight.com/courses/apache-camel-intro-integration) - Pluralsight o<span style="color: rgb(34,34,34);">nline <span style="color: rgb(34,34,34);">training course covering the core Camel framework, pattern implementations <span style="color: rgb(34,34,34);">and [hawt.io](http://hawt.io/) 
 *   [Apache Camel Video Tutorial](http://www.nvisia.com/apache-camel-video-tutorial) - A 3 part video series that introduces you to Apache Camel, covers an use-case, and then highlights why you should use Camel.
@@ -334,7 +334,7 @@ These examples show Camel combined with several tools (e.g. IDE), ESBs, Applicat
 *   [Udemy Training: Apache Camel for Beginners - Learn by Coding in Java](https://www.udemy.com/apache-camel-for-beginners-learn-by-coding-in-java/) - Learn Apache Camel framework by coding it in Java. This is purely a coding course where you will be performing ton of code throughout the course. This course will cover integrations with Kafka, Active MQ, Postgres SQL , Rest WebServices and etc.
 *   [Max Munus](http://www.maxmunus.com/page/Apache-Camel) - Provides online training to many different technologies. They provide online training for Apache Camel.
 
-### Other
+## Other
 
 *   [Linkedin Apache Camel group](http://www.linkedin.com/groups?mostPopular=&gid=2447439) - Linkedin group for the Apache Camel project.
 *   [EIP printable flashcards studylib](https://studylib.net/doc/8175313/enterprise-integration-patterns-flashcards), [EIP printable flashcards nanopdf](https://nanopdf.com/download/enterprise-integration-patterns-flashcards_pdf), [EIP printable flashcards docplayer](https://docplayer.net/46191198-Enterprise-integration-patterns-flashcards.html) - A 6 page PDF with printable EIP cards.
@@ -345,7 +345,7 @@ These examples show Camel combined with several tools (e.g. IDE), ESBs, Applicat
 *   The Apache Camel Components Poster ([PDF](https://pdfslide.net/documents/apache-camel-components.html) _by Gliesian LLC._ (October, 2013)
 *   [TrustRadius Apache Camel Reviews](https://www.trustradius.com/products/apache-camel/reviews) - Reviews and ratings from Camel end users on the TrustRadius website. 
 
-### Blogs
+## Blogs
 
 *   [Ashwin Karpe's Blog (OpenSourceKnowledge)](http://opensourceknowledge.blogspot.com/) - Ashwin is a Camel committer and writes about Camel.
 *   [Ben O'Day's Blog](http://benoday.blogspot.com/) - Ben works in the field and sometimes blogs about Camel
@@ -366,14 +366,14 @@ These examples show Camel combined with several tools (e.g. IDE), ESBs, Applicat
 *   [Souciance Eqdam Rashti](https://soucianceeqdamrashti.wordpress.com/) - Blogs about integration and Apache Camel in English. 
 *   [Mastertheboss](http://www.mastertheboss.com) - Contains several tutorials for Camel 2 and 3 in English. 
 
-### Twitterers
+## Twitterers
 
 *   [@davsclaus](http://twitter.com/#!/davsclaus) - Claus Ibsen ([@davsclaus](http://twitter.com/#!/davsclaus)) tweets often about Camel, open source, and integration.
 *   [@bibryam](http://twitter.com/#!/bibryam) - Bilgin Ibryam ([@bibryam](http://twitter.com/#!/bibryam)) tweets often about Camel.
 *   [@jstrachan](https://twitter.com/jstrachan) - James Strachan ([@jstrachan](https://twitter.com/jstrachan)) tweets about Camel, open source and integration.
 *   [@hekonsek](https://twitter.com/hekonsek) - Henryk Konsek ([@hekonsek](https://twitter.com/hekonsek)) tweets about Camel and the Internet Of Things
 
-### Non-English
+## Non-English
 
 *   [Java integration frameworks - Spring Integration vs. Apache Camel](http://www.journaldunet.com/developpeur/java-j2ee/spring-integration-vs-apache-camel/) Article from April 2010 which compares the two frameworks (**in french**).
 *   [3 Articles about Apache Camel to push notifications to Apple devices (in French)](http://blog.xebia.fr/2010/09/30/creer-un-composant-apache-camel-de-connexion-a-lapns-1-sur-3/) _by Alexis Kinsella_

--- a/content/community/team.md
+++ b/content/community/team.md
@@ -4,7 +4,7 @@ title: "Team"
 
 This page lists who we are. By all means add yourself to the list - lets sort it in alphabetical order
 
-# Committers
+## Committers
 
 When posting to the mailing lists, use plain text mails. Do not use HTML mails. HTML mails is more likely to be targeted as spam mails and will be rejected; as well it's not easily readable by others.
 
@@ -73,7 +73,7 @@ When posting to the mailing lists, use plain text mails. Do not use HTML mails. 
 | Zoran Regvart          | zregvart         | Red Hat                    |
 {{< /table >}}
 
-## Contributors
+### Contributors
 
 Adding your name to the list below.
 

--- a/content/community/user-stories.md
+++ b/content/community/user-stories.md
@@ -66,6 +66,7 @@ This page is intended as a place to collect user stories and feedback on Apache 
 |[Camel Extra project](https://camel-extra.github.io/)|contains a number of extension components which due to GPL/LGPL licensing cannot be hosted at Apache.
 {{< /table >}}
 
+## User Groups
 
 {{< table >}}
 | User Groups  | Description |
@@ -77,6 +78,7 @@ This page is intended as a place to collect user stories and feedback on Apache 
 |[Apache Camel User Group Japan](https://jcug-oss.github.io/)|A Japanese user group for Apache Camel.|
 {{< /table >}}
 
+## External Camel Components
 
 {{< table >}}
 | External Camel Components  | Description |

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -2,14 +2,14 @@
 
 <div class="body">
     <main role="main">
-        <div class="toolbar hugo"></div>
+        <div class="static toolbar"></div>
         <div class="content">
             <article class="static doc {{ .Page.Section }}">
                 {{ with .Title }}
                 <h1>{{ . }} </h1>
                 {{ end }}
                 <aside class="toc embedded">
-                    <div class="toc-hugo">
+                    <div class="toc-menu">
                         <h3>Contents</h3>
                         {{ .TableOfContents }}
                     </div>
@@ -17,7 +17,7 @@
                 {{ .Content }}
             </article>
             <aside class="toc toc-sidebar">
-                <div class="toc-hugo">
+                <div class="toc-menu">
                     <h3>Contents</h3>
                     {{ .TableOfContents }}
                 </div>

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -2,15 +2,26 @@
 
 <div class="body">
     <main role="main">
-        <article class="static doc {{ .Page.Section }}">
-
-            {{ with .Title }}
+        <div class="content">
+            <article class="static doc {{ .Page.Section }}">
+                {{ with .Title }}
                 <h1>{{ . }} </h1>
-            {{ end }}
-
-{{ .Content }}
-
-        </article>
+                {{ end }}
+                <aside class="toc embedded">
+                    <div class="toc-hugo">
+                        <h3>Contents</h3>
+                        {{ .TableOfContents }}
+                    </div>
+                </aside>
+                {{ .Content }}
+            </article>
+            <aside class="toc toc-sidebar">
+                <div class="toc-hugo">
+                    <h3>Contents</h3>
+                    {{ .TableOfContents }}
+                </div>
+            </aside>
+        </div>
     </main>
 </div>
 

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -2,6 +2,7 @@
 
 <div class="body">
     <main role="main">
+        <div class="toolbar hugo"></div>
         <div class="content">
             <article class="static doc {{ .Page.Section }}">
                 {{ with .Title }}


### PR DESCRIPTION
### Motive for building Hugo toc
For the apache camel website, the antora pages have a toc generated which will help in easing the user navigation. Thus, for the Hugo pages, toc should be implemented. 

### DIfference between toc of Antora and Hugo 
The manner in which the toc of Antora and Hugo is structured is completed different. To trigger the toc for Hugo, one code of line needs to be inserted i.e `{{ TableOfContents }}` however I wanted the UI implementation of both Antora and Hugo to be the same.
In Hugo, the manner in which toc is created is just a nested loop of `ul` and `li` but in the case of Antora, it's a proper structure with defined levels where `##`  would signify `data-level: 2` and `###` would signify `data-level:3`. This wasn't the case of Hugo. 

Thus, my first implementation within the **js** file was to create the data levels.

### Problems faced while implementing fragment jumping of links and also based on scrolling. 
The `scroll` event function that is implemented for antora in the `on-this-page.js` can't be used for the Hugo as their structures are completely different as stated before. Hence, I have implemented my own logic similar to that of antora for the scroll and fragment jumping and it works. 

#### Drawbacks to my implementation currently

In my implementation, the fragment jumping works smoothly when done through the keyboard however when using a scrollbar, it shows odd behavior on scrolling down in some cases. 

![toc-content-hugo](https://user-images.githubusercontent.com/44139348/89124527-66809400-d4f5-11ea-99f9-77806e1984f4.gif)
