### PR TITLE
CAMEL-16576: pages from user manual moved to community section

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,7 +303,7 @@ You need to rebuild the Antora UI theme in order to see your changes reflected l
 ### Changes for Camel and Camel K docs
 
 The Apache Camel website includes documentation sources from other github repositories. Content sources are defined in
-[site.yml](site.yml).
+[antora-playbook.yml](antora-playbook.yml).
 
 At the moment these are the documentation sources from [Camel](https://github.com/apache/camel)
 and [Camel K](https://github.com/apache/camel-k). These are basically the component reference docs and the Camel user

--- a/antora-ui-camel/src/partials/footer-content.hbs
+++ b/antora-ui-camel/src/partials/footer-content.hbs
@@ -32,7 +32,7 @@
                 <dt><label for="footer-toggle-community">Community</label><label for="footer-toggle-community">&#65291;</label></dt>
                 <dd><a href="{{siteRootPath}}/community/support/">Support</a></dd>
                 <dd><a href="{{siteRootPath}}/manual/latest/contributing.html">Contributing</a></dd>
-                <dd><a href="{{siteRootPath}}/manual/latest/mailing-lists.html">Mailing Lists</a></dd>
+                <dd><a href="{{siteRootPath}}/community/mailing-list/">Mailing Lists</a></dd>
                 <dd><a href="{{siteRootPath}}/community/user-stories/">User stories</a></dd>
                 <dd><a href="{{siteRootPath}}/community/articles/">Articles</a></dd>
                 <dd><a href="{{siteRootPath}}/community/books/">Books</a></dd>

--- a/antora-ui-camel/src/partials/footer-content.hbs
+++ b/antora-ui-camel/src/partials/footer-content.hbs
@@ -31,7 +31,7 @@
             <dl>
                 <dt><label for="footer-toggle-community">Community</label><label for="footer-toggle-community">&#65291;</label></dt>
                 <dd><a href="{{siteRootPath}}/community/support/">Support</a></dd>
-                <dd><a href="{{siteRootPath}}/manual/latest/contributing.html">Contributing</a></dd>
+                <dd><a href="{{siteRootPath}}/community/contributing/">Contributing</a></dd>
                 <dd><a href="{{siteRootPath}}/community/mailing-list/">Mailing Lists</a></dd>
                 <dd><a href="{{siteRootPath}}/community/user-stories/">User stories</a></dd>
                 <dd><a href="{{siteRootPath}}/community/articles/">Articles</a></dd>

--- a/content/_index.md
+++ b/content/_index.md
@@ -220,9 +220,9 @@ Camel is an [Apache Software Foundation](https://www.apache.org) project, availa
 
 [Sources](./community/sources/), [mailing lists](./community/mailing-list/), [issue tracker](./community/support/): it's fully open, you can access directly.
 
-We also love contributions: don't hesitate to [contribute](./manual/latest/contributing.html). You can contribute by <a href="https://github.com/apache/camel-website/edit/main/content/_index.md">editing this page</a>!
+We also love contributions: don't hesitate to [contribute](./community/contributing/). You can contribute by <a href="https://github.com/apache/camel-website/edit/main/content/_index.md">editing this page</a>!
 
-[Be Involved In The Community](./manual/latest/contributing.html) | [How To Contribute](./manual/latest/contributing.html)
+[Be Involved In The Community](./community/contributing/) | [How To Contribute](./community/contributing/)
 
 {{< /div >}}
 

--- a/content/blog/2020/03/Outreachy-May2020/index.md
+++ b/content/blog/2020/03/Outreachy-May2020/index.md
@@ -27,4 +27,4 @@ Apache Camel is a project with a great community, we are here to help, mentor an
 
 As part of the application process, all applicants must make at least one contribution to be accepted as an intern for this project. Only applicants who make a contribution will be eligible to be accepted as interns.
 
-Look at the [contributing to Camel page](/manual/latest/contributing.html) for details on how to get started contributing and how to reach out to the Camel community via various communication channels. And look at the [README](https://github.com/apache/camel-website/blob/main/README.md) in the Camel Website repository on how to get started with the website itself.
+Look at the [contributing to Camel page](/community/contributing/) for details on how to get started contributing and how to reach out to the Camel community via various communication channels. And look at the [README](https://github.com/apache/camel-website/blob/main/README.md) in the Camel Website repository on how to get started with the website itself.

--- a/content/blog/2020/04/Camel-Quarkus-release-1.0.0-M7/index.md
+++ b/content/blog/2020/04/Camel-Quarkus-release-1.0.0-M7/index.md
@@ -64,5 +64,5 @@ All supported bits can be seen in the [List of Camel Quarkus extensions](/camel-
 
 Quarkus was upgraded to 1.4.1 (from 1.3.2 in Camel Quarkus 1.0.0-M6).
 
-Enjoy and give feedback either via [mailing lists](/manual/latest/mailing-lists.html)
+Enjoy and give feedback either via [mailing lists](/community/mailing-list/)
 or [GitHub issues](https://github.com/apache/camel-quarkus/issues)!

--- a/content/blog/2020/06/camel-quarkus-release-1.0.0-CR2/index.md
+++ b/content/blog/2020/06/camel-quarkus-release-1.0.0-CR2/index.md
@@ -59,5 +59,5 @@ Camel Quarkus release. Please use
 [Microprofile Fault Tolerance](/camel-quarkus/latest/reference/extensions/microprofile-fault-tolerance.html)
 as a replacement.
 
-Enjoy and give feedback either via [mailing lists](/manual/latest/mailing-lists.html)
+Enjoy and give feedback either via [mailing lists](/community/mailing-list/)
 or [GitHub issues](https://github.com/apache/camel-quarkus/issues)!

--- a/content/blog/2020/07/camel-quarkus-release-1.0.0-CR3/index.md
+++ b/content/blog/2020/07/camel-quarkus-release-1.0.0-CR3/index.md
@@ -51,5 +51,5 @@ with JAXB dependencies having been removed from the OpenAPI components. There's 
 Quarkus was upgraded to 1.6.0.Final.
 
 
-Enjoy! Feel free to give feedback via the [mailing lists](/manual/latest/mailing-lists.html)
+Enjoy! Feel free to give feedback via the [mailing lists](/community/mailing-list/)
 or [GitHub issues](https://github.com/apache/camel-quarkus/issues).

--- a/content/community/_index.md
+++ b/content/community/_index.md
@@ -50,7 +50,7 @@ One way to get help is to use the Camel mailing lists. This allows the entire co
 
 {{< div "icon" >}}
 
-[![Camel](/_/img/contributing.svg)](/manual/latest/contributing.html)
+[![Camel](/_/img/contributing.svg)](/community/contributing/)
 
 {{< /div >}}
 

--- a/content/community/_index.md
+++ b/content/community/_index.md
@@ -14,10 +14,31 @@ Title: "Community"
 
 ## Support
 
-If you are experiencing problems using Camel then please report your problem to our mailing list. This allows the entire community to help with your problem. 
-
+If you are experiencing problems using Camel there are several channels available to seek help from the community.
 <p>
 <a class="button dark" href="/community/support/">Read More</a>
+</p>
+
+{{< /div >}}
+
+{{< /div >}}
+
+{{< div "box" >}}
+
+{{< div "icon" >}}
+
+[![Camel](/_/img/support.svg)](/community/mailing-list/)
+
+{{< /div >}}
+
+{{< div "content" >}}
+
+## Mailing List
+
+One way to get help is to use the Camel mailing lists. This allows the entire community to help with your problem. 
+
+<p>
+<a class="button dark" href="/community/mailing-list/">Read More</a>
 </p>
 
 {{< /div >}}

--- a/content/community/_index.md
+++ b/content/community/_index.md
@@ -61,7 +61,7 @@ One way to get help is to use the Camel mailing lists. This allows the entire co
 There are many ways you can help make Camel better - please dive in and help!Identify areas you can contribute first. You don’t have to be an expert in an area, the Apache Camel developers are available to offer help and guidance.
 
 <p>
-<a class="button dark" href="/manual/latest/contributing.html">Read More</a>
+<a class="button dark" href="/community/contributing/">Read More</a>
 </p>
 
 {{< /div >}}

--- a/content/community/contributing.md
+++ b/content/community/contributing.md
@@ -1,0 +1,170 @@
+## Contributing to Apache Camel
+First of all, thank you for having an interest in contributing to Apache Camel.
+
+Here are some guidelines on how to best approach the Apache Camel community and how to best apply yourself.
+There are many ways you can help make Camel a better piece of software - please dive in and help!
+
+- Try surfing the documentation - if something confuses you, [bring it to our attention](/manual/latest/improving-the-documentation.html).
+- Download the code & try it out and see what you think.
+- Browse the source code. Got an itch to scratch, want to tune some operation, or add some feature?
+- Want to do some hacking on Camel? Try surfing our [issue tracker](https://issues.apache.org/jira/browse/CAMEL) for open issues or features that need to be implemented. Take ownership of a particular issue, and try to fix it.
+- If you are a new Camel rider and would like to help us, you can also find [some easy to resolve issues](https://issues.apache.org/jira/issues/?filter=12348073) or [issues we need help with](https://issues.apache.org/jira/issues/?filter=12348074).
+- Leave a comment on the issue to let us know you are working on it, and add yourself as a watcher to get informed about all modifications.
+
+Identify areas you can contribute first. You don't have to be an expert in an area, the Apache Camel developers are available to offer help and guidance.
+
+Introduce yourself on the developer's mailing list (see below), tell us what area of work or problem you wish to address in Camel. Create a draft of your solution, this can be simple 1-2 sentences on the change you wish to make. Try to be as specific as you can: include a short description of your intent, what you tried and what didn't work, or what you need help with. The best way of approaching the developers is by describing what you would like to work on and asking specific questions on how to get started. We'll do our best to guide you and help you make your contribution. 
+
+We also participate in Google Summer of Code and Outreachy programs; for information about those look at those program websites. If you wish to participate in either of those follow the guidelines and schedule set by those programs. If you are unsure please reach out via official communication channels of those programs, or ask on the developer's mailing list for help.
+
+## Table of Contents
+
+- [Getting in touch](#getting-in-touch)
+- [If you find a bug or problem](#if-you-find-a-bug-or-problem)
+- [Working on the code](#working-on-the-code)
+- [Testing the changes](#testing-the-changes)
+- [Running checkstyle](#running-checkstyle)
+- [Creating patches](#creating-patches)
+- [Submitting your contribution](#submitting-your-contribution)
+- [Becoming a committer](#becoming-a-committer)
+
+
+## Getting in touch
+
+Apache Camel is an Apache Software Foundation project, all communication is done in the open on the project mailing lists. You can [read more on the reasoning behind this](https://www.apache.org/foundation/mailinglists.html) to get a better understanding of this.
+
+All communication is subject to the [ASF Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
+
+There are various ways of communicating with the Camel community.
+For questions and guidance around contributing subscribe to the developer's mailing list by sending an e-mail to dev-subscribe@camel.apache.org.
+[This page](../mailing-list/) describes all the Camel mailing lists.
+
+We can also be reached on the Zulip chat at https://camel.zulipchat.com.
+
+## If you find a bug or problem
+
+Please raise a new issue in our [issue tracker](https://issues.apache.org/jira/browse/CAMEL). This way we’ll know when the issue has been fixed and we can ensure that the problem stays fixed in future releases. Please describe the bug/issue clearly, and add pictures/screenshots if necessary.
+If you can create a JUnit test case which demonstrates the problem, then your issue is more likely to be resolved quickly.
+For examples, take a look at some of the existing [unit test cases](https://github.com/apache/camel/tree/main/core/camel-core/src/test/java/org/apache/camel).
+
+**NOTE:** you will need to register to create or comment on JIRA issues. The "Log In" link in the upper right will allow you to login with an existing account or sign up for an account.
+
+
+## Working on the code
+
+We recommend working on the code from the [camel GitHub repository](https://github.com/apache/camel/). Camel subprojects are maintained in [separate repositories in GitHub](https://github.com/apache?q=camel).
+
+    git clone https://github.com/apache/camel.git
+    cd camel
+    
+**NOTE:** If you are an Apache Camel committer, then you may also clone the [ASF git repo](https://gitbox.apache.org/repos/asf/camel.git).
+
+Build the project with [Maven](http://maven.apache.org/download.html). Maven 3.6.x or newer is required to build Camel 3 or later. The following command will do a fast build.
+
+    mvn clean install -Pfastinstall
+    
+**NOTE:** You might need to build multiple times (if you get a build error) because sometimes maven fails to download all the required jars.
+Then import the projects into your workspace.
+
+You can find more details about building camel in the User Manual [Building](/manual/latest/building.html) page.
+
+If you aren't able to build a component after adding some new URI parameters due to `Empty doc for option: [OPTION], parent options: <null>` please make sure that you either added properly javadoc for get/set method or description in `@UriPath` annotation.
+
+
+### Verify Karaf features
+
+Camel-Karaf now lives in its own repository, so to verify a Karaf feature, you'll need to fork the [camel-karaf repository](https://github.com/apache/camel-karaf).
+
+To check a new Karaf feature or an existing one, you should run a verification on the features.xml file. You'll need to follow these steps:
+The first step is to run a full build of Camel. Then
+
+    cd platform/karaf/features/
+    mvn clean install
+
+If you modified a component/dataformat or updated a dependency in the main camel repository, you'll first need to build the main camel locally and then run a full build of camel-karaf.
+
+
+
+## Testing the changes
+
+If you need to implement tests for your changes (highly recommended!), you will probably need to handle 3 separate things: 
+
+- simulate the infrastructure required for the test (ie.: JMS brokers, Kafka, etc), 
+- writing testable code,
+- the test logic itself. 
+Naturally, there is no rule of
+thumb for how the code changes and test logic should be written. The [Testing](/manual/latest/testing.html) page in the User Manual provides detailed information and examples for writing Camel unit tests.
+With regard to simulating the test infrastructure, there is a
+growing library of reusable components that can be helpful. These components are located in the test-infra module and provide
+support for simulating message brokers, cloud environments, databases and much more.
+
+Using these components is usually as simple as registering them as JUnit 5 extensions:
+
+    @RegisterExtension
+    static NatsService service = NatsServiceFactory.createService();
+
+Then you can access the service by using the methods and properties provided by the services. This varies according to each service.
+
+If you need to implement a new test-infra service, check the [readme on the test-infra module](https://github.com/apache/camel/tree/main/test-infra#readme) for additional details.
+
+## Running checkstyle
+
+Apache Camel source code uses a coding style/format that can 
+be verified for compliance using the checkstyle plugin.
+To enable source style checking with checkstyle, build Camel with the -Psourcecheck parameter:
+
+    mvn clean install -Psourcecheck
+
+Please remember to run this check on your code changes before submitting a patch or Github PR. You do not need to run this against the entire project, but only in the modules you modified. Let's say you do some code changes in the camel-ftp component, following which you can run the check from within this directory:
+
+    cd camel-ftp
+    mvn clean install -Psourcecheck
+
+
+## Submitting your contribution
+We gladly accept patches if you can find ways to improve, tune, or fix Camel in some way.
+Make sure you have followed the steps and guidelines outlined in this document. For larger changes, make sure that you have discussed them on the developer's mailing list or in the Jira issue tracker before hand. To get the best response from the team, make sure that the reasoning behind the contribution you wish to make is clear: outline the problem and explain your solution for it. Describe any changes you have made for which you are unaware or unsure of any consequences or side effects.
+
+Be mindful of the source checks, formatting and the structure of the git commit message we abide by. In particular, if there is a JIRA issue, reference it in the first line of your commit message, for example:
+
+    CAMEL-9999: Some message goes here
+
+Ensure that the unit tests include proper assertions, and not only system.out or logging.
+Please also avoid unnecessary changes, like reordering methods and fields, which will make your PR harder to review.
+
+Following these guidelines will help you in getting your contribution accepted. 
+
+### Creating a Pull Request at Github
+The *preferred* way of submitting your contribution is to fork the camel Github repository and push your changes there.
+You can find many resources online explaining how to work on GitHub projects and how to submit work to these projects.
+After updating your private repository, create a Pull Request (PR). One of the committers then needs to accept your PR to bring the code into the ASF codebase. 
+
+Expect that your Pull Request will receive a review and that you will need to respond and correspond to that via comments at GitHub.
+
+Stay engaged, follow and respond to comments or questions you might be asked.
+
+After the code has been included into the ASF codebase, you need to close the Pull Request because we can't do that...
+
+### Manual patch files
+
+For smaller patches, you may also submit a patch file instead of using a Pull Request. To do this:
+
+- [create a new JIRA issue](https://issues.apache.org/jira/browse/CAMEL)
+- attach the patch or tarball as an attachment
+- **tick the Patch Attached** button on the issue
+
+Most IDEs can create nice patches now very easily. e.g., on Eclipse, right-click on a file/directory, and select Team -> Create Patch. Then save the patch as a file and attach it to the corresponding JIRA issue.
+If you prefer working on the command-line, try the following to create the patch:
+
+    diff -u Main.java.orig Main.java >> patchfile.txt
+
+or
+
+    git diff --no-prefix > patchfile.txt
+
+
+
+## Becoming a committer
+
+Once you've become involved as above, we may well invite you to be a committer. See [How do I become a committer](/manual/latest/faq/how-do-i-become-a-committer.html) for more details.
+

--- a/content/community/contributing.md
+++ b/content/community/contributing.md
@@ -4,7 +4,7 @@ First of all, thank you for having an interest in contributing to Apache Camel.
 Here are some guidelines on how to best approach the Apache Camel community and how to best apply yourself.
 There are many ways you can help make Camel a better piece of software - please dive in and help!
 
-- Try surfing the documentation - if something confuses you, [bring it to our attention](/manual/latest/improving-the-documentation.html).
+- Try surfing the documentation - if something confuses you, [bring it to our attention or suggest an improvement](#working-on-the-documentation).
 - Download the code & try it out and see what you think.
 - Browse the source code. Got an itch to scratch, want to tune some operation, or add some feature?
 - Want to do some hacking on Camel? Try surfing our [issue tracker](https://issues.apache.org/jira/browse/CAMEL) for open issues or features that need to be implemented. Take ownership of a particular issue, and try to fix it.
@@ -13,21 +13,9 @@ There are many ways you can help make Camel a better piece of software - please 
 
 Identify areas you can contribute first. You don't have to be an expert in an area, the Apache Camel developers are available to offer help and guidance.
 
-Introduce yourself on the developer's mailing list (see below), tell us what area of work or problem you wish to address in Camel. Create a draft of your solution, this can be simple 1-2 sentences on the change you wish to make. Try to be as specific as you can: include a short description of your intent, what you tried and what didn't work, or what you need help with. The best way of approaching the developers is by describing what you would like to work on and asking specific questions on how to get started. We'll do our best to guide you and help you make your contribution. 
+Introduce yourself on the [developer's mailing list] (#getting-in-touch), tell us what area of work or problem you wish to address in Camel. Create a draft of your solution, this can be simple 1-2 sentences on the change you wish to make. Try to be as specific as you can: include a short description of your intent, what you tried and what didn't work, or what you need help with. The best way of approaching the developers is by describing what you would like to work on and asking specific questions on how to get started. We'll do our best to guide you and help you make your contribution. 
 
 We also participate in Google Summer of Code and Outreachy programs; for information about those look at those program websites. If you wish to participate in either of those follow the guidelines and schedule set by those programs. If you are unsure please reach out via official communication channels of those programs, or ask on the developer's mailing list for help.
-
-## Table of Contents
-
-- [Getting in touch](#getting-in-touch)
-- [If you find a bug or problem](#if-you-find-a-bug-or-problem)
-- [Working on the code](#working-on-the-code)
-- [Testing the changes](#testing-the-changes)
-- [Running checkstyle](#running-checkstyle)
-- [Creating patches](#creating-patches)
-- [Submitting your contribution](#submitting-your-contribution)
-- [Becoming a committer](#becoming-a-committer)
-
 
 ## Getting in touch
 
@@ -49,6 +37,10 @@ For examples, take a look at some of the existing [unit test cases](https://gith
 
 **NOTE:** you will need to register to create or comment on JIRA issues. The "Log In" link in the upper right will allow you to login with an existing account or sign up for an account.
 
+## Working on the documentation
+
+Documentation is extremely important to help users make the most of Apache Camel and it's probably the area that needs the most help!
+So if you are interested in helping the documentation effort; whether it's just to fix a page here or there, correct a link or even write a tutorial or improve existing documentation please do dive in and help! Most of the documentation is managed in the same repositories as the related source code so the process is similar to working on the code. For more details please refer to [Improving the documentation in the User Manual](/manual/latest/improving-the-documentation.html).
 
 ## Working on the code
 

--- a/content/community/mailing-list.md
+++ b/content/community/mailing-list.md
@@ -4,19 +4,20 @@ title: "Mailing Lists"
 
 ## Use Camel User List
 
-You should post and subscriber to the Camel User List for all your questions on using Camel, or how to do X with Camel etc. If in doubt use this list.
-The other list Camel Developer List, is for the Camel team to discus development of the actual Camel project; do not use this list for question on using Camel.
-Again to re-iterate, use the Camel User List, for you Camel questions. This is the correct mailing list, and have the most people there ready for helping you.
+You should post and subscribe to the Camel User List for all your questions on using Camel, or how to do X with Camel etc. If in doubt use this list.
+The Camel Developer List, is for the Camel team to discus development of the actual Camel project; do not use this list for questions on using Camel.
+Again to re-iterate, use the Camel User List, for your Camel questions. This is the correct mailing list, and has the most people there ready for helping you.
 
 ## Post plain text mails
 
 When posting to the mailing lists, use plain text mails. Do not use HTML mails. HTML mails is more likely to be targeted as spam mails and will be rejected; as well it's not easily readable by others.
 
 {{< table >}}
-| List Name  | Address | Subscribe | Unsubscribe | Archive | Comment |
-|------------|---------|-----------|-------------|---------|---------|
-| Camel User List  | users@camel.apache.org | [subscribe](mailto:users-subscribe@camel.apache.org) | [unsubscribe](mailto:users-unsubscribe@camel.apache.org) | [Archives](http://mail-archives.apache.org/mod_mbox/camel-users/) | Use this list for your Camel questions. |
-| Camel Developer List  | dev@camel.apache.org | [subscribe](mailto:dev-subscribe@camel.apache.org) | [unsubscribe](mailto:dev-unsubscribe@camel.apache.org) | [Archives](http://mail-archives.apache.org/mod_mbox/camel-dev/) | Used by Camel contributors to discuss development of Camel. |
-| Camel Commits List  | commits@camel.apache.org | [subscribe](mailto:commits-subscribe@camel.apache.org) | [unsubscribe](mailto:commits-unsubscribe@camel.apache.org) | [Archives](http://mail-archives.apache.org/mod_mbox/camel-commits/) | Notifications on changes to the Camel code |
-| Camel Issues List  | issues@camel.apache.org | [subscribe](mailto:issues-subscribe@camel.apache.org) | [unsubscribe](mailto:issues-unsubscribe@camel.apache.org) | [Archives](http://mail-archives.apache.org/mod_mbox/camel-issues/) | Notifications of JIRA issues |
+| List Name  | Address | Subscribe | Unsubscribe | Archive | Nabble | Comment |
+|------------|---------|-----------|-------------|---------|--------|---------|
+| Camel User List  | users@camel.apache.org | [subscribe](mailto:users-subscribe@camel.apache.org) | [unsubscribe](mailto:users-unsubscribe@camel.apache.org) | [Archives](http://mail-archives.apache.org/mod_mbox/camel-users/) | [Nabble](http://camel.465427.n5.nabble.com/Camel-Users-f465428.html) | Use this list for your Camel questions. |
+| Camel Developer List  | dev@camel.apache.org | [subscribe](mailto:dev-subscribe@camel.apache.org) | [unsubscribe](mailto:dev-unsubscribe@camel.apache.org) | [Archives](http://mail-archives.apache.org/mod_mbox/camel-dev/) | [Nabble](http://camel.465427.n5.nabble.com/Camel-Development-f479097.html) | Used by Camel contributors to discuss development of Camel. |
+| Camel Commits List  | commits@camel.apache.org | [subscribe](mailto:commits-subscribe@camel.apache.org) | [unsubscribe](mailto:commits-unsubscribe@camel.apache.org) | [Archives](http://mail-archives.apache.org/mod_mbox/camel-commits/) | [Nabble](http://camel.465427.n5.nabble.com/Camel-Commits-f498405.html) | Notifications on changes to the Camel code |
+| Camel Issues List  | issues@camel.apache.org | [subscribe](mailto:issues-subscribe@camel.apache.org) | [unsubscribe](mailto:issues-unsubscribe@camel.apache.org) | [Archives](http://mail-archives.apache.org/mod_mbox/camel-issues/) | | Notifications of JIRA issues |
 {{< /table >}}
+

--- a/content/community/mailing-list.md
+++ b/content/community/mailing-list.md
@@ -13,11 +13,11 @@ Again to re-iterate, use the Camel User List, for your Camel questions. This is 
 When posting to the mailing lists, use plain text mails. Do not use HTML mails. HTML mails is more likely to be targeted as spam mails and will be rejected; as well it's not easily readable by others.
 
 {{< table >}}
-| List Name  | Address | Subscribe | Unsubscribe | Archive | Nabble | Comment |
-|------------|---------|-----------|-------------|---------|--------|---------|
-| Camel User List  | users@camel.apache.org | [subscribe](mailto:users-subscribe@camel.apache.org) | [unsubscribe](mailto:users-unsubscribe@camel.apache.org) | [Archives](http://mail-archives.apache.org/mod_mbox/camel-users/) | [Nabble](http://camel.465427.n5.nabble.com/Camel-Users-f465428.html) | Use this list for your Camel questions. |
-| Camel Developer List  | dev@camel.apache.org | [subscribe](mailto:dev-subscribe@camel.apache.org) | [unsubscribe](mailto:dev-unsubscribe@camel.apache.org) | [Archives](http://mail-archives.apache.org/mod_mbox/camel-dev/) | [Nabble](http://camel.465427.n5.nabble.com/Camel-Development-f479097.html) | Used by Camel contributors to discuss development of Camel. |
-| Camel Commits List  | commits@camel.apache.org | [subscribe](mailto:commits-subscribe@camel.apache.org) | [unsubscribe](mailto:commits-unsubscribe@camel.apache.org) | [Archives](http://mail-archives.apache.org/mod_mbox/camel-commits/) | [Nabble](http://camel.465427.n5.nabble.com/Camel-Commits-f498405.html) | Notifications on changes to the Camel code |
-| Camel Issues List  | issues@camel.apache.org | [subscribe](mailto:issues-subscribe@camel.apache.org) | [unsubscribe](mailto:issues-unsubscribe@camel.apache.org) | [Archives](http://mail-archives.apache.org/mod_mbox/camel-issues/) | | Notifications of JIRA issues |
+| List Name  | Address | Subscribe | Unsubscribe | Archive | Comment |
+|------------|---------|-----------|-------------|---------|---------|
+| Camel User List  | users@camel.apache.org | [subscribe](mailto:users-subscribe@camel.apache.org) | [unsubscribe](mailto:users-unsubscribe@camel.apache.org) | [Archives](https://lists.apache.org/list.html?users@camel.apache.org) | Use this list for your Camel questions. |
+| Camel Developer List  | dev@camel.apache.org | [subscribe](mailto:dev-subscribe@camel.apache.org) | [unsubscribe](mailto:dev-unsubscribe@camel.apache.org) | [Archives](https://lists.apache.org/list.html?dev@camel.apache.org) | Used by Camel contributors to discuss development of Camel. |
+| Camel Commits List  | commits@camel.apache.org | [subscribe](mailto:commits-subscribe@camel.apache.org) | [unsubscribe](mailto:commits-unsubscribe@camel.apache.org) | [Archives](https://lists.apache.org/list.html?commits@camel.apache.org) | Notifications on changes to the Camel code |
+| Camel Issues List  | issues@camel.apache.org | [subscribe](mailto:issues-subscribe@camel.apache.org) | [unsubscribe](mailto:issues-unsubscribe@camel.apache.org) | [Archives](https://lists.apache.org/list.html?issues@camel.apache.org) | Notifications of JIRA issues |
 {{< /table >}}
 

--- a/content/community/support.md
+++ b/content/community/support.md
@@ -18,9 +18,9 @@ Please read the section below (How to get help), and follow the bullets advised 
 ### Reporting bugs - Please read this first
 
 We prefer people to get in touch first using the mailing list, or Zulip chat. Or take time to read FAQs, or search in the mailing list archives to find answers.
-Unfortunately some people create a JIRA ticket as first thing. Please don't do that! Only if you are sure it really is a bug etc. JIRA tickets create noise
-for the Camel team to react on issues that are not bugs. But already covered in FAQs, in the mailing lists etc. Or in the existing documentation.
-Also on the mailing lists there is more people active to help you better.
+Unfortunately some people create a JIRA ticket as first thing. **Please don't do that!** Only if you are sure it really is a bug etc. JIRA tickets create noise
+for the Camel team to react on issues that are not bugs but are already covered in FAQs, in the mailing lists etc., or in the existing documentation.
+Also on the mailing lists there are more people active to help you better.
 
 Also please avoid sending direct emails to members of the Camel team - we are busy already. And conversations about Camel should happen in the public, and not via private emails.
 
@@ -35,7 +35,7 @@ You are also likely to find helpful discussions on technical blogs, on [Google](
 
 ### Using deprecated components
 
-Deprecated components are not supported and issues such as bugs may not be fixed. We encourage users to migrate away from using any deprecated component.
+Deprecated components are *not* supported and issues such as bugs may not be fixed. We encourage users to migrate away from using any deprecated component.
 A list of deprecated components is listed on the github page at: https://github.com/apache/camel/tree/master/components#components
 
 ### How to get help
@@ -45,13 +45,13 @@ When you report an issue, please be sure to include as much information as possi
 
 *What version do you use*
 
-What version of Camel do you use! Remember to include this information.
+What version of Camel do you use? Remember to include this information.
 
 *  what are the version numbers of involved software components? (this is very important to detail)
 *  what platform and JDK?
 *  any particular container being used? and if so, what version?
-*  stack traces generally really help! (Remember to post which version of Camel you use, this is important to know when posting stacktraces) If in doubt, include the whole thing; often exceptions get wrapped in other exceptions and the exception right near the bottom explains the actual error, not the first few lines at the top. It's very easy for us to skim-read past unnecessary parts of a stack trace.
-*  log output can be useful too; sometimes enabling DEBUG logging can help
+*  stack traces generally really help! (Remember to post which version of Camel you use, this is important to know when posting stacktraces.) If in doubt, include the whole thing; often exceptions get wrapped in other exceptions and the exception right near the bottom explains the actual error, not the first few lines at the top. It's very easy for us to skim-read past unnecessary parts of a stack trace.
+*  log output can be useful too; sometimes [enabling DEBUG logging] (/manual/latest/faq/how-do-i-change-the-logging.html) can help
 *  your code & configuration files are often useful
 *  did it work before? what have you changed to break it?
 *  try upgrading to the latest release and see if it's fixed there
@@ -59,7 +59,7 @@ What version of Camel do you use! Remember to include this information.
 *  search the user forum to see if has been discussed before
 *  see the "known issues" section in the release notes
 *  and check the issue tracker to see if the issue has already been reported
-*  do not send private emails to Camel Team members to ask them to help you faster, or in the private only. Help on Apache Camel is volunteer based and must happen in the open on the public Mailing Lists. If you want to get help faster or in private, then see further below.
+*  do *not* send private emails to Camel Team members to ask them to help you faster, or in the private only. Help on Apache Camel is volunteer based and must happen in the open on the public Mailing Lists. If you want to get help faster or in private, then see further below.
 
 ### How to get help faster
 
@@ -67,7 +67,7 @@ We can help you much quicker if you try the following
 
 *  provide us with a JUnit test case that demonstrates your issue. e.g. if you think you've found a bug, can you create a test case to demonstrate the bug?
 *  [submit a patch](/manual/latest/contributing.html) fixing the bug! (We also buy you beer when we meet you if you submit bug fixes (smile) )
-*  for memory leak or performance related issues, if you can run a profiler on your test case and attach the output as a file (or zipped file if it's huge) to the JIRA we can normally fix things much faster. e.g. you could run jmap/jhat, JProfiler or YourKit on your code and send us the output. To find memory leaks it's quicker to resolve if you can tell us what classes are taking up all of the RAM; we can normally figure out what's wrong from that.
+*  for memory leak or performance related issues, if you can run a profiler on your test case and attach the output as a file (or zipped file if it's huge) to the JIRA we can normally fix things much faster. For example, you could run jmap/jhat, JProfiler or YourKit on your code and send us the output. To find memory leaks it's quicker to resolve if you can tell us what classes are taking up all of the RAM; we can normally figure out what's wrong from that.
 
 ## Commercial Support
 

--- a/content/community/support.md
+++ b/content/community/support.md
@@ -66,7 +66,7 @@ What version of Camel do you use? Remember to include this information.
 We can help you much quicker if you try the following
 
 *  provide us with a JUnit test case that demonstrates your issue. e.g. if you think you've found a bug, can you create a test case to demonstrate the bug?
-*  [submit a patch](/manual/latest/contributing.html) fixing the bug! (We also buy you beer when we meet you if you submit bug fixes (smile) )
+*  [submit a patch](/community/contributing/) fixing the bug! (We also buy you beer when we meet you if you submit bug fixes (smile) )
 *  for memory leak or performance related issues, if you can run a profiler on your test case and attach the output as a file (or zipped file if it's huge) to the JIRA we can normally fix things much faster. For example, you could run jmap/jhat, JProfiler or YourKit on your code and send us the output. To find memory leaks it's quicker to resolve if you can tell us what classes are taking up all of the RAM; we can normally figure out what's wrong from that.
 
 ## Commercial Support

--- a/content/community/team.md
+++ b/content/community/team.md
@@ -16,12 +16,13 @@ When posting to the mailing lists, use plain text mails. Do not use HTML mails. 
 | Andrea Cosentino       | acosentino       | Red Hat                    |
 | Antonin Stefanutti     | astefanutti      | Red Hat                    |
 | Babak Vahdat           | bvahdat          | Cyberlogic Consulting GmbH |
-| Ben O'Day              |  boday           | Initek Consulting          |
+| Ben O'Day              | boday            | Initek Consulting          |
 | Bilgin Ibryam          | bibryam          | Red Hat                    |
+| Bob Paulin             | bob              |                            |
 | Bruce Snyder           | bsnyder          |                            |
 | Charles Moulliard      | cmoulliard       | Red Hat                    |
 | Christian Mueller      | cmueller         | Amazon Web Services        |
-| Christian Posta        | ceposta          | Red Hat                    |
+| Christian Posta        | ceposta          | Solo                       |
 | Christian Schneider    | cschneider       |                            |
 | Claus Ibsen            | davsclaus        | Red Hat                    |
 | Colm O hEigeartaigh    | coheigea         | Talend                     |
@@ -47,7 +48,7 @@ When posting to the mailing lists, use plain text mails. Do not use HTML mails. 
 | Johan Edstrom          | joed             | Savoir Technologies        |
 | John Poth              |                  | Red Hat                    |
 | Jonathan Anstey        | janstey          | Red Hat                    |
-| James Netherton        | Red Hat          |                            |
+| James Netherton        |                  | Red Hat                    |
 | James Strachan         | jstrachan        |                            |
 | Luca Burgazzoli        | lburgazzoli      | Red Hat                    |
 | Martin Krasser         | krasserm         |                            |
@@ -55,6 +56,7 @@ When posting to the mailing lists, use plain text mails. Do not use HTML mails. 
 | Nicola Ferraro         | nicolaferraro    | Red Hat                    |
 | Onder Sezgin           | onders           |                            |
 | Omar Al-Safi           | oalsafi          | Talend                     |
+| Otavio Rodolfo Piske   | orpiske          | Red Hat                    |
 | Quinn Stevenson        | quinn            |                            |
 | Raul Kripalani         | raulk            |                            |
 | Pascal Schumacher      | pascalschumacher |                            |
@@ -91,8 +93,9 @@ If you have been contributing to the Apache Camel project, and you want your nam
 | Axel Hohaus             |                                |
 | Arjan Moraal            |                                |
 | Arno Noordover          | het CAK                        |
+| Bahaa Zaid              |                                |
 | Barry Kaplan            |                                |
-| Brett Meyer             | 3RiverDev, Savoir Technologies |
+| Brett Meyer             | Impact Upgrade                 |
 | Brian Diesenhaus        |                                |
 | Brian Guan              |                                |
 | Brian Madigan           |                                |
@@ -104,9 +107,11 @@ If you have been contributing to the Apache Camel project, and you want your nam
 | Christopher G. Stach II |                                |
 | Charles Anthony         |                                |
 | Christian Posta         | Red Hat                        |
+| Christopher Köster      |                                |
 | Claus Straube           |                                |
 | Dan Checkoway           |                                |
-| Dennis Byrne            | Thoughtworks                   |  
+| Dennis Byrne            | Thoughtworks                   |
+| Dimitrios Liapis        |                                |
 | Erik Onnen              |                                |
 | Fabrizio Spataro        | Bizmate                        |
 | Fernando Ribeiro        |                                |
@@ -122,6 +127,8 @@ If you have been contributing to the Apache Camel project, and you want your nam
 | Jérôme Delagnes         |                                |
 | Jeff Sparkes            |                                |
 | Jeff Lansing            | SYS Technologies               |
+| Jeremy Ross             | Elevation Solutions            |
+| Jeremy Volkman          |                                |
 | Joe Fernandez           | TTM                            |
 | John Heitmann           |                                |
 | Jonathan Cook           | BBC                            |
@@ -135,9 +142,10 @@ If you have been contributing to the Apache Camel project, and you want your nam
 | Lauri Kimmel            |                                |
 | Marco Buss              | product + concept              |
 | Marco Luebcke           |                                |
+| Mario Siegenthaler      |                                |
 | Mark Bucayan            |                                |
 | Mark Timmings           |                                |
-| Mario Siegenthaler      |                                |
+| Martin Bramwell         |                                |
 | Mathieu Lalonde         |                                |
 | Mats Henricson          |                                |
 | Matt Hoffman            |                                |

--- a/content/community/user-stories.md
+++ b/content/community/user-stories.md
@@ -7,64 +7,65 @@ This page is intended as a place to collect user stories and feedback on Apache 
 {{< table >}}
 | Company, Product, or Project  | Description |
 |-------------------------------|------------|
-|[Apache ActiveMQ](http://activemq.apache.org)|Uses Camel to add [Enterprise Integration Patterns](../../components/latest/eips/enterprise-integration-patterns.html) support into the [ActiveMQ broker](http://activemq.apache.org/enterprise-integration-patterns.html). If you run an out of the box ActiveMQ broker, look in *conf/camel.xml* and you'll see *camelContext* with some example routing rules. Can be used to bridge ActiveMQ with any of the camel [Components](../../manual/latest/component.html).|
-|[Apache ServiceMix](http://servicemix.apache.org/home.html)|Uses Camel as a routing engine as a [JBI service](http://servicemix.apache.org/servicemix-camel.html) unit for use either in [JBI](http://servicemix.apache.org/docs/4.4.x/jbi/components/index.html) or OSGi to route between JBI endpoints. See the [tutorial](http://servicemix.apache.org/3-beginner-using-apache-camel-inside-servicemix.html) or [example](http://servicemix.apache.org/camel-example.html)|
+|[Apache ActiveMQ](http://activemq.apache.org)|Uses Camel to add [Enterprise Integration Patterns](../../components/latest/eips/enterprise-integration-patterns.html) support into the [ActiveMQ broker](http://activemq.apache.org/enterprise-integration-patterns.html). If you run an out of the box ActiveMQ broker, look in *conf/camel.xml* and you'll see &lt;camelContext&gt; with some example routing rules. Can be used to bridge ActiveMQ with any of the camel [Components](../../manual/latest/component.html).|
+|[Apache ServiceMix](https://servicemix.apache.org/home.html)|Uses Camel as a routing engine as a [JBI service](http://servicemix.apache.org/servicemix-camel.html) unit for use either in [JBI](https://servicemix.apache.org/docs/4.4.x/jbi/components/index.html) or OSGi to route between JBI endpoints. See the [tutorial](https://servicemix.apache.org/3-beginner-using-apache-camel-inside-servicemix.html) or [example](https://servicemix.apache.org/camel-example.html) *** TODO, servicemix camel links broken ***|
 |[Apache Ignite](https://ignite.apache.org/)|Apache Ignite In-Memory Data Fabric is a high-performance, integrated and distributed in-memory platform for computing and transacting on large-scale data sets in real-time, orders of magnitude faster than possible with traditional disk-based or flash technologies.It uses Camel for its universal streamer.|
-|[JBoss Fuse](http://www.jboss.org/products/fuse/overview) ([formerly known as Fuse ESB](http://fusesource.com/products/enterprise-servicemix))|Red Hat provides a commercial distribution of an ESB which includes Camel, ActiveMQ, CXF, ServiceMix, Karaf, [Fabric8](http://fabric8.io), and [Hawtio](http://hawt.io).|
-|[Tools for Apache Camel](http://tools.jboss.org/features/apachecamel.html) (formerly know as Fuse IDE)|JBoss provides developer tooling for Camel, ActiveMQ, ServiceMix, Karaf, CXF, and [Fabric8](http://fabric8.io). The tools is a set of Eclipse plugins, such as a graphical Camel editor and also includes a Camel route debugger, where you can set breakpoints in your routes.|
-|[Apache Camel IDEA Plugin](https://github.com/camel-idea-plugin/camel-idea-plugin)|Plugin for Intellij IDEA to provide a set of Apache Camel related editing capabilities to the code editor.|
-|[Syndesis](https://syndesis.io)|Syndesis is for anyone that wants to integrate services. Syndesis includes a swish UI that enables the user to design integration flows and manage them from their browser.No coding required… Unless you really want to and then Syndesis allows you to dive into the code, develop your own connectors (if one doesn’t already exist), or hack on the integration definition directly.|
-|[Fabric8](http://fabric8.io)|Fabric8 is an open source integration platform, allow to run Camel applications anywhere; whether its on-premise or in the cloud.|
-|[hawt.io](http://hawt.io)|hawt.io is an open source HTML5 web application for visualizing, managing and tracing Camel routes &amp; endpoints, ActiveMQ brokers, JMX, OSGi, logging, and much more.|
-|[Grails](http://grails.org)|The [Grails Camel Routing Plugin](http://grails.org/plugin/routing) provides integration of Camel into Grails|
-|[Open ESB Camel SE](http://wiki.open-esb.java.net/Wiki.jsp?page=CamelSE)|Provides a JBI Service Engine for [Open ESB](https://open-esb.dev.java.net). See the [example](http://blogs.sun.com/polyblog/entry/camel_fuji) using OpenESB and Fuji|
-|[SubRecord](http://www.subrecord.org)|Uses Camel for routing and EDA processing|
-|[Open eHealth Integration Platform](http://openehealth.org/display/ipf2/Home)|The Open eHealth Integration Platform (IPF) is an extension of the Apache Camel routing and mediation engine. It has an application programming layer based on the Groovy programming language and comes with comprehensive support for message processing and connecting systems in the eHealth domain.|
-|[Camel SOAP](http://code.google.com/p/camel-soap)|Zero code WSDL based SOAP Client component for Apache Camel.|
-|[PrismTech](http://www.opensplice.com/section-item.asp?id=964)|PrismTech Simplifies Systems Integration &amp; SOA Connectivity with Release of Open Source OpenSplice DDS Connector for Apache Camel.|
-|[Axiom](http://github.com/hyperthunk/axiom)|Axiom is is a framework for testing integration scenarios and uses Apache Camel to interact with your integration stack.|
-|[Capital Region of Denmark](http://www.regionh.dk/English/English.htm)|Chose to switch proprietary ESB to open source Apache Camel.|
-|[Arla Foods](http://www.arla.com)|Uses Camel to integrate business backend with web application for farmers to access information about quality of their delivered milk. Application used in numerous european countries.|
-|[Akka](http://akkasource.org)|Akka uses Apache Camel to implement additional messaging interfaces for [actors](http://doc.akkasource.org/actors). Any Camel [component](http://camel.apache.org/components.html) can be used to send and receive messages from Akka actors. For details refer to the documentation of the [akka-camel](http://doc.akkasource.org/camel) extension module.|
-|[JBoss Drools](http://jboss.org/drools)|[Drools](http://blog.athico.com/2010/07/declarative-rest-services-for-drools.html) integrates with Camel.|
-|[JBoss ESB](http://www.jboss.org/jbossesb)|JBoss ESB integrates with Camel.|
-|[Simple-dm](http://code.google.com/p/simple-dm)|Simple Dynamic Module System for Maven integrates with Camel.|
-|[JOnAS Application Server](http://wiki.jonas.ow2.org/xwiki/bin/view/Main/WebHome)|JOnAS Application Server integrates with Camel.|
-|[Active BAM](http://code.google.com/p/active-bam)|Web Console Business Activity Monitoring for ServiceMix, Camel and ActiveMQ.|
-|[Apache Hise](http://incubator.apache.org/hise/)|Apache Hise (Open Source Implementation of WS-Human-Task Specification) integrates with Camel.|
-|[Catify](http://www.catify.com)|Catify is build on top of proven software stack like Spring, Apache ActiveMQ, Apache Camel, Apache Felix and MongoDB.|
-|[TouK](http://touk.pl/toukeu/rw/pages/index.en.do)|We are using Apache ServiceMix (both 3.x and 4.x) with [Apache Camel](http://camel.apache.org/), [Apache ODE](http://ode.apache.org/) and [Apache HISE](http://incubator.apache.org/hise/) as a middleware integration platform, with the biggest deployment for [Play](http://www.playmobile.pl), mobile telco operator in Poland|
-|[Progress Sonic ESB](http://web.progress.com/en/sonic/sonic-esb.html)|Progress Sonic ESB uses Camel internally to mediate Web Service messages (leveraging CXF stack) and Sonic ESB messages|
-|[scalaz-camel](https://github.com/krasserm/scalaz-camel)|A Scala(z)-based DSL for Apache Camel|
+|[Red Hat integration](https://www.redhat.com/en/technologies/jboss-middleware/fuse)|Red Hat provides a commercial distribution of an ESB which includes Camel, ActiveMQ, CXF, ServiceMix, Karaf, [Fabric8](http://fabric8.io), and [Hawtio](http://hawt.io).|
+|[Open eHealth Integration Platform](https://openehealth.org/display/ipf2/Home)|The Open eHealth Integration Platform (IPF) is an extension of the Apache Camel routing and mediation engine. It has an application programming layer based on the Groovy programming language and comes with comprehensive support for message processing and connecting systems in the eHealth domain.|
+|[Camel SOAP](https://code.google.com/p/camel-soap)|Zero code WSDL based SOAP Client component for Apache Camel.|
+|[PrismTech](https://www.opensplice.com/section-item.asp?id=964)|PrismTech Simplifies Systems Integration &amp; SOA Connectivity with Release of Open Source OpenSplice DDS Connector for Apache Camel.|
+|[Capital Region of Denmark](https://www.regionh.dk/English/English.htm)|Chose to switch proprietary ESB to open source Apache Camel.|
+|[Arla Foods](https://www.arla.com)|Uses Camel to integrate business backend with web application for farmers to access information about quality of their delivered milk. Application used in numerous european countries.|
+|[Akka](https://akkasource.org)|Akka uses Apache Camel to implement additional messaging interfaces for [actors](https://doc.akkasource.org/actors). Any Camel [component](../../components/latest/index.html) can be used to send and receive messages from Akka actors. For details refer to the documentation of the [akka-camel](https://doc.akkasource.org/camel) extension module.|
+|[JBoss Drools](https://www.drools.org)|[Drools](https://blog.athico.com/2010/07/declarative-rest-services-for-drools.html) integrates with Camel.|
+|[JBoss ESB](https://jbossesb.jboss.org/jbossesb)|JBoss ESB integrates with Camel.|
+|[Simple-dm](https://code.google.com/archive/p/simple-dm)|Simple Dynamic Module System for Maven integrates with Camel.|
+|[JOnAS Application Server](https://jonas.ow2.org/view/Documentation/JOnAS%20Camel)|JOnAS Application Server integrates with Camel.|
+|[Active BAM](https://code.google.com/p/active-bam)|Web Console Business Activity Monitoring for ServiceMix, Camel and ActiveMQ.|
+|[TouK](https://touk.pl/toukeu/rw/pages/index.en.do)|We are using Apache ServiceMix (both 3.x and 4.x) with Apache Camel, [Apache ODE](https://ode.apache.org/) and [Apache HISE](https://incubator.apache.org/hise/) as a middleware integration platform, with the biggest deployment for [Play](https://www.playmobile.pl), mobile telco operator in Poland|
 |[camel-camelpe](https://github.com/obergner/camelpe)|A CDI Portable Extension for Apache Camel|
-|[Kuali Ole](http://www.kuali.org/ole)|Kuali OLE uses Apache Camel in their open source administrative software|
-|[CaerusOne](http://code.google.com/p/caerusone)|CaerusOne is advanced application integration framework, sdk, server application server. It uses apache camel routing engine as part of core process engine.|
-|[JBoss SwitchYard](http://www.jboss.org/switchyard)|SwitchYard is a lightweight service delivery framework for SOA and its integrated with Camel out of the box.|
-|[camel-scala-extra](https://github.com/osinka/camel-scala-extra)|Extra Apache Camel methods for Scala|
+|[CaerusOne](http://code.google.com/p/caerusone)|CaerusOne is advanced application integration framework, sdk, server application server. It uses Apache Camel routing engine as part of core process engine.|
+|[JBoss SwitchYard](https://switchyard.jboss.org)|SwitchYard is a lightweight service delivery framework for SOA and its integrated with Camel out of the box.|
 |[camel-play](https://github.com/marcuspocus/play-camel)|A EIP + Messaging module for the Play! Framework|
-|[Activiti](http://activiti.org)|[Activiti BPM](http://bpmn20inaction.blogspot.com/2011/05/supersize-activiti-with-mule-esb-and.html) has direct Apache Camel integration.|
-|[EasyForms Camel Support](http://easyforms-camel.forge.onehippo.org)|The EasyForms Camel Support Components provides extended HST EasyForms Components which can invoke Apache Camel Routes.|
-|[CamelDiagramGenerator](http://code.google.com/p/rmannibucau/wiki/CamelDiagramGenerator)|A maven plugin to generate camel diagram from routes.|
-|[CamelWatch](http://sksamuel.github.com/camelwatch)|A web app for monitoring Camel applications.|
-|[JRebel](http://zeroturnaround.com/software/jrebel)|JRebel now supports [reloading](http://zeroturnaround.com/jrebel/jrebel-5-1-2-released-apache-camel-now-supported) Camel routes without any application server restarts.|
-|[Camelry](https://github.com/AlanFoster/Camelry)|This IntelliJ plugin is designed to improve the development experience when working with Apache Blueprint, Apache karaf and Apache Camel.|
-|[Jel](http://giacomolm.github.io/Jel)|Javascript graphical Editor that generates DSL. This is a web based tooling that offers a GUI for defining and editing Apache Camel routes using the XML DSL.|
-|[Babel](http://crossing-tech.github.io/babel)|Babel is a Domain Specific Language for Integration made in Scala. It provides elegant API in order to use well-known integration frameworks. Babel provides an API on top of Apache Camel which may be used in Scala.|
+|[EasyForms Camel Support](https://easyforms-camel.forge.onehippo.org)|The EasyForms Camel Support Components provides extended HST EasyForms Components which can invoke Apache Camel Routes.|
+|[CamelWatch](https://sksamuel.github.com/camelwatch)|A web app for monitoring Camel applications.|
+|[Streamz](https://github.com/krasserm/streamz)|A combinator library for integrating Functional Streams for Scala (FS2), Akka Streams and Apache Camel.|
+|[scalaz-camel](https://github.com/krasserm/scalaz-camel)|A Scala(z)-based DSL for Apache Camel|
+|[Babel](https://crossing-tech.github.io/babel)|Babel is a Domain Specific Language for Integration made in Scala. It provides elegant API in order to use well-known integration frameworks. Babel provides an API on top of Apache Camel which may be used in Scala.|
 |[Wildfly Camel](https://github.com/wildflyext/wildfly-camel)|The WildFly-Camel Subsystem allows you to add Camel Routes as part of the WildFly configuration. Routes can be deployed as part of JavaEE applications. JavaEE components can access the Camel Core API and various Camel Component APIs. Your Enterprise Integration Solution can be architected as a combination of JavaEE and Camel functionality.|
 |[Camel M2M gateway](https://github.com/hekonsek/camel-m2m-gateway)|This project summarizes the R&amp;D activities around the process of adopting the Apache Camel as the Internet Of Things M2M gateway. By the gateway we understand a field device with the moderate processing power (such as Raspberry Pi or BeagleBone Black) responsible for the routing of the messages between the IoT edge devices (sensors, drones, cars, etc) and the data center.|
 |[Netflix](https://www.youtube.com/watch?v=k_ckJ7QgLW0#t=480)|Netflix uses Apache Camel as part of the cloud payment system.|
-|[JBoss Forge](http://forge.jboss.org)|The [Camel](http://forge.jboss.org/addon/io.fabric8.forge:camel) addon from [Fabric8](http://fabric8.io) allows to setup and manage your Apache Camel maven projects from a CLI, Eclipse, IDEA, and NetBeans. With this addon from the IDEs you can use a wizard driven UI to add new Camel components, add/edit existing endpoints in a UI that allows to edit each options individually in a more type safe manner. You can also setup your Maven project for Docker and Kubernetes platforms. 
-|[Islandora](http://islandora.ca)|Islandora is an open-source software framework designed to help institutions and organizations and their audiences collaboratively manage, and discover digital assets using a best-practices framework.&nbsp;&nbsp;They use Camel and JMS queues in the platform.|
-|SAP HANA|[HANA](https://blogs.saphana.com/2016/02/01/hana-smart-data-integration-simplifies-connecting-consuming-facebook-data-hana-apache-camel-adapter) The platform from SAP uses Apache Camel.|
+|[Islandora](http://islandora.ca)|Islandora is an open-source software framework designed to help institutions and organizations and their audiences collaboratively manage, and discover digital assets using a best-practices framework. They use Camel and JMS queues in the platform.|
+|[SAP HANA](https://blogs.saphana.com/2016/02/01/hana-smart-data-integration-simplifies-connecting-consuming-facebook-data-hana-apache-camel-adapter)| The platform from SAP uses Apache Camel.|
 |[Hammock](https://github.com/hammock-project/hammock])|Hammock is a CDI based microservices framework. Hammock integrates with Camel.|
-|[Streamz](https://github.com/krasserm/streamz)|A combinator library for integrating Functional Streams for Scala (FS2), Akka Streams and Apache Camel.|
 |[OpenHub](http://www.openhub.cz)|OpenHub is an integration platform that is built on top of Apache Camel.|
-|[API Tracker 4j](https://abi-laboratory.pro/java/tracker/timeline/camel-core) of camel-core|The review of API changes for the Camel Core library since Camel 2.16 which is updated several times per week.|
 |[Assimbly Gateway](https://github.com/assimbly/gateway)|A message gateway based on Apache Camel|
-|[GraphAwareHume Orchestra](https://graphaware.com/products/hume/)|Integration framework built on top of Apache Camel, making as easy as simple clicks.|
+|[GraphAwareHume Orchestra](https://graphaware.com/products/hume/)|Integration framework built on top of Apache Camel, making as easy as simple clicks.| ** added in MD ***
 |[Yeoman generator-camel-project](https://www.npmjs.com/package/generator-camel-project)|This project uses the Yeoman framework and node.js to generate the scaffold for Apache Camel projects as well as a simple template that can be used as a starting point.|
 |[Camel-graph](https://github.com/avvero/camel-graph)|Camel-graph is a route graph viewer for ServiceMix and Camel applications, visualising your route topologies with metrics.|
 |[Camel Extra project](https://camel-extra.github.io/)|contains a number of extension components which due to GPL/LGPL licensing cannot be hosted at Apache.
+|[Platform6](https://www.platform6.io/) | Decentralised application framework for blockchains, called Platform 6 which heavily uses Apache Camel and Web3j.|
+{{< /table >}}
+
+## Developer Tooling
+{{< table >}}
+| Company, Product, or Project  | Description |
+|-------------------------------|-------------|
+|[Eclipse Desktop Tools for Apache Camel](http://tools.jboss.org/features/fusetools.html)|Red Hat provides developer tooling for Camel, ActiveMQ, ServiceMix, Karaf, CXF, and [Fabric8](http://fabric8.io). The tools are a set of Eclipse plugins, such as a graphical Camel editor and also includes a Camel route debugger, where you can set breakpoints in your routes.|
+|[Apache Camel IDEA Plugin](https://github.com/camel-idea-plugin/camel-idea-plugin)|Plugin for Intellij IDEA to provide a set of Apache Camel related editing capabilities to the code editor.|
+|[Camel Language Server](https://github.com/camel-tooling/camel-language-server)| A server implementation of the [Language Server protocol](https://github.com/Microsoft/language-server-protocol) that provides Camel DSL smartness (completion, validation, hover, outline). It is packaged for [VS Code](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-apache-camel), [Eclipse Desktop IDE](https://marketplace.eclipse.org/content/language-support-apache-camel) and [Eclipse Che](https://www.eclipse.org/che/). It can be embedded in several [other editors and IDEs](https://github.com/camel-tooling/camel-language-server#clients).|
+|[VS Code extension pack for Camel](https://marketplace.visualstudio.com/items?itemName=redhat.apache-camel-extension-pack)|It provides a set of tools to develop Camel applications.|
+|[Camel Designer](https://marketplace.visualstudio.com/items?itemName=brunoNetId.camel-designer)| Visual designer generating Camel XML routes.|
+|[Syndesis](https://syndesis.io)|Syndesis is for anyone that wants to integrate services. Syndesis includes a swish UI that enables the user to design integration flows and manage them from their browser.No coding required… Unless you really want to and then Syndesis allows you to dive into the code, develop your own connectors (if one doesn’t already exist), or hack on the integration definition directly.|
+|[Fabric8](http://fabric8.io)|Fabric8 is an open source integration platform, allow to run Camel applications anywhere; whether its on-premise or in the cloud.|
+|[hawt.io](http://hawt.io)|hawt.io is an open source HTML5 web application for visualizing, managing and tracing Camel routes &amp; endpoints, ActiveMQ brokers, JMX, OSGi, logging, and much more.|
+|[Axiom](http://github.com/hyperthunk/axiom)|Axiom is is a framework for testing integration scenarios and uses Apache Camel to interact with your integration stack.|
+|[CamelDiagramGenerator](http://code.google.com/p/rmannibucau/wiki/CamelDiagramGenerator)|A maven plugin to generate camel diagram from routes.|
+|[JRebel](http://zeroturnaround.com/software/jrebel)|JRebel now supports [reloading](http://zeroturnaround.com/jrebel/jrebel-5-1-2-released-apache-camel-now-supported) Camel routes without any application server restarts.|
+|[Camelry](https://github.com/AlanFoster/Camelry)|This IntelliJ plugin is designed to improve the development experience when working with Apache Blueprint, Apache karaf and Apache Camel.|
+|[Jel](http://giacomolm.github.io/Jel)|Javascript graphical Editor that generates DSL. This is a web based tooling that offers a GUI for defining and editing Apache Camel routes using the XML DSL.|
+|[JBoss Forge](http://forge.jboss.org)|The [Camel](http://forge.jboss.org/addon/io.fabric8.forge:camel) addon from [Fabric8](http://fabric8.io) allows to setup and manage your Apache Camel maven projects from a CLI, Eclipse, IDEA, and NetBeans. With this addon from the IDEs you can use a wizard driven UI to add new Camel components, add/edit existing endpoints in a UI that allows to edit each options individually in a more type safe manner. You can also setup your Maven project for Docker and Kubernetes platforms.|
+|[API Tracker 4j](https://abi-laboratory.pro/java/tracker/timeline/camel-core) of camel-core|The review of API changes for the Camel Core library since Camel 2.16 which is updated several times per week.|
 {{< /table >}}
 
 ## User Groups

--- a/content/docs/_index.md
+++ b/content/docs/_index.md
@@ -13,7 +13,7 @@ Title: "Documentation"
 
 ## Camel Core
 
-The [User Manual](/manual/latest/) is a comprehensive guide meant to help you with the key concepts of Apache Camel and software integration, from how to [begin contributing](/manual/latest/contributing.html) to Apache Camel, how to [upgrade to Camel 3.x](/manual/latest/camel-3x-upgrade-guide.html), to [architecture](/manual/latest/architecture.html) or [integration patterns](/components/latest/eips/enterprise-integration-patterns.html).
+The [User Manual](/manual/latest/) is a comprehensive guide meant to help you with the key concepts of Apache Camel and software integration, from how to [get started](/manual/latest/getting-started.html) with Apache Camel, how to [upgrade to Camel 3.x](/manual/latest/camel-3x-upgrade-guide.html), to [architecture](/manual/latest/architecture.html) or [integration patterns](/components/latest/eips/enterprise-integration-patterns.html).
 
 <p>
 <a class="button dark" href="/manual/latest/">Documentation</a>

--- a/content/download/_index.md
+++ b/content/download/_index.md
@@ -6,7 +6,7 @@ We do frequent releases, a release almost every month, and even though we strive
 
 Unless you need the latest features, you might consider using a Long Term Support (LTS) version that will receive bug and security fixes for a longer time - up to one year.
 
-A good strategy to prepare for future LTS releases might be to test the latest releases. You can do this on less impactful projects or by running tests of your codebase against newer releases. Please do [report any issues](/manual/latest/contributing.html#using-the-issue-tracker) with functionality or backward compatibility so they can be addressed in time for the LTS version.
+A good strategy to prepare for future LTS releases might be to test the latest releases. You can do this on less impactful projects or by running tests of your codebase against newer releases. Please do [report any issues](/community/contributing/#if-you-find-a-bug-or-problem) with functionality or backward compatibility so they can be addressed in time for the LTS version.
 
 For information on the release planning look at the blog posts in the [Roadmap](/categories/Roadmap/) category.
 

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -34,7 +34,7 @@
             <dl>
                 <dt><label for="footer-toggle-community">Community</label><label for="footer-toggle-community">&#65291;</label></dt>
                 <dd><a href="/community/support/">Support</a></dd>
-                <dd><a href="/manual/latest/contributing.html">Contributing</a></dd>
+                <dd><a href="/community/contributing/">Contributing</a></dd>
                 <dd><a href="/community/mailing-list">Mailing Lists</a></dd>
                 <dd><a href="/community/user-stories/">User stories</a></dd>
                 <dd><a href="/community/articles/">Articles</a></dd>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -35,7 +35,7 @@
                 <dt><label for="footer-toggle-community">Community</label><label for="footer-toggle-community">&#65291;</label></dt>
                 <dd><a href="/community/support/">Support</a></dd>
                 <dd><a href="/manual/latest/contributing.html">Contributing</a></dd>
-                <dd><a href="/manual/latest/mailing-lists.html">Mailing Lists</a></dd>
+                <dd><a href="/community/mailing-list">Mailing Lists</a></dd>
                 <dd><a href="/community/user-stories/">User stories</a></dd>
                 <dd><a href="/community/articles/">Articles</a></dd>
                 <dd><a href="/community/books/">Books</a></dd>


### PR DESCRIPTION
The Community section of the Camel user manual contained .adoc pages which duplicated content in the Community section of the website. They've been removed and extra changes made there have been merged to the pages in the Community section.
There are also changes in the camel repository itself which need to be merged at the same time as these.