### PR TITLE
chore: redesign the release downloads

### DIFF
--- a/antora-ui-camel/src/css/download.css
+++ b/antora-ui-camel/src/css/download.css
@@ -6,6 +6,20 @@
   white-space: nowrap;
 }
 
-.download tr td:first-child small {
-  font-style: italic;
+.download tr td:first-child strong {
+  font-size: 0.9rem;
+}
+
+.download tr td em.kind {
+  color: var(--body-background);
+  background: var(--color-asf-light-blue);
+  border-radius: 3px;
+  font-style: normal;
+  font-size: 0.75rem;
+  font-weight: bold;
+  padding: 0.1rem 0.3rem;
+}
+
+.download .tableblock tbody tr:nth-child(2n) {
+  background: var(--color-smoke-50);
 }

--- a/antora-ui-camel/src/css/release.css
+++ b/antora-ui-camel/src/css/release.css
@@ -13,6 +13,10 @@
   word-break: break-word;
 }
 
+.release .tableblock thead tr th {
+  text-align: left;
+}
+
 .release .tableblock tbody tr:nth-child(2n) {
   background: var(--color-smoke-50);
 }

--- a/antora-ui-camel/src/css/vars.css
+++ b/antora-ui-camel/src/css/vars.css
@@ -19,6 +19,7 @@
   --color-black: #000;
   --color-asf-dark-blue: #303284;
   --color-asf-moderate-blue: #4f51ae;
+  --color-asf-light-blue: #7375bf;
   --color-camel-orange: #e97826;
   --color-camel-orange-light: #f39421;
   --color-highlight: #cf7428;

--- a/archetypes/release-note.md
+++ b/archetypes/release-note.md
@@ -1,5 +1,7 @@
 ---
-date: {{ .Date }}
+date: {{ dateFormat "2006-01-02" .Date }}
+# EOL date, default 1 year from release date
+eol: {{ ((time .Date).AddDate 1 0 0).Format "2006-01-02" }}
 draft: true
 type: release-note
 version: "{{ replace .File.BaseFileName "release-" "" }}"

--- a/content/releases/release-3.4.5.md
+++ b/content/releases/release-3.4.5.md
@@ -1,5 +1,6 @@
 ---
 date: 2020-12-23
+eol: 2021-12-01
 draft: false
 type: release-note
 version: 3.4.5

--- a/content/releases/release-3.7.4.md
+++ b/content/releases/release-3.7.4.md
@@ -1,5 +1,6 @@
 ---
 date: 2021-05-03
+eol: 2022-05-01
 draft: false
 type: release-note
 version: 3.7.4

--- a/layouts/partials/releases/downloads.html
+++ b/layouts/partials/releases/downloads.html
@@ -114,11 +114,12 @@
 <table class="tableblock frame-all grid-all stretch">
     <thead>
         <tr>
-            <th>Version</th>
-            <th>Description</th>
-            <th>Download Link</th>
-            <th>PGP Signature file of download</th>
-            <th>SHA512 Checksum file of download</th>
+            {{ if eq $.Section "download" }}
+                <th>Version</th>
+                <th>Note</th>
+            {{ end }}
+            <th>Download</th>
+            <th>Signature and checksum</th>
         </tr>
     </thead>
 
@@ -132,30 +133,41 @@
             {{ end }}
 
             <tr>
-                {{ if gt (len $.Category.downloads) 1 }}
-                <td rowspan="{{ len $.Category.downloads }}">
-                {{ else }}
-                <td>
-                {{ end }}
-                    <strong><a href="{{ $release_note.Permalink | relURL }}">{{ $v }}</a></strong>
-                    {{ with $kind }}
-                        <br/>
-                        <small>{{ . }}</small>
-                        <br/>
-                        <small>{{ ((index (where (where (where $.Pages "Section" "releases") ".Params.category" $.Category.id) ".Params.version" $v) 0).Param "date").Format "Jan, 2006" }}</small>
+                {{ if eq $.Section "download" }}
+                    {{ if gt (len $.Category.downloads) 1 }}
+                    <td rowspan="{{ len $.Category.downloads }}">
+                    {{ else }}
+                    <td>
                     {{ end }}
-                </td>
+                        <strong><a href="{{ $release_note.Permalink | relURL }}">{{ $v }}</a></strong>
+                        {{ with $kind }}
+                            <br/>
+                            <em class="kind">{{ . }}</em>
+                        {{ end }}
+                    </td>
+                    {{ if gt (len $.Category.downloads) 1 }}
+                    <td rowspan="{{ len $.Category.downloads }}">
+                    {{ else }}
+                    <td>
+                    {{ end }}
+                        <a href="{{ $release_note.Permalink | relURL }}">Release notes</a>
+                        <br/>
+                        {{ with (index (where (where (where $.Pages "Section" "releases") ".Params.category" $.Category.id) ".Params.version" $v) 0) }}
+                        <small>
+                            Released in {{ (.Param "date").Format "Jan 2006" }}{{ if .Param "eol" }}, end of life in {{ dateFormat "Jan 2006" (.Param "eol") }}{{ end }}
+                        </small>
+                        {{ end }}
+                    </td>
+                {{ end }}
                 {{ range $idx, $download := $.Category.downloads }}
                     {{ if ne $idx 0 }}
                     </tr><tr>
                     {{ end }}
                     {{ $path := replace $download.path_format "{version}" $v }}
                     {{ $filename := replace $download.filename_format "{version}" $v }}
-                    <td>{{ $download.name}}</td>
                     {{ if $path }}
-                        <td><a href="{{ $artifact_base_url }}{{ $path }}">{{ $filename }}</a></td>
-                        <td><a href="{{ $meta_base_url }}{{ $path }}.asc">{{ $filename }}.asc</a></td>
-                        <td><a href="{{ $meta_base_url }}{{ $path }}{{ $hash_extension }}">{{ $filename }}{{ $hash_extension }}</a></td>
+                        <td><a href="{{ $artifact_base_url }}{{ $path }}">{{ $filename }}</a> ({{ $download.name}})</td>
+                        <td><a href="{{ $meta_base_url }}{{ $path }}.asc">PGP Signature</a>, <a href="{{ $meta_base_url }}{{ $path }}{{ $hash_extension }}">SHA512 Checksum</a></td>
                     {{ else }}
                          <td colspan="3"><a href="{{ .link }}">{{ replace .title "{version}" $v }}</a></td>
                     {{ end }}

--- a/layouts/shortcodes/downloads.html
+++ b/layouts/shortcodes/downloads.html
@@ -1,3 +1,3 @@
 {{ range $x, $category := sort (index $.Site.Data "release-categories") "order" }}
-    {{ partial "releases/downloads.html" (dict "Category" (index (index $.Site.Data "release-categories") $category.id) "Pages" $.Site.Pages) }}
+    {{ partial "releases/downloads.html" (dict "Category" (index (index $.Site.Data "release-categories") $category.id) "Pages" $.Site.Pages "Section" $.Page.Section) }}
 {{ end }}


### PR DESCRIPTION
With this now we have `eol` front matter that'll be added to the new
_Notes_ column in the download table which, replaces the _Description_
column; also features a link to the release notes, previously linked
from the version number. The description of the download is now in
parentheses next to the download link.

The kind of the download (LTS/latest/legacy) is now designed as a label
to make it more prominent.

Also shortens the column headings for better layout on smaller screens
and compacts the PGP and SHA512 columns into one.