### PR TITLE
refactor: latest -> next redirects

### DIFF
--- a/static/.htaccess
+++ b/static/.htaccess
@@ -1283,25 +1283,31 @@ Redirect 301 /blog/release-3-4-4.html /blog/2020/09/RELEASE-3.4.4/
 Redirect 301 /blog/release-3-5-0.html /blog/2020/09/RELEASE-3.5.0/
 Redirect 301 /blog/release-3-6-0.html /blog/2020/09/RELEASE-3.6.0/
 
-# default to 'next' documentation versions, to make it easier on folk to type in shorter urls
-# However, this may not comply with the Apache policy to not direct people to unreleased software.
-RewriteRule "^components/$" "/components/next/" [R=permanent,L]
-RewriteRule "^camel-spring-boot/$" "/camel-spring-boot/next/" [R=permanent,L]
-RewriteRule "^camel-karaf/$" "/camel-karaf/next/" [R=permanent,L]
-RewriteRule "^camel-k/$" "/camel-k/next/" [R=permanent,L]
-RewriteRule "^camel-kafka-connector/$" "/camel-kafka-connector/next/" [R=permanent,L]
-RewriteRule "^camel-quarkus/$" "/camel-quarkus/next/" [R=permanent,L]
+# if the request can serve the file, serve it don't evaluate rules below
+RewriteCond %{REQUEST_FILENAME} !-f
 
-# latest to next
-RewriteRule "^components/latest/$" "/components/next/" [R=permanent,L]
-RewriteRule "^camel-spring-boot/latest/$" "/camel-spring-boot/next/" [R=permanent,L]
-RewriteRule "^camel-karaf/latest/$" "/camel-karaf/next/" [R=permanent,L]
-RewriteRule "^camel-k/latest/$" "/camel-k/next/" [R=permanent,L]
-RewriteRule "^camel-kafka-connector/latest/$" "/camel-kafka-connector/next/" [R=permanent,L]
-RewriteRule "^camel-quarkus/latest/$" "/camel-quarkus/next/" [R=permanent,L]
+# request for `/<Antora component>` with either `/latest` or not `/next`,
+# eating up the next `/` if it exists and capturing everything after that
+# get redirected to `/<Antora component>/next/<what was captured>`
+# NOTES:
+#  * no / at the beginning in the rule, i.e. starts with `^(components...`
+#    as `RewriteBase` is set to `/`, so no slash prefix here
+#  * first group captures the current component name
+#  * next group eats `/latest` or doesn't match `/next` but consumes both
+#    the negative match against `/next` is to prevent redirect loops for
+#    urls with `/next` in them (e.g. `/<Antora component/next/...`)
+#  * optionaly matching `/` consumes the `/` if it's there so we can
+#    add the `/` so `/components/next` becomes `/components/next/` but
+#    `/components/next/` doesn't become `/components/next//`
+#  * we need to be careful with Antora componets with the same prefixes
+#    e.g. camel-k, camel-karaf and camel-kafka-connector, so we don't match
+#    partialy and capture the rest of the Antora component name in subsequent
+#    groups
+RewriteRule ^(components|camel-spring-boot|camel-k(?:araf|afka-connector)|camel-quarkus)(?|(/latest)|(?!/next))/?(.*)$ /$1/next/$3 [R=permanent,L]
 
 # manual is now unversioned
-RewriteRule "^manual/latest/$" "/manual/" [R=permanent,L]
+Redirect 301 /manual/latest/ /manual/
+Redirect 301 /manual/latest /manual/
 
 # Disable the pattern matching based on filenames.
 #

--- a/support/README.md
+++ b/support/README.md
@@ -18,7 +18,7 @@ Use like this from the root of the git repository after building the
 website (`yarn build`):
 
 ```shell
-$ docker run -it --rm -p 80:80 -p 443:443 \
+$ docker run --rm -p 80:80 -p 443:443 \
   -v "$PWD/public":/usr/local/apache2/htdocs/:Z \
   -v "$PWD/support/http":/support:Z \
   httpd:2.4 /bin/bash -c "cp /support/* /usr/local/apache2/conf/ && httpd-foreground" 

--- a/tests/redirect.sh
+++ b/tests/redirect.sh
@@ -1,0 +1,69 @@
+#!/bin/env bash
+
+BASE_URL="${1:-https://localhost}"
+
+function test {
+  local url=$1
+  local code=$2
+  local location=$3
+
+  local output=$(curl -k -w '%{http_code},%{redirect_url}\n' -o /dev/null -s "${url}")
+
+  if [ "${output}" == "${code},${location}" ]; then 
+    echo " OK : ${url}"
+  else
+    echo "FAIL: ${url} -> ${code},${location} != ${output}"
+  fi
+}
+
+test $BASE_URL/components 301 $BASE_URL/components/next/
+test $BASE_URL/components/ 301 $BASE_URL/components/next/
+test $BASE_URL/components/next 301 $BASE_URL/components/next/
+test $BASE_URL/components/next/ 200
+test $BASE_URL/components/latest 301 $BASE_URL/components/next/
+test $BASE_URL/components/latest/ 301 $BASE_URL/components/next/
+test $BASE_URL/components/latest/activemq-component.html 301 $BASE_URL/components/next/activemq-component.html
+test $BASE_URL/components/next/activemq-component.html 200
+
+test $BASE_URL/camel-spring-boot 301 $BASE_URL/camel-spring-boot/next/
+test $BASE_URL/camel-spring-boot/ 301 $BASE_URL/camel-spring-boot/next/
+test $BASE_URL/camel-spring-boot/next 301 $BASE_URL/camel-spring-boot/next/
+test $BASE_URL/camel-spring-boot/next/ 200
+test $BASE_URL/camel-spring-boot/latest 301 $BASE_URL/camel-spring-boot/next/
+test $BASE_URL/camel-spring-boot/latest/ 301 $BASE_URL/camel-spring-boot/next/
+test $BASE_URL/camel-spring-boot/latest/list.html 301 $BASE_URL/camel-spring-boot/next/list.html
+test $BASE_URL/camel-spring-boot/next/list.html 200
+
+test $BASE_URL/camel-karaf 301 $BASE_URL/camel-karaf/next/
+test $BASE_URL/camel-karaf/ 301 $BASE_URL/camel-karaf/next/
+test $BASE_URL/camel-karaf/next 301 $BASE_URL/camel-karaf/next/
+test $BASE_URL/camel-karaf/next/ 200
+test $BASE_URL/camel-karaf/latest 301 $BASE_URL/camel-karaf/next/
+test $BASE_URL/camel-karaf/latest/ 301 $BASE_URL/camel-karaf/next/
+test $BASE_URL/camel-karaf/latest/components.html 301 $BASE_URL/camel-karaf/next/components.html
+test $BASE_URL/camel-karaf/next/components.html 200
+
+test $BASE_URL/camel-kafka-connector 301 $BASE_URL/camel-kafka-connector/next/
+test $BASE_URL/camel-kafka-connector/ 301 $BASE_URL/camel-kafka-connector/next/
+test $BASE_URL/camel-kafka-connector/next 301 $BASE_URL/camel-kafka-connector/next/
+test $BASE_URL/camel-kafka-connector/next/ 200
+test $BASE_URL/camel-kafka-connector/latest 301 $BASE_URL/camel-kafka-connector/next/
+test $BASE_URL/camel-kafka-connector/latest/ 301 $BASE_URL/camel-kafka-connector/next/
+test $BASE_URL/camel-kafka-connector/latest/contributor-guide/release-guide.html 301 $BASE_URL/camel-kafka-connector/next/contributor-guide/release-guide.html
+test $BASE_URL/camel-kafka-connector/next/contributor-guide/release-guide.html 200
+
+test $BASE_URL/camel-quarkus 301 $BASE_URL/camel-quarkus/next/
+test $BASE_URL/camel-quarkus/ 301 $BASE_URL/camel-quarkus/next/
+test $BASE_URL/camel-quarkus/next 301 $BASE_URL/camel-quarkus/next/
+test $BASE_URL/camel-quarkus/next/ 200
+test $BASE_URL/camel-quarkus/latest 301 $BASE_URL/camel-quarkus/next/
+test $BASE_URL/camel-quarkus/latest/ 301 $BASE_URL/camel-quarkus/next/
+test $BASE_URL/camel-quarkus/latest/user-guide/cdi.html 301 $BASE_URL/camel-quarkus/next/user-guide/cdi.html
+test $BASE_URL/camel-quarkus/next/user-guide/cdi.html 200
+
+test $BASE_URL/manual 301 $BASE_URL/manual/
+test $BASE_URL/manual/latest 301 $BASE_URL/manual/
+test $BASE_URL/manual/latest/ 301 $BASE_URL/manual/
+test $BASE_URL/manual/latest/component-dsl.html 301 $BASE_URL/manual/component-dsl.html
+test $BASE_URL/manual/ 200
+test $BASE_URL/manual/component-dsl.html 200


### PR DESCRIPTION
This makes sure we redirect from `/<Antora component/latest...` to
`/<Antora component/next...`. A test script was added in
`tests/redirect.sh` so we can test this live or in development; and a
small tweak was done to the way Apache HTTPD is run for development -
for some reason it was terminating for me with SIGWINCH (window resize).