### PR TITLE
Changed the link to Componend DSL to a statick github file

### DIFF
--- a/content/blog/2020/07/camel-quarkus-release-1.0.0-CR3/index.md
+++ b/content/blog/2020/07/camel-quarkus-release-1.0.0-CR3/index.md
@@ -17,7 +17,7 @@ Here are some highlights of Camel Quarkus 1.0.0-CR3.
 The following new extensions were added:
 
 * [AWS 2 Athena](/camel-quarkus/latest/reference/extensions/aws2-athena.html)
-* [Component DSL](/camel-quarkus/latest/reference/extensions/componentdsl.html)
+* [Component DSL](https://github.com/apache/camel-quarkus/blob/1.0.0-CR3/docs/modules/ROOT/pages/extensions/componentdsl.adoc)
 * [JOLT](/camel-quarkus/latest/reference/extensions/jolt.html)
 * [JTA](/camel-quarkus/latest/reference/extensions/jta.html)
 * [OpenApi Java](/camel-quarkus/latest/reference/extensions/openapi-java.html)


### PR DESCRIPTION
That quarkus doc page from version 1.0.0.-CR3 was deleted.