### PR TITLE
restore canonical link element

### DIFF
--- a/antora-ui-camel/src/partials/head-info.hbs
+++ b/antora-ui-camel/src/partials/head-info.hbs
@@ -1,3 +1,6 @@
+    {{#with page.canonicalUrl}}
+    <link rel="canonical" href="{{{this}}}">
+    {{/with}}
     {{#unless (eq page.attributes.pagination undefined)}}
     {{#with page.previous}}
     <link rel="prev" href="{{{relativize ./url}}}">


### PR DESCRIPTION
This restores the <link rel="canonical"... /> element recently removed.