### PR TITLE
CAMEL-15421: render of AsciiDoc admonitions for Antora

### DIFF
--- a/antora-ui-camel/src/css/doc.css
+++ b/antora-ui-camel/src/css/doc.css
@@ -313,7 +313,7 @@
 }
 
 .doc .admonitionblock .icon {
-  position: absolute;
+  position: relative;
   top: 0;
   left: 0;
   font-size: calc(15 / var(--rem-base) * 1rem);
@@ -322,8 +322,7 @@
   line-height: 1;
   font-weight: var(--admonition-label-font-weight);
   text-transform: uppercase;
-  border-radius: 0.45rem;
-  transform: translate(-0.5rem, -50%);
+  border-radius: 0 0.45rem 0.45rem 0;
 }
 
 .doc .admonitionblock.caution .icon {
@@ -360,6 +359,7 @@
 .doc .admonitionblock .icon i::after {
   content: attr(title);
   hyphens: none;
+  writing-mode: tb-rl;
 }
 
 .doc .imageblock {

--- a/antora-ui-camel/src/css/doc.css
+++ b/antora-ui-camel/src/css/doc.css
@@ -322,7 +322,6 @@
   line-height: 1;
   font-weight: var(--admonition-label-font-weight);
   text-transform: uppercase;
-  border-radius: 0 0.45rem 0.45rem 0;
 }
 
 .doc .admonitionblock.caution .icon {

--- a/antora-ui-camel/src/css/vars.css
+++ b/antora-ui-camel/src/css/vars.css
@@ -83,7 +83,7 @@
   --important-on-color: var(--color-white);
   --note-color: #217ee7;
   --note-on-color: var(--color-white);
-  --tip-color: #41af46;
+  --tip-color: #4d4fb7;
   --tip-on-color: var(--color-white);
   --warning-color: #e18114;
   --warning-on-color: var(--color-white);


### PR DESCRIPTION
The AsciiDoc admonitions weren't being rendered on the antora pages. Hence, I made a few tweaks to the CSS for the admonitions to be rendered. 

![admonition-block-antora](https://user-images.githubusercontent.com/44139348/90519558-d2196100-e185-11ea-808f-b6b0e7c96be3.png)
