### PR TITLE
release: publish ui-bundle to let other projects reference it

### DIFF
--- a/.github/workflows/release-bundle.yaml
+++ b/.github/workflows/release-bundle.yaml
@@ -1,0 +1,67 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: Release UI Bundle
+
+on:
+  push:
+    branches:
+    - master
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+      - name: Build
+        run: yarn workspace antora-ui-camel run build
+      - name: Cleanup existing release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          EXISTING_RELEASE=$(curl --fail --silent -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/$GITHUB_REPOSITORY/releases/tags/snapshot | jq -r .id)
+          if [[ ! -z "$EXISTING_RELEASE" ]]; then
+            echo "Deleting existing release $EXISTING_RELEASE..."
+            curl --fail --silent -X DELETE -H "Authorization: Bearer $GITHUB_TOKEN" -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/$GITHUB_REPOSITORY/releases/$EXISTING_RELEASE
+          fi
+      - name: Create release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: snapshot
+          release_name: snapshot release
+          body: |
+            Snapshot release created from `${{ github.ref }}`.
+
+            This release contains the Apache Camel website template file, used by 
+            Apache Camel subprojects to display previews.
+          draft: false
+          prerelease: true
+      - name: Upload ui-bundle to release
+        id: upload-release-asset 
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./antora-ui-camel/build/ui-bundle.zip
+          asset_name: ui-bundle.zip
+          asset_content_type: application/zip


### PR DESCRIPTION
I don't know if this will work with the new Apache policies (it works in my fork btw).

This will continuously release a moving `snapshot` tag based on the current master, with the `ui-bundle.zip` template as release artifact. This way I can set the following on a Camel subproject antora-playbook file:

```yaml
# ...
ui:
  bundle:
    url: https://github.com/apache/camel-website/releases/download/snapshot/ui-bundle.zip
```

And that will render the subproject docs with the latest Apache Camel website template.

It's actually the same approach used by Antora for their default template (but they are on Gitlab).