### PR TITLE
fix: unparsable data reported by Google search

### DIFF
--- a/antora-ui-camel/src/partials/breadcrumbs-microdata.hbs
+++ b/antora-ui-camel/src/partials/breadcrumbs-microdata.hbs
@@ -19,10 +19,10 @@
         "position": 3,
         "name": "{{{page.componentVersion.displayVersion}}}",
         "item": "{{{add site.url page.componentVersion.url}}}"
-        },
+        }
         {{#if page.breadcrumbs}}
         {{#each page.breadcrumbs}}
-        {
+        ,{
         "@type": "ListItem",
         "position": {{add @index 4}},
         "name": "{{{ ./content }}}",


### PR DESCRIPTION
Google search console reports unparsable structured data issue in:

https://camel.apache.org/camel-quarkus-examples/latest/index.html

This is caused by the `camel-quarkus-examples` not having any subpages
and the template for microdata assiming that each component would
contain subpages.