### PR TITLE
refactor: keep the height fixed in Kamelet catalog

### DIFF
--- a/antora-ui-camel/src/css/catalog.css
+++ b/antora-ui-camel/src/css/catalog.css
@@ -43,5 +43,7 @@
 }
 
 .catalog .item .image img {
-  width: 4rem;
+  height: 3rem;
+  width: auto;
+  max-width: 60%;
 }


### PR DESCRIPTION
I've noticed that layout for some Kamelets in the catalog breaks through
the container, so this reverts the fixed confines to the height instead
of the width. This also has some interesting side-effects (e.g. the
Minio Kamelet), but overall doesn't look as broken as the fixed width.