### PR TITLE
resolves #666: finish up with spring-boot changes to use aggregate-collector

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -71,20 +71,16 @@ content:
         - docs
         - connectors
 
-    - url: https://github.com/apache/camel-spring-boot.git
-#    - url: https://github.com/djencks/camel-spring-boot.git
+#    - url: https://github.com/apache/camel-spring-boot.git
+    - url: https://github.com/djencks/camel-spring-boot.git
       branches:
-        - main
-        - camel-spring-boot-3.12.x
-        - camel-spring-boot-3.11.x
-        - camel-spring-boot-3.7.x
-#        - main-collect
-#        - camel-spring-boot-3.12.x-collect
-#        - camel-spring-boot-3.11.x-collect
-#        - camel-spring-boot-3.7.x-collect
+        - main-collect
+        - camel-spring-boot-3.12.x-collect
+        - camel-spring-boot-3.11.x-collect
+        - camel-spring-boot-3.7.x-collect
       start_paths:
-#        - components-starter
-#        - core
+        - components-starter
+        - core
         - docs/components
         - docs/spring-boot
 


### PR DESCRIPTION
This brings in 

apache/camel-spring-boot#405
apache/camel-spring-boot#406
apache/camel-spring-boot#407
apache/camel-spring-boot#408
apache/camel-spring-boot#409

Most likely we'll use https://github.com/apache/camel-website/pull/671 instead of this.