### PR TITLE
CAMEL-15296:  Create sitemap for Camel website

### DIFF
--- a/antora-ui-camel/src/css/site.css
+++ b/antora-ui-camel/src/css/site.css
@@ -23,3 +23,4 @@
 @import 'misc.css';
 @import 'community.css';
 @import 'docs.css';
+@import 'sitemap.css';

--- a/antora-ui-camel/src/css/sitemap.css
+++ b/antora-ui-camel/src/css/sitemap.css
@@ -1,0 +1,18 @@
+.sitemap h1 {
+  text-align: center;
+}
+
+.sitemap ul.sitemap-list {
+  list-style-type: none;
+  -webkit-columns: 2;
+  -moz-columns: 2;
+  columns: 2;
+  padding: 0;
+  column-gap: 25%;
+}
+
+@media screen and (max-width: 626px) {
+  .sitemap ul.sitemap-list {
+    columns: 1;
+  }
+}

--- a/antora-ui-camel/src/css/sitemap.css
+++ b/antora-ui-camel/src/css/sitemap.css
@@ -9,6 +9,7 @@
   columns: 2;
   padding: 0;
   column-gap: 25%;
+  white-space: nowrap;
 }
 
 @media screen and (max-width: 626px) {

--- a/antora-ui-camel/src/partials/footer-content.hbs
+++ b/antora-ui-camel/src/partials/footer-content.hbs
@@ -61,6 +61,9 @@
                 <div class="context">
                     <a target="_blank" rel="noopener noreferrer nofollow" href="https://www.apache.org/foundation/policies/conduct">Code of Conduct</a>
                 </div>
+                <div class="context">
+                    <a href="{{siteRootPath}}/sitemap/">Sitemap</a>
+                </div>
             </div>
             <div class="footer-icons">
                 <a rel="noopener noreferrer nofollow" href="https://github.com/apache/camel/" title="Collaborate on GitHub"><svg class="brand-icon"><use xlink:href="{{uiRootPath}}/img/brand-logos.svg#github" /></svg></a>

--- a/content/community/_index.md
+++ b/content/community/_index.md
@@ -1,4 +1,5 @@
 ---
+Title: "Community"
 ---
 
 {{< div "section" >}}

--- a/content/docs/_index.md
+++ b/content/docs/_index.md
@@ -1,4 +1,5 @@
 ---
+Title: "Documentation"
 ---
 
 {{< div "camel-project" >}}

--- a/content/misc/_index.md
+++ b/content/misc/_index.md
@@ -1,0 +1,4 @@
+---
+title: "Miscellaneous"
+---
+The Apache Software Foundation (ASF) is an open source project organized under the auspices of a public benefit corporation. You can find terms of use of this website under [Privacy Policy]("/privacy-policy"). You can read more about organisations that helped Camel under [Acknowledgements](/acknowledgements).

--- a/content/releases/_index.md
+++ b/content/releases/_index.md
@@ -1,5 +1,5 @@
 ---
-title: "Apache Camel Releases"
+title: "Releases"
 ---
 
 # Apache Camel releases archive

--- a/content/security/_index.md
+++ b/content/security/_index.md
@@ -1,5 +1,5 @@
 ---
-title: "Apache Camel security information"
+title: "Security"
 ---
 
 # Apache Camel security information

--- a/content/sitemap/_index.md
+++ b/content/sitemap/_index.md
@@ -1,3 +1,3 @@
 ---
-title: "Camel Website Sitemap"
+title: "Sitemap"
 ---

--- a/content/sitemap/_index.md
+++ b/content/sitemap/_index.md
@@ -1,0 +1,3 @@
+---
+title: "Camel Website Sitemap"
+---

--- a/layouts/download/download.html
+++ b/layouts/download/download.html
@@ -2,7 +2,7 @@
 
 <div class="body">
     <main role="main">
-        <article class="static doc">
+        <article class="static doc docs">
             <h1>{{ .Title }}</h1>
 
             <h2>Latest releases</h2>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -67,6 +67,9 @@
                 <div class="context">
                     <a target="_blank" rel="noopener noreferrer nofollow" href="https://www.apache.org/foundation/policies/conduct">Code of Conduct</a>
                 </div>
+                <div class="context">
+                    <a href="/sitemap/">Sitemap</a>
+                </div>
             </div>
             <div class="footer-icons">
                 <a rel="noopener noreferrer nofollow" href="https://github.com/apache/camel/" title="Collaborate on GitHub"><svg class="brand-icon"><use href="{{ "_/img/brand-logos.svg#github" | relURL }}" /></svg></a>

--- a/layouts/sitemap/sitemap.html
+++ b/layouts/sitemap/sitemap.html
@@ -3,7 +3,7 @@
 <div class="body">
     <main class="article">
         <div class="content">
-            <article class="doc static sitemap"> 
+            <article class="static doc sitemap"> 
                 <h1 class="page">{{ .Title }} </h1>
                 <a href="/"><h2>Overview</h2></a>
                 <ul class="sitemap-list">
@@ -13,16 +13,15 @@
                         <li><a href = "{{ .Permalink }}" >{{.Title}}</a></li>
                         {{end}}
                     {{ end }}
-                    <li><a href = "/community/">Community</a></li>
                 </ul>
                 <a href="/docs/"><h2>Documentation</h2></a>
                 <ul class="sitemap-list">
                     <li><a href = "/manual/latest/getting-started.html">Getting Started</a></li>
                     <li><a href = "/manual/latest/">User Manual</a></li>
-                    <li><a href = "/manual/latest/faq/">FAQ</a></li>
+                    <li><a href = "/manual/latest/faq/">Frequently Asked Questions</a></li>
                     <li><a href = "/components/latest/">Component Reference</a></li>
                     <li><a href = "/components/latest/dataformats/">Data Formats</a></li>
-                    <li><a href = "/components/latest/eips/enterprise-integration-patterns.html">EIP</a></li>
+                    <li><a href = "/components/latest/eips/enterprise-integration-patterns.html">Enterprise Integration Patterns</a></li>
                 </ul>
                 <a href="/docs/"><h2>Sub Projects</h2></a>
                 <ul class="sitemap-list">

--- a/layouts/sitemap/sitemap.html
+++ b/layouts/sitemap/sitemap.html
@@ -1,0 +1,41 @@
+{{ partial "header.html" . }}
+
+<div class="body">
+    <main class="article">
+        <div class="content">
+            <article class="doc static sitemap"> 
+                <h1 class="page">{{ .Title }} </h1>
+                <a href="/"><h2>Overview</h2></a>
+                <ul class="sitemap-list">
+                    {{ $currentPage := .Permalink }}
+                    {{ range .Site.Sections }}
+                        {{ if not (eq $currentPage .Permalink) }} 
+                        <li><a href = "{{ .Permalink }}" >{{.Title}}</a></li>
+                        {{end}}
+                    {{ end }}
+                    <li><a href = "/community/">Community</a></li>
+                </ul>
+                <a href="/docs/"><h2>Documentation</h2></a>
+                <ul class="sitemap-list">
+                    <li><a href = "/manual/latest/getting-started.html">Getting Started</a></li>
+                    <li><a href = "/manual/latest/">User Manual</a></li>
+                    <li><a href = "/manual/latest/faq/">FAQ</a></li>
+                    <li><a href = "/components/latest/">Component Reference</a></li>
+                    <li><a href = "/components/latest/dataformats/">Data Formats</a></li>
+                    <li><a href = "/components/latest/eips/enterprise-integration-patterns.html">EIP</a></li>
+                </ul>
+                <a href="/docs/"><h2>Sub Projects</h2></a>
+                <ul class="sitemap-list">
+                    <li><a href = "/manual/latest/">Camel Core</a></li>
+                    <li><a href = "/camel-k/latest/">Camel K</a></li>
+                    <li><a href = "/camel-quarkus/latest/">Camel Quarkus</a></li>
+                    <li><a href = "/camel-spring-boot/latest/">Camel Spring Boot</a></li>
+                    <li><a href = "/camel-kafka-connector/latest/">Camel Kafka Connector</a></li>
+                    <li><a href = "/camel-karaf/latest/">Camel Karaf</a></li>
+                </ul>
+            </article>
+        </div>
+    </main>
+</div>
+
+{{ partial "footer.html" . }}


### PR DESCRIPTION
This PR adds the first version of sitemap for camel-website. Sitemap can be accessed from the footer. The problem with fetching links programmatically is that links like "misc" and "news" show up, even though they don't have any landing pages. We could choose to hard code all our links instead to avoid such behavior.