### PR TITLE
CAMEL-15419: Enhance website build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,9 +120,12 @@ inside [Project root directory/antora-ui-camel](antora-ui-camel). So first switc
 In that directory execute:
 
     $ yarn install # needed only once, or if dependencies change
+    $ yarn format  # to format the code
     $ yarn build   # to perform the ui theme build
 
 You should see the Antora theme bundle generated in in [antora-ui-camel/build/ui-bundle.zip](antora-ui-camel).
+
+In case `yarn build` raises error, run `yarn format` to format the code and re-run `yarn build` to build your bundle successfully.
 
 The Camel Antora UI theme should not be a subject to change very frequently. So you might execute this once and
 never come back.
@@ -135,10 +138,8 @@ the theme bundle exists in [antora-ui-camel/build/ui-bundle.zip](antora-ui-camel
 To build the website go to the project root directory and run:
 
     $ yarn install # needed only once, or if dependencies change
-    $ yarn format  # to format the code
     $ yarn build   # to perform the build
 
-In case `yarn build` raises error, run `yarn format` to format the code and re-run `yarn build` to build your bundle successfully.
 
 In case `yarn build` throws the error: **JavaScript heap out of memory**, the issue can be resolved by increasing the memory used by node.js by setting `NODE_OPTIONS` environment variable to include `--max_old_space_size`, for example to increase the old space to 4GB do:
 


### PR DESCRIPTION
"yarn format" is supported only in antora-ui-camel dir

As per Zoran's suggestion in JIRA: "yarn format script is supported only on the Antora UI theme, to invoke it one must be in the antora-ui-camel directory."