### PR TITLE
chore: don't use deprecated API from higlight.js

### DIFF
--- a/antora-ui-camel/src/js/vendor/highlight.bundle.js
+++ b/antora-ui-camel/src/js/vendor/highlight.bundle.js
@@ -9,5 +9,5 @@
   hljs.registerLanguage('sql', require('highlight.js/lib/languages/sql'))
   hljs.registerLanguage('xml', require('highlight.js/lib/languages/xml'))
   hljs.registerLanguage('yaml', require('highlight.js/lib/languages/yaml'))
-  hljs.initHighlightingOnLoad()
+  hljs.highlightAll()
 })()


### PR DESCRIPTION
Fixes #682