### PR TITLE
CAMEL-15929: sort documentation components

### DIFF
--- a/antora-ui-camel/src/helpers/order_components.js
+++ b/antora-ui-camel/src/helpers/order_components.js
@@ -1,0 +1,25 @@
+'use strict'
+
+module.exports = (components) => Object.entries(components).sort((a, b) => {
+  const nameA = a[0]
+  const nameB = b[0]
+
+  if (nameA === 'manual') {
+    return -1
+  }
+  if (nameB === 'manual') {
+    return 1
+  }
+
+  if (nameA === 'components') {
+    return -1
+  }
+  if (nameB === 'components') {
+    return 1
+  }
+
+  return nameA.localeCompare(nameB)
+}).reduce((obj, [k, v]) => {
+  obj[k] = v
+  return obj
+}, {})

--- a/antora-ui-camel/src/partials/nav-explore.hbs
+++ b/antora-ui-camel/src/partials/nav-explore.hbs
@@ -6,7 +6,7 @@
   </div>
   {{/if}}
   <ul class="components">
-    {{#each site.components}}
+    {{#each (order_components site.components)}}
     <li class="component{{#if (eq this @root.page.component)}} is-current{{/if}}">
       <span class="title">{{{./title}}}</span>
       <ul class="versions">


### PR DESCRIPTION
We want the manual first, components next, and the rest of the
sub-projects after them sorted alphabetically.