### PR TITLE
chore: prepare jsonpath pipeline

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -98,7 +98,6 @@ asciidoc:
     - ./extensions/table.js
     - ./extensions/inline-styles.js
     - "@djencks/asciidoctor-antora-indexer"
-    - "@djencks/asciidoctor-jsonpath"
   attributes:
     eip-vc: latest@components
 
@@ -106,3 +105,7 @@ runtime:
   log:
     level: info
     failure_level: warn
+
+pipeline:
+  extensions:
+    - require: '@djencks/asciidoctor-jsonpath'

--- a/util/jsonpath-util.js
+++ b/util/jsonpath-util.js
@@ -1,0 +1,65 @@
+module.exports = {
+  alias: (name, aliases) => {
+    for (expr of (aliases || '').split(',')) {
+      const {pattern, alias} = splitOnce(expr)
+      const re = new RegExp(pattern, 'i')
+      if (re.test(name)) {
+        return alias
+      }
+    }
+    return ''
+  },
+
+  description: (value) => {
+    try {
+      return module.exports.strong(value, "Autowired")
+        + module.exports.strong(value, "Required")
+        + module.exports.strong(value, "Deprecated")
+        + module.exports.escapeAttributes(value.description) + (value.description.endsWith(".") ? "" : ".")
+        + (value.deprecatedNote ? `\n\nNOTE: ${value.deprecatedNote}` : "")
+        + (value.enum ? `${["\n\nEnum values:\n"].concat(value.enum).join("\n* ")}` : "")
+    } catch (e) {
+      console.log('error', e)
+      return e.msg()
+    }
+  },
+
+  escapeAttributes: (text) => {
+    return text.split('{').join('\\{')
+  },
+
+  formatSignature: (signature) => {
+    return signature.split('$').join('.') + ';'
+  },
+
+  javaSimpleName: (name) => {
+    return name.split(/<.*>/).join('').split('.').pop()
+  },
+
+  pascalCase: (input) => {
+    return input ?
+      input.split('-').map((segment) => {
+        return segment.length ?
+          segment.charAt(0).toUpperCase() + segment.slice(1) :
+          segment
+      }).join('') :
+      input
+  },
+
+  producerConsumerLong: (consumerOnly, producerOnly) => {
+    if (consumerOnly) return 'Only consumer is supported'
+    if (producerOnly) return 'Only producer is supported'
+    return 'Both producer and consumer are supported'
+  },
+
+  strong: (data, text) => {
+    return data[text.toLowerCase()] ? `*${text}* ` : ''
+  },
+}
+
+function splitOnce (querySpec, token = '=') {
+  const index = querySpec.indexOf(token)
+  const pattern = querySpec.substring(0, index).trim()
+  const alias = querySpec.substring(index + 1).trim()
+  return { pattern, alias }
+}


### PR DESCRIPTION
This is the last bit needed for the changes in https://github.com/apache/camel/pull/6040

To get merged, utilizing the jsonpath macro in the Antora pipeline to generate component/endpoint options table.

This has been picked from https://github.com/apache/camel-website/pull/617 to ease merging. The bit that was not included in this or in the PR #620 is the refactoring around absolute/relative URLs, i.e. the `patch-sitemap.js` is still present after this.