### PR TITLE
chore: minify microdata

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -21,7 +21,8 @@ gulp.task('minify', (done) => {
       collapseWhitespace: true,
       collapseInlineTagWhitespace: true,
       conservativeCollapse: true,
-      useShortDoctype: true
+      useShortDoctype: true,
+      processScripts: ['application/ld+json']
     }))
     .pipe(gulp.dest('public'));
 });


### PR DESCRIPTION
We can instruct htmlmin to minify the microdata and save few bytes in
transfer.