### PR TITLE
refactor: use dashed underline link decoration

### DIFF
--- a/antora-ui-camel/src/css/doc.css
+++ b/antora-ui-camel/src/css/doc.css
@@ -153,11 +153,7 @@
 .doc a {
   color: var(--link-font-color);
   word-break: break-word;
-  text-decoration: none;
-  background-image: linear-gradient(to right, #583ac2 50%, transparent 50%);
-  background-position: 0 1.1em;
-  background-repeat: repeat-x;
-  background-size: 7px 1px;
+  text-decoration: underline dashed;
 }
 
 .doc li a,

--- a/antora-ui-camel/src/css/frontpage.css
+++ b/antora-ui-camel/src/css/frontpage.css
@@ -20,11 +20,7 @@ section.frontpage {
 
 section.frontpage a {
   color: var(--link-font-color);
-  text-decoration: none;
-  background-image: linear-gradient(to right, #583ac2 50%, transparent 50%);
-  background-position: 0 1.1em;
-  background-repeat: repeat-x;
-  background-size: 7px 1px;
+  text-decoration: underline dashed;
 }
 
 section.frontpage a:hover {


### PR DESCRIPTION
The current implementation doesn't look as appealing to me, I think the
(almost) default decoration for links looks better.