### PR TITLE
Provide pointers to the project's Jira

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ Tools used to generate the website:
    website.
  - (optional) [Maven](https://maven.apache.org/) a build tool used to run the complete website generating process.
 
+## Issues
+
+Please report issues on the [project's Jira](https://issues.apache.org/jira/projects/CAMEL) specifiying the `website` component.
+
 ## Build with Node and yarn
 
 You can build the website locally using the tools `Node.js` and `yarn`.


### PR DESCRIPTION
It's not clear how to open issues about the website right now. This adds a small section at the top of the README to point to the project's Jira.