### PR TITLE
chore: add custom link as an download option

### DIFF
--- a/data/release-categories.yaml
+++ b/data/release-categories.yaml
@@ -87,6 +87,9 @@ camel-kafka-connector:
     - name: 'Sources'
       path_format: 'camel/camel-kafka-connector/{version}/apache-camel-kafka-connector-{version}-src.zip'
       filename_format: 'apache-camel-kafka-connector-{version}-src.zip'
+    - name: 'Binaries'
+      title: 'Connectors download list'
+      link: '/camel-kafka-connector/latest/connectors.html'
 camel-quarkus:
   id: 'camel-quarkus'
   name: 'Apache Camel Quarkus'

--- a/layouts/partials/releases/downloads.html
+++ b/layouts/partials/releases/downloads.html
@@ -144,9 +144,13 @@
                     {{ $path := replace $download.path_format "{version}" $v }}
                     {{ $filename := replace $download.filename_format "{version}" $v }}
                     <td>{{ $download.name}}</td>
-                    <td><a href="{{ $artifact_base_url }}{{ $path }}">{{ $filename }}</a></td>
-                    <td><a href="{{ $meta_base_url }}{{ $path }}.asc">{{ $filename }}.asc</a></td>
-                    <td><a href="{{ $meta_base_url }}{{ $path }}{{ $hash_extension }}">{{ $filename }}{{ $hash_extension }}</a></td>
+                    {{ if $path }}
+                        <td><a href="{{ $artifact_base_url }}{{ $path }}">{{ $filename }}</a></td>
+                        <td><a href="{{ $meta_base_url }}{{ $path }}.asc">{{ $filename }}.asc</a></td>
+                        <td><a href="{{ $meta_base_url }}{{ $path }}{{ $hash_extension }}">{{ $filename }}{{ $hash_extension }}</a></td>
+                    {{ else }}
+                         <td colspan="3"><a href="{{ .link }}">{{ replace .title "{version}" $v }}</a></td>
+                    {{ end }}
                 {{ end }}
             </tr>
         {{ end }}


### PR DESCRIPTION
This adds custom link as an option for downloads. This way we can link
to binary downloads hosted elsewhere, i.e. other than the ASF list, but
still most likely on the camel.apache.org website.

Even though it supports version substitution via `{version}` variable,
for Camel Kafka Connectors it links to the documentation and we only
publish the "latest" version. There is also an issue that a release
version, say `1.2.3` doesn't match up with the documentation version, as
we do it today, i.e. we would have documentation version of `1.2.x`. The
solution might be to publish documentation for each version, but that
will take a toll on the website build times, and we can't really have
docs for all versions ever released, the website would be become really
unmanageable.

So this is a first pass, just to help users find the downloads, and we
need to figure what we would like to do WRT versioning.