### PR TITLE
chore(ckc): Maven Central Repository Search link

### DIFF
--- a/layouts/partials/releases/camel-kafka-connector.html
+++ b/layouts/partials/releases/camel-kafka-connector.html
@@ -1,4 +1,10 @@
-<h2>Source Distribution</h2>
+<h2 id="maven"><a class="anchor" href="#maven"></a>Getting the binaries from Maven Central</h2>
+
+<p>We maintain a handy table linking to binary packages for the latest release on the <a href="/camel-kafka-connector/latest/connectors.html">connector list</a>.</p>
+
+<p>For this release you can use Maven Central Repository Search to find and download the binary packages. This search will show the packages from this release: <code>g:org.apache.camel.kafkaconnector AND l:package AND v:{{ .Params.version }}</code>, or you can follow this link to the <a href="https://search.maven.org/search?q=g:org.apache.camel.kafkaconnector%20AND%20l:package%20AND%20v:{{ .Params.version }}">search results</a>.</p>
+
+<h2 id="source"><a class="anchor" href="#source"></a>Source Distribution</h2>
 
 <p>
   Source distribution contains all the artifacts Apache Camel project


### PR DESCRIPTION
This adds paragraph explaining where to get the Camel Kafka Connector
release binary packages, and link to the Maven Central Repository Search
results to fetch those.

@valdar as we spoke briefly about this, can you have a look, I'll paste a link to the preview once it's built.