### PR TITLE
fix: toc for hugo within mobile view

### DIFF
--- a/antora-ui-camel/src/css/toc.css
+++ b/antora-ui-camel/src/css/toc.css
@@ -55,6 +55,12 @@
   padding-left: 1.25rem;
 }
 
+@media screen and (max-width: 1023px) {
+  .toc .toc-menu ul li ul li ul li a {
+    padding-left: 1.25rem;
+  }
+}
+
 .toc .toc-menu li[data-level="3"] a {
   padding-left: 2rem;
 }

--- a/antora-ui-camel/src/css/toolbar.css
+++ b/antora-ui-camel/src/css/toolbar.css
@@ -12,6 +12,12 @@
   z-index: var(--z-index-toolbar);
 }
 
+.static.toolbar {
+  box-shadow: none;
+  margin: 0;
+  max-width: 100vw;
+}
+
 @media screen and (max-width: 1023px) {
   .toolbar {
     top: var(--navbar-mobile-height);

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -2,6 +2,7 @@
 
 <div class="body">
     <main role="main">
+        <div class="static toolbar"></div>
         <div class="content">
             <article class="static doc {{ .Page.Section }}">
                 {{ with .Title }}


### PR DESCRIPTION
The fragment jumping within the mobile screen doesn't work as expected. On click of the link within the toc, it lands to the paragraph for the particular link and not the heading. The reason is that the fragment jumping for the toc is done with respect to the toolbar. Thus, I incorporated the toolbar to have proper fragment jumping.

Another issue is that, within the smaller screen width ( < 1023px ), the toc isn't indexed as per the `data-level`. Thus, I made a possible modification to sort this out.