### PR TITLE
fix: justify button to center

### DIFF
--- a/antora-ui-camel/src/css/docs.css
+++ b/antora-ui-camel/src/css/docs.css
@@ -33,7 +33,7 @@
 }
 
 .camel-project .camel-documentation .links {
-  background-color: var(--color-camel-orange);
+  background-color: var(--color-camel-orange-light);
   padding: 0 0.5rem;
   border-radius: 25px;
   color: var(--navbar-background);
@@ -76,6 +76,7 @@
 .section .list {
   display: flex;
   flex-wrap: wrap;
+  justify-content: center;
 }
 
 .section .links {
@@ -84,7 +85,7 @@
   align-items: center;
   margin: 1.5rem 0;
   word-break: break-word;
-  background-color: var(--color-camel-orange);
+  background-color: var(--color-camel-orange-light);
   padding: 0 0.5rem;
   border-radius: 25px;
   color: var(--navbar-background);
@@ -99,7 +100,7 @@
 }
 
 .section .list .links {
-  margin: 0.5rem auto 0.5rem 0.5rem;
+  margin: 0.5rem;
 }
 
 .section .links img {

--- a/antora-ui-camel/src/css/vars.css
+++ b/antora-ui-camel/src/css/vars.css
@@ -20,6 +20,7 @@
   --color-asf-dark-blue: #303284;
   --color-asf-moderate-blue: #4f51ae;
   --color-camel-orange: #e97826;
+  --color-camel-orange-light: #f39421;
   --color-highlight: #cf7428;
   --color-glow: #fff7a3;
   --color-wheat: #f5deb3;


### PR DESCRIPTION
As per discussion, this is an extension to PR #453 in which two modifications are made:
1. The color of the button is used as a lighter shade of the current camel orange. However, this shade is present on the logo itself. 
2. Justify the buttons to the center as in some screen width, the spacing was huge between the buttons. Thus, justifying content to center resolves it.