### PR TITLE
feat: display supported Java version

### DIFF
--- a/archetypes/release-ckc.md
+++ b/archetypes/release-ckc.md
@@ -8,4 +8,5 @@ title: "Camel Kafka Connector release {{ replace (replaceRE ".*/release-(.*).md"
 preview: ""
 changelog: ""
 category: "camel-kafka-connector"
+jdk: [8,11]
 ---

--- a/archetypes/release-k-runtime.md
+++ b/archetypes/release-k-runtime.md
@@ -9,4 +9,5 @@ preview: ""
 changelog: ""
 category: "camel-k-runtime"
 milestone:
+jdk: [11]
 ---

--- a/archetypes/release-k.md
+++ b/archetypes/release-k.md
@@ -9,4 +9,5 @@ preview: ""
 changelog: ""
 category: "camel-k"
 milestone:
+jdk: [11]
 ---

--- a/archetypes/release-note.md
+++ b/archetypes/release-note.md
@@ -13,4 +13,5 @@ jiraVersionId: ""
 category: "camel"
 # kind can be lts or legacy (for 2.x)
 # kind:
+jdk: [8,11]
 ---

--- a/archetypes/release-q.md
+++ b/archetypes/release-q.md
@@ -9,4 +9,5 @@ preview: ""
 changelog: ""
 category: "camel-quarkus"
 milestone:
+jdk: [11]
 ---

--- a/content/releases/ckc/release-0.10.0.md
+++ b/content/releases/ckc/release-0.10.0.md
@@ -7,4 +7,5 @@ title: "Camel Kafka Connector release 0.10.0"
 preview: ""
 changelog: ""
 category: "camel-kafka-connector"
+jdk: [8,11]
 ---

--- a/content/releases/ckc/release-0.10.1.md
+++ b/content/releases/ckc/release-0.10.1.md
@@ -7,4 +7,5 @@ title: "Camel Kafka Connector release 0.10.1"
 preview: ""
 changelog: ""
 category: "camel-kafka-connector"
+jdk: [8,11]
 ---

--- a/content/releases/ckc/release-0.11.0.md
+++ b/content/releases/ckc/release-0.11.0.md
@@ -7,4 +7,5 @@ title: "Camel Kafka Connector release 0.11.0"
 preview: ""
 changelog: ""
 category: "camel-kafka-connector"
+jdk: [8,11]
 ---

--- a/content/releases/ckc/release-0.6.1.md
+++ b/content/releases/ckc/release-0.6.1.md
@@ -7,4 +7,5 @@ title: "Camel Kafka Connector release 0.6.1"
 preview: ""
 changelog: ""
 category: "camel-kafka-connector"
+jdk: [8,11]
 ---

--- a/content/releases/ckc/release-0.7.0.md
+++ b/content/releases/ckc/release-0.7.0.md
@@ -7,4 +7,5 @@ title: "Camel Kafka Connector release 0.7.0"
 preview: ""
 changelog: ""
 category: "camel-kafka-connector"
+jdk: [8,11]
 ---

--- a/content/releases/ckc/release-0.7.1.md
+++ b/content/releases/ckc/release-0.7.1.md
@@ -7,4 +7,5 @@ title: "Camel Kafka Connector release 0.7.1"
 preview: ""
 changelog: ""
 category: "camel-kafka-connector"
+jdk: [8,11]
 ---

--- a/content/releases/ckc/release-0.7.2.md
+++ b/content/releases/ckc/release-0.7.2.md
@@ -7,4 +7,5 @@ title: "Camel Kafka Connector release 0.7.2"
 preview: ""
 changelog: ""
 category: "camel-kafka-connector"
+jdk: [8,11]
 ---

--- a/content/releases/ckc/release-0.7.3.md
+++ b/content/releases/ckc/release-0.7.3.md
@@ -7,4 +7,5 @@ title: "Camel Kafka Connector release 0.7.3"
 preview: ""
 changelog: ""
 category: "camel-kafka-connector"
+jdk: [8,11]
 ---

--- a/content/releases/ckc/release-0.8.0.md
+++ b/content/releases/ckc/release-0.8.0.md
@@ -7,4 +7,5 @@ title: "Camel Kafka Connector release 0.8.0"
 preview: ""
 changelog: ""
 category: "camel-kafka-connector"
+jdk: [8,11]
 ---

--- a/content/releases/ckc/release-0.9.0.md
+++ b/content/releases/ckc/release-0.9.0.md
@@ -7,4 +7,5 @@ title: "Camel Kafka Connector release 0.9.0"
 preview: ""
 changelog: ""
 category: "camel-kafka-connector"
+jdk: [8,11]
 ---

--- a/content/releases/k-runtime/release-1.10.0.md
+++ b/content/releases/k-runtime/release-1.10.0.md
@@ -8,4 +8,5 @@ preview: ""
 changelog: ""
 category: "camel-k-runtime"
 milestone: 14
+jdk: [11]
 ---

--- a/content/releases/k-runtime/release-1.5.0.md
+++ b/content/releases/k-runtime/release-1.5.0.md
@@ -8,4 +8,5 @@ preview: ""
 changelog: ""
 category: "camel-k-runtime"
 milestone: 7
+jdk: [11]
 ---

--- a/content/releases/k-runtime/release-1.6.0.md
+++ b/content/releases/k-runtime/release-1.6.0.md
@@ -8,4 +8,5 @@ preview: ""
 changelog: ""
 category: "camel-k-runtime"
 milestone: 8
+jdk: [11]
 ---

--- a/content/releases/k-runtime/release-1.7.0.md
+++ b/content/releases/k-runtime/release-1.7.0.md
@@ -8,4 +8,5 @@ preview: ""
 changelog: ""
 category: "camel-k-runtime"
 milestone: 10
+jdk: [11]
 ---

--- a/content/releases/k-runtime/release-1.8.0.md
+++ b/content/releases/k-runtime/release-1.8.0.md
@@ -8,4 +8,5 @@ preview: ""
 changelog: ""
 category: "camel-k-runtime"
 milestone: 12
+jdk: [11]
 ---

--- a/content/releases/k-runtime/release-1.9.1.md
+++ b/content/releases/k-runtime/release-1.9.1.md
@@ -8,4 +8,5 @@ preview: ""
 changelog: ""
 category: "camel-k-runtime"
 milestone: 13
+jdk: [11]
 ---

--- a/content/releases/k/release-1.2.1.md
+++ b/content/releases/k/release-1.2.1.md
@@ -8,4 +8,5 @@ preview: ""
 changelog: ""
 category: "camel-k"
 milestone: 18
+jdk: [11]
 ---

--- a/content/releases/k/release-1.3.0.md
+++ b/content/releases/k/release-1.3.0.md
@@ -8,4 +8,5 @@ preview: ""
 changelog: ""
 category: "camel-k"
 milestone: 11
+jdk: [11]
 ---

--- a/content/releases/k/release-1.3.1.md
+++ b/content/releases/k/release-1.3.1.md
@@ -8,4 +8,5 @@ preview: ""
 changelog: ""
 category: "camel-k"
 milestone: 19
+jdk: [11]
 ---

--- a/content/releases/k/release-1.3.2.md
+++ b/content/releases/k/release-1.3.2.md
@@ -8,6 +8,7 @@ preview: ""
 changelog: ""
 category: "camel-k"
 milestone: 20
+jdk: [11]
 ---
 
 This release is a minor update of the 1.3.x branch.

--- a/content/releases/k/release-1.4.0.md
+++ b/content/releases/k/release-1.4.0.md
@@ -8,4 +8,5 @@ preview: ""
 changelog: ""
 category: "camel-k"
 milestone: 17
+jdk: [11]
 ---

--- a/content/releases/k/release-1.4.1.md
+++ b/content/releases/k/release-1.4.1.md
@@ -8,4 +8,5 @@ preview: ""
 changelog: ""
 category: "camel-k"
 milestone: 22
+jdk: [11]
 ---

--- a/content/releases/k/release-1.5.0.md
+++ b/content/releases/k/release-1.5.0.md
@@ -8,4 +8,5 @@ preview: ""
 changelog: ""
 category: "camel-k"
 milestone: 21
+jdk: [11]
 ---

--- a/content/releases/k/release-1.5.1.md
+++ b/content/releases/k/release-1.5.1.md
@@ -8,4 +8,5 @@ preview: ""
 changelog: ""
 category: "camel-k"
 milestone: 24
+jdk: [11]
 ---

--- a/content/releases/k/release-1.6.0.md
+++ b/content/releases/k/release-1.6.0.md
@@ -8,4 +8,5 @@ preview: ""
 changelog: ""
 category: "camel-k"
 milestone: 23
+jdk: [11]
 ---

--- a/content/releases/k/release-1.6.1.md
+++ b/content/releases/k/release-1.6.1.md
@@ -8,4 +8,5 @@ preview: ""
 changelog: ""
 category: "camel-k"
 milestone: 26
+jdk: [11]
 ---

--- a/content/releases/k/release-1.7.0.md
+++ b/content/releases/k/release-1.7.0.md
@@ -8,4 +8,5 @@ preview: ""
 changelog: ""
 category: "camel-k"
 milestone: 25
+jdk: [11]
 ---

--- a/content/releases/q/release-1.4.0.md
+++ b/content/releases/q/release-1.4.0.md
@@ -8,4 +8,5 @@ preview: ""
 changelog: ""
 category: "camel-quarkus"
 milestone: 8
+jdk: [11]
 ---

--- a/content/releases/q/release-1.5.0.md
+++ b/content/releases/q/release-1.5.0.md
@@ -8,4 +8,5 @@ preview: ""
 changelog: ""
 category: "camel-quarkus"
 milestone: 9
+jdk: [11]
 ---

--- a/content/releases/q/release-1.6.0.md
+++ b/content/releases/q/release-1.6.0.md
@@ -8,4 +8,5 @@ preview: ""
 changelog: ""
 category: "camel-quarkus"
 milestone: 10
+jdk: [11]
 ---

--- a/content/releases/q/release-1.7.0.md
+++ b/content/releases/q/release-1.7.0.md
@@ -8,4 +8,5 @@ preview: ""
 changelog: ""
 category: "camel-quarkus"
 milestone: 11
+jdk: [11]
 ---

--- a/content/releases/q/release-1.8.0.md
+++ b/content/releases/q/release-1.8.0.md
@@ -8,4 +8,5 @@ preview: ""
 changelog: ""
 category: "camel-quarkus"
 milestone: 12
+jdk: [11]
 ---

--- a/content/releases/q/release-1.8.1.md
+++ b/content/releases/q/release-1.8.1.md
@@ -8,4 +8,5 @@ preview: ""
 changelog: ""
 category: "camel-quarkus"
 milestone: 14
+jdk: [11]
 ---

--- a/content/releases/q/release-2.0.0.md
+++ b/content/releases/q/release-2.0.0.md
@@ -8,4 +8,5 @@ preview: ""
 changelog: ""
 category: "camel-quarkus"
 milestone: 15
+jdk: [11]
 ---

--- a/content/releases/q/release-2.1.0.md
+++ b/content/releases/q/release-2.1.0.md
@@ -8,4 +8,5 @@ preview: ""
 changelog: ""
 category: "camel-quarkus"
 milestone: 17
+jdk: [11]
 ---

--- a/content/releases/q/release-2.2.0.md
+++ b/content/releases/q/release-2.2.0.md
@@ -8,4 +8,5 @@ preview: ""
 changelog: ""
 category: "camel-quarkus"
 milestone: 18
+jdk: [11]
 ---

--- a/content/releases/q/release-2.3.0.md
+++ b/content/releases/q/release-2.3.0.md
@@ -8,4 +8,5 @@ preview: ""
 changelog: ""
 category: "camel-quarkus"
 milestone: 19
+jdk: [11]
 ---

--- a/content/releases/q/release-2.4.0.md
+++ b/content/releases/q/release-2.4.0.md
@@ -8,4 +8,5 @@ preview: ""
 changelog: ""
 category: "camel-quarkus"
 milestone: 20
+jdk: [11]
 ---

--- a/content/releases/release-2.18.0.md
+++ b/content/releases/release-2.18.0.md
@@ -10,6 +10,7 @@ knownIssues: ""
 jiraVersionId: 12334759
 category: camel
 kind: legacy
+jdk: [8]
 ---
 
 Welcome to the 2.18.0 release which resolved over 500 issues. This is

--- a/content/releases/release-2.18.1.md
+++ b/content/releases/release-2.18.1.md
@@ -10,6 +10,7 @@ knownIssues: ""
 jiraVersionId: 12338295
 category: camel
 kind: legacy
+jdk: [8]
 ---
 
 This release is a minor update of the 2.18.x branch.

--- a/content/releases/release-2.18.2.md
+++ b/content/releases/release-2.18.2.md
@@ -10,6 +10,7 @@ knownIssues: ""
 jiraVersionId: 12338705
 category: camel
 kind: legacy
+jdk: [8]
 ---
 
 This release is a minor update of the 2.18.x branch.

--- a/content/releases/release-2.18.3.md
+++ b/content/releases/release-2.18.3.md
@@ -10,6 +10,7 @@ knownIssues: ""
 jiraVersionId: 12339161
 category: camel
 kind: legacy
+jdk: [8]
 ---
 
 This release is a minor update of the 2.18.x branch.

--- a/content/releases/release-2.18.4.md
+++ b/content/releases/release-2.18.4.md
@@ -10,6 +10,7 @@ knownIssues: ""
 jiraVersionId: 12339774
 category: camel
 kind: legacy
+jdk: [8]
 ---
 
 This release is a minor update of the 2.18.x branch.

--- a/content/releases/release-2.18.5.md
+++ b/content/releases/release-2.18.5.md
@@ -10,6 +10,7 @@ knownIssues: ""
 jiraVersionId: 12340599
 category: camel
 kind: legacy
+jdk: [8]
 ---
 
 This release is a minor update of the 2.18.x branch.

--- a/content/releases/release-2.19.0.md
+++ b/content/releases/release-2.19.0.md
@@ -10,6 +10,7 @@ knownIssues: ""
 jiraVersionId: 12337871
 category: camel
 kind: legacy
+jdk: [8]
 ---
 
 Welcome to the 2.19.0 release which resolved over 670 issues including

--- a/content/releases/release-2.19.1.md
+++ b/content/releases/release-2.19.1.md
@@ -10,6 +10,7 @@ knownIssues: ""
 jiraVersionId: 12340460
 category: camel
 kind: legacy
+jdk: [8]
 ---
 
 This release is a minor update of the 2.19.x branch.

--- a/content/releases/release-2.19.2.md
+++ b/content/releases/release-2.19.2.md
@@ -10,6 +10,7 @@ knownIssues: ""
 jiraVersionId: 12340945
 category: camel
 kind: legacy
+jdk: [8]
 ---
 
 This release is a minor update of the 2.19.x branch.

--- a/content/releases/release-2.19.3.md
+++ b/content/releases/release-2.19.3.md
@@ -10,6 +10,7 @@ knownIssues: ""
 jiraVersionId: 12341135
 category: camel
 kind: legacy
+jdk: [8]
 ---
 
 This release is a minor update of the 2.19.x branch.

--- a/content/releases/release-2.19.4.md
+++ b/content/releases/release-2.19.4.md
@@ -10,6 +10,7 @@ knownIssues: ""
 jiraVersionId: 12341575
 category: camel
 kind: legacy
+jdk: [8]
 ---
 
 This release is a minor update of the 2.19.x branch.

--- a/content/releases/release-2.19.5.md
+++ b/content/releases/release-2.19.5.md
@@ -10,6 +10,7 @@ knownIssues: ""
 jiraVersionId: 12342135
 category: camel
 kind: legacy
+jdk: [8]
 ---
 
 This release is a minor update of the 2.19.x branch.

--- a/content/releases/release-2.20.0.md
+++ b/content/releases/release-2.20.0.md
@@ -10,6 +10,7 @@ knownIssues: ""
 jiraVersionId: 12340219
 category: camel
 kind: legacy
+jdk: [8]
 ---
 
 Welcome to the 2.20.0 release which resolved over 550 issues including

--- a/content/releases/release-2.20.1.md
+++ b/content/releases/release-2.20.1.md
@@ -10,6 +10,7 @@ knownIssues: ""
 jiraVersionId: 12341590
 category: camel
 kind: legacy
+jdk: [8]
 ---
 
 This release is a minor update of the 2.20.x branch.

--- a/content/releases/release-2.20.2.md
+++ b/content/releases/release-2.20.2.md
@@ -10,6 +10,7 @@ knownIssues: ""
 jiraVersionId: 12342152
 category: camel
 kind: legacy
+jdk: [8]
 ---
 
 This release is a minor update of the 2.20.x branch.

--- a/content/releases/release-2.20.3.md
+++ b/content/releases/release-2.20.3.md
@@ -10,6 +10,7 @@ knownIssues: ""
 jiraVersionId: 12342652
 category: camel
 kind: legacy
+jdk: [8]
 ---
 
 This release is a minor update of the 2.20.x branch.

--- a/content/releases/release-2.20.4.md
+++ b/content/releases/release-2.20.4.md
@@ -10,6 +10,7 @@ knownIssues: ""
 jiraVersionId: 12342958
 category: camel
 kind: legacy
+jdk: [8]
 ---
 
 This release is a minor update of the 2.20.x branch.

--- a/content/releases/release-2.21.0.md
+++ b/content/releases/release-2.21.0.md
@@ -10,6 +10,7 @@ knownIssues: ""
 jiraVersionId: 12341576
 category: camel
 kind: legacy
+jdk: [8]
 ---
 
 Welcome to the 2.21.0 release which resolved 400 issues including new

--- a/content/releases/release-2.21.1.md
+++ b/content/releases/release-2.21.1.md
@@ -10,6 +10,7 @@ knownIssues: ""
 jiraVersionId: 12342869
 category: camel
 kind: legacy
+jdk: [8]
 ---
 
 This release is a minor update of the 2.21.x branch.

--- a/content/releases/release-2.21.2.md
+++ b/content/releases/release-2.21.2.md
@@ -10,6 +10,7 @@ knownIssues: ""
 jiraVersionId: 12343107
 category: camel
 kind: legacy
+jdk: [8]
 ---
 
 This release is a minor update of the 2.21.x branch.

--- a/content/releases/release-2.21.3.md
+++ b/content/releases/release-2.21.3.md
@@ -10,6 +10,7 @@ knownIssues: ""
 jiraVersionId: 12343751
 category: camel
 kind: legacy
+jdk: [8]
 ---
 
 This release is a minor update of the 2.21.x branch.

--- a/content/releases/release-2.21.4.md
+++ b/content/releases/release-2.21.4.md
@@ -10,6 +10,7 @@ knownIssues: ""
 jiraVersionId: 12344344
 category: camel
 kind: legacy
+jdk: [8]
 ---
 
 This release is a minor update of the 2.21.x branch.

--- a/content/releases/release-2.21.5.md
+++ b/content/releases/release-2.21.5.md
@@ -10,6 +10,7 @@ knownIssues: ""
 jiraVersionId: 12344816
 category: camel
 kind: legacy
+jdk: [8]
 ---
 
 This release is a minor update of the 2.21.x branch.

--- a/content/releases/release-2.22.0.md
+++ b/content/releases/release-2.22.0.md
@@ -10,6 +10,7 @@ knownIssues: ""
 jiraVersionId: 12342707
 category: camel
 kind: legacy
+jdk: [8]
 ---
 
 Welcome to the 2.22.0 release which resolved 216 issues including new features, improvements and bug fixes.

--- a/content/releases/release-2.22.1.md
+++ b/content/releases/release-2.22.1.md
@@ -10,6 +10,7 @@ knownIssues: ""
 jiraVersionId: 12343346
 category: camel
 kind: legacy
+jdk: [8]
 ---
 
 This release is a minor update of the 2.22.x branch.

--- a/content/releases/release-2.22.2.md
+++ b/content/releases/release-2.22.2.md
@@ -10,6 +10,7 @@ knownIssues: ""
 jiraVersionId: 12343751
 category: camel
 kind: legacy
+jdk: [8]
 ---
 
 This release is a minor update of the 2.22.x branch.

--- a/content/releases/release-2.22.3.md
+++ b/content/releases/release-2.22.3.md
@@ -10,6 +10,7 @@ knownIssues: ""
 jiraVersionId: 12344398
 category: camel
 kind: legacy
+jdk: [8]
 ---
 
 This release is a minor update of the 2.22.x branch.

--- a/content/releases/release-2.22.4.md
+++ b/content/releases/release-2.22.4.md
@@ -10,6 +10,7 @@ knownIssues: ""
 jiraVersionId: 12344887
 category: camel
 kind: legacy
+jdk: [8]
 ---
 
 This release is a minor update of the 2.22.x branch.

--- a/content/releases/release-2.22.5.md
+++ b/content/releases/release-2.22.5.md
@@ -10,6 +10,7 @@ knownIssues: ""
 jiraVersionId: 12345404
 category: camel
 kind: legacy
+jdk: [8]
 ---
 
 This release is a minor update of the 2.22.x branch.

--- a/content/releases/release-2.23.0.md
+++ b/content/releases/release-2.23.0.md
@@ -10,6 +10,7 @@ knownIssues: ""
 jiraVersionId: 12343345
 category: camel
 kind: legacy
+jdk: [8]
 ---
 
 Welcome to the Apache Camel 2.23.0 release which is a new minor release and resolved 262 issues

--- a/content/releases/release-2.23.1.md
+++ b/content/releases/release-2.23.1.md
@@ -10,6 +10,7 @@ knownIssues: ""
 jiraVersionId: 12344567
 category: camel
 kind: legacy
+jdk: [8]
 ---
 
 This release is a minor update of the 2.23.x branch.

--- a/content/releases/release-2.23.2.md
+++ b/content/releases/release-2.23.2.md
@@ -10,6 +10,7 @@ knownIssues: ""
 jiraVersionId: 12344839
 category: camel
 kind: legacy
+jdk: [8]
 ---
 
 This release is a minor update of the 2.23.x branch.

--- a/content/releases/release-2.23.3.md
+++ b/content/releases/release-2.23.3.md
@@ -10,6 +10,7 @@ knownIssues: ""
 jiraVersionId: 12345358
 category: camel
 kind: legacy
+jdk: [8]
 ---
 
 This release is a minor update of the 2.23.x branch.

--- a/content/releases/release-2.23.4.md
+++ b/content/releases/release-2.23.4.md
@@ -10,6 +10,7 @@ knownIssues: ""
 jiraVersionId: 12345671
 category: camel
 kind: legacy
+jdk: [8]
 ---
 
 This release is a minor update of the 2.23.x branch.

--- a/content/releases/release-2.24.0.md
+++ b/content/releases/release-2.24.0.md
@@ -10,6 +10,7 @@ knownIssues: ""
 jiraVersionId: 12344459
 category: camel
 kind: legacy
+jdk: [8]
 ---
 
 This release is a minor update of the 2.24.x branch.

--- a/content/releases/release-2.24.1.md
+++ b/content/releases/release-2.24.1.md
@@ -10,6 +10,7 @@ knownIssues: ""
 jiraVersionId: 12345495
 category: camel
 kind: legacy
+jdk: [8]
 ---
 
 This release is a minor update of the 2.24.x branch.

--- a/content/releases/release-2.24.2.md
+++ b/content/releases/release-2.24.2.md
@@ -10,6 +10,7 @@ knownIssues: ""
 jiraVersionId: 12345672
 category: camel
 kind: legacy
+jdk: [8]
 ---
 
 This release is a minor update of the 2.24.x branch.

--- a/content/releases/release-2.24.3.md
+++ b/content/releases/release-2.24.3.md
@@ -10,6 +10,7 @@ knownIssues: ""
 jiraVersionId: 12345672
 category: camel
 kind: legacy
+jdk: [8]
 ---
 
 This release is a minor update of the 2.24.x branch.

--- a/content/releases/release-2.25.0.md
+++ b/content/releases/release-2.25.0.md
@@ -10,6 +10,7 @@ knownIssues: ""
 jiraVersionId: 12345517
 category: camel
 kind: legacy
+jdk: [8]
 ---
 
 This release is the new Camel 2.25.0 minor release.

--- a/content/releases/release-2.25.1.md
+++ b/content/releases/release-2.25.1.md
@@ -10,6 +10,7 @@ knownIssues: ""
 jiraVersionId: 12346872
 category: camel
 kind: legacy
+jdk: [8]
 ---
 
 This release is the new Camel 2.25.1 patch release.

--- a/content/releases/release-2.25.2.md
+++ b/content/releases/release-2.25.2.md
@@ -10,6 +10,7 @@ knownIssues: ""
 jiraVersionId: 12348081
 category: camel
 kind: legacy
+jdk: [8]
 ---
 
 This release is the new Camel 2.25.2 patch release.

--- a/content/releases/release-2.25.3.md
+++ b/content/releases/release-2.25.3.md
@@ -10,6 +10,7 @@ knownIssues: ""
 jiraVersionId: 12348722
 category: camel
 kind: legacy
+jdk: [8]
 ---
 
 This release is the new Camel 2.25.3 patch release.

--- a/content/releases/release-2.25.4.md
+++ b/content/releases/release-2.25.4.md
@@ -11,6 +11,7 @@ knownIssues: ""
 jiraVersionId: 12349511
 category: camel
 kind: legacy
+jdk: [8]
 ---
 
 This release is the new Camel 2.25.4 patch release.

--- a/content/releases/release-3.0.0-RC1.md
+++ b/content/releases/release-3.0.0-RC1.md
@@ -10,6 +10,7 @@ apiBreaking: ""
 knownIssues: ""
 jiraVersionId: 12345723
 category: camel
+jdk: [8,11]
 ---
 
 This release the first release candidate towards Camel 3.0.0 release.

--- a/content/releases/release-3.0.0-RC2.md
+++ b/content/releases/release-3.0.0-RC2.md
@@ -10,6 +10,7 @@ apiBreaking: ""
 knownIssues: ""
 jiraVersionId: 12345998
 category: camel
+jdk: [8,11]
 ---
 
 This release the second release candidate towards Camel 3.0.0 release.

--- a/content/releases/release-3.0.0-RC3.md
+++ b/content/releases/release-3.0.0-RC3.md
@@ -10,6 +10,7 @@ apiBreaking: ""
 knownIssues: ""
 jiraVersionId: 12346354
 category: camel
+jdk: [8,11]
 ---
 
 This release the third and final release candidate towards Camel 3.0.0 release.

--- a/content/releases/release-3.0.0.md
+++ b/content/releases/release-3.0.0.md
@@ -9,6 +9,7 @@ apiBreaking: ""
 knownIssues: ""
 jiraVersionId: 12345672
 category: camel
+jdk: [8,11]
 ---
 
 This release is the new Camel 3.0.0 major release.

--- a/content/releases/release-3.0.1.md
+++ b/content/releases/release-3.0.1.md
@@ -9,6 +9,7 @@ apiBreaking: ""
 knownIssues: ""
 jiraVersionId: 12346544
 category: camel
+jdk: [8,11]
 ---
 
 This release is a minor update of the 3.0.x branch.

--- a/content/releases/release-3.1.0.md
+++ b/content/releases/release-3.1.0.md
@@ -9,6 +9,7 @@ apiBreaking: ""
 knownIssues: ""
 jiraVersionId: 12346526
 category: camel
+jdk: [8,11]
 ---
 
 This release is the new Camel 3.1.0 major release.

--- a/content/releases/release-3.10.0.md
+++ b/content/releases/release-3.10.0.md
@@ -9,6 +9,7 @@ apiBreaking: ""
 knownIssues: ""
 jiraVersionId: 12350004
 category: camel
+jdk: [8,11]
 ---
 
 This release is the new Camel 3.10.0 minor release.

--- a/content/releases/release-3.11.0.md
+++ b/content/releases/release-3.11.0.md
@@ -11,6 +11,7 @@ knownIssues: ""
 jiraVersionId: 12350096
 category: camel
 kind: lts
+jdk: [8,11]
 ---
 
 This release is the new Camel 3.11.0 LTS minor release.

--- a/content/releases/release-3.11.1.md
+++ b/content/releases/release-3.11.1.md
@@ -11,6 +11,7 @@ knownIssues: ""
 jiraVersionId: 12350361
 category: camel
 kind: lts
+jdk: [8,11]
 ---
 
 This release is the new Camel 3.11.1 LTS patch release.

--- a/content/releases/release-3.11.2.md
+++ b/content/releases/release-3.11.2.md
@@ -11,6 +11,7 @@ knownIssues: ""
 jiraVersionId: 12350487
 category: camel
 kind: lts
+jdk: [8,11]
 ---
 
 This release is the new Camel 3.11.2 LTS patch release.

--- a/content/releases/release-3.11.3.md
+++ b/content/releases/release-3.11.3.md
@@ -11,6 +11,7 @@ knownIssues: ""
 jiraVersionId: 12350593
 category: camel
 kind: lts
+jdk: [8,11]
 ---
 
 This release is the new Camel 3.11.3 LTS patch release.

--- a/content/releases/release-3.12.0.md
+++ b/content/releases/release-3.12.0.md
@@ -9,6 +9,7 @@ apiBreaking: ""
 knownIssues: ""
 jiraVersionId: 12350283
 category: camel
+jdk: [8,11]
 ---
 
 This release is the new Camel 3.12.0 minor release.

--- a/content/releases/release-3.13.0.md
+++ b/content/releases/release-3.13.0.md
@@ -9,6 +9,7 @@ apiBreaking: ""
 knownIssues: ""
 jiraVersionId: 12350624
 category: camel
+jdk: [8,11]
 ---
 
 This release is the new Camel 3.13.0 minor release.

--- a/content/releases/release-3.2.0.md
+++ b/content/releases/release-3.2.0.md
@@ -9,6 +9,7 @@ apiBreaking: ""
 knownIssues: ""
 jiraVersionId: 12346956
 category: camel
+jdk: [8,11]
 ---
 
 This release is the new Camel 3.2.0 major release.

--- a/content/releases/release-3.3.0.md
+++ b/content/releases/release-3.3.0.md
@@ -9,6 +9,7 @@ apiBreaking: ""
 knownIssues: ""
 jiraVersionId: 12347798
 category: camel
+jdk: [8,11]
 ---
 
 This release is the new Camel 3.3.0 major release.

--- a/content/releases/release-3.4.0.md
+++ b/content/releases/release-3.4.0.md
@@ -10,6 +10,7 @@ knownIssues: ""
 jiraVersionId: 12347798
 category: camel
 kind: lts
+jdk: [8,11]
 ---
 
 This release is the new Camel 3.4.0 LTS release.

--- a/content/releases/release-3.4.1.md
+++ b/content/releases/release-3.4.1.md
@@ -10,6 +10,7 @@ knownIssues: ""
 jiraVersionId: 12348393
 category: camel
 kind: lts
+jdk: [8,11]
 ---
 
 This release is the new Camel 3.4.1 patch release.

--- a/content/releases/release-3.4.2.md
+++ b/content/releases/release-3.4.2.md
@@ -10,6 +10,7 @@ knownIssues: ""
 jiraVersionId: 12348562
 category: camel
 kind: lts
+jdk: [8,11]
 ---
 
 This release is the new Camel 3.4.2 patch release.

--- a/content/releases/release-3.4.3.md
+++ b/content/releases/release-3.4.3.md
@@ -10,6 +10,7 @@ knownIssues: ""
 jiraVersionId: 12348603
 category: camel
 kind: lts
+jdk: [8,11]
 ---
 
 This release is the new Camel 3.4.3 patch release.

--- a/content/releases/release-3.4.4.md
+++ b/content/releases/release-3.4.4.md
@@ -10,6 +10,7 @@ knownIssues: ""
 jiraVersionId: 12348674
 category: camel
 kind: lts
+jdk: [8,11]
 ---
 
 This release is the new Camel 3.4.4 patch release.

--- a/content/releases/release-3.4.5.md
+++ b/content/releases/release-3.4.5.md
@@ -11,6 +11,7 @@ knownIssues: ""
 jiraVersionId: 12348825
 category: camel
 kind: lts
+jdk: [8,11]
 ---
 
 This release is the new Camel 3.4.5 patch release.

--- a/content/releases/release-3.4.6.md
+++ b/content/releases/release-3.4.6.md
@@ -11,6 +11,7 @@ knownIssues: ""
 jiraVersionId: 12349520
 category: camel
 kind: lts
+jdk: [8,11]
 ---
 
 This release is the new Camel 3.4.6 patch release.

--- a/content/releases/release-3.5.0.md
+++ b/content/releases/release-3.5.0.md
@@ -9,6 +9,7 @@ apiBreaking: ""
 knownIssues: ""
 jiraVersionId: 12348299
 category: camel
+jdk: [8,11]
 ---
 
 This release is the new Camel 3.5.0 patch release.

--- a/content/releases/release-3.6.0.md
+++ b/content/releases/release-3.6.0.md
@@ -9,6 +9,7 @@ apiBreaking: ""
 knownIssues: ""
 jiraVersionId: 12348664
 category: camel
+jdk: [8,11]
 ---
 
 This release is the new Camel 3.6.0 patch release.

--- a/content/releases/release-3.7.0.md
+++ b/content/releases/release-3.7.0.md
@@ -10,6 +10,7 @@ knownIssues: ""
 jiraVersionId: 12349250
 category: camel
 kind: lts
+jdk: [8,11]
 ---
 
 This release is the new Camel 3.7.0 LTS release.

--- a/content/releases/release-3.7.1.md
+++ b/content/releases/release-3.7.1.md
@@ -10,6 +10,7 @@ knownIssues: ""
 jiraVersionId: 12349485
 category: camel
 kind: lts
+jdk: [8,11]
 ---
 
 This release is the new Camel 3.7.1 LTS release.

--- a/content/releases/release-3.7.2.md
+++ b/content/releases/release-3.7.2.md
@@ -10,6 +10,7 @@ knownIssues: ""
 jiraVersionId: 12349596
 category: camel
 kind: lts
+jdk: [8,11]
 ---
 
 This release is the new Camel 3.7.2 LTS release.

--- a/content/releases/release-3.7.3.md
+++ b/content/releases/release-3.7.3.md
@@ -10,6 +10,7 @@ knownIssues: ""
 jiraVersionId: 12349682
 category: camel
 kind: lts
+jdk: [8,11]
 ---
 
 This release is the new Camel 3.7.3 LTS release.

--- a/content/releases/release-3.7.4.md
+++ b/content/releases/release-3.7.4.md
@@ -11,6 +11,7 @@ knownIssues: ""
 jiraVersionId: 12349972
 category: camel
 kind: lts
+jdk: [8,11]
 ---
 
 This release is the new Camel 3.7.4 LTS release.

--- a/content/releases/release-3.7.5.md
+++ b/content/releases/release-3.7.5.md
@@ -11,6 +11,7 @@ knownIssues: ""
 jiraVersionId: 12350137
 category: camel
 kind: lts
+jdk: [8,11]
 ---
 
 This release is the new Camel 3.7.5 LTS release.

--- a/content/releases/release-3.7.6.md
+++ b/content/releases/release-3.7.6.md
@@ -11,6 +11,7 @@ knownIssues: ""
 jiraVersionId: 12350411
 category: camel
 kind: lts
+jdk: [8,11]
 ---
 
 This release is the new Camel 3.7.6 LTS release.

--- a/content/releases/release-3.8.0.md
+++ b/content/releases/release-3.8.0.md
@@ -9,6 +9,7 @@ apiBreaking: ""
 knownIssues: ""
 jiraVersionId: 12349420
 category: camel
+jdk: [8,11]
 ---
 
 This release is the new Camel 3.8.0 minor release.

--- a/content/releases/release-3.9.0.md
+++ b/content/releases/release-3.9.0.md
@@ -9,6 +9,7 @@ apiBreaking: ""
 knownIssues: ""
 jiraVersionId: 12349612
 category: camel
+jdk: [8,11]
 ---
 
 This release is the new Camel 3.9.0 minor release.

--- a/layouts/partials/releases/downloads.html
+++ b/layouts/partials/releases/downloads.html
@@ -154,7 +154,12 @@
                         <br/>
                         {{ with (index (where (where (where $.Pages "Section" "releases") ".Params.category" $.Category.id) ".Params.version" $v) 0) }}
                         <small>
-                            Released in {{ (.Param "date").Format "Jan 2006" }}{{ if .Param "eol" }}, end of life in {{ dateFormat "Jan 2006" (.Param "eol") }}{{ end }}
+                            {{ with .Params.jdk }}
+                              Supports Java {{ delimit . ", " " and " }}
+                              <br>
+                            {{ end }}
+                            Released in {{ (.Param "date").Format "Jan 2006" }}{{ if .Param "eol" }}, end of life in {{ dateFormat "Jan 2006" (.Param "eol") }}
+                            {{ end }}
                         </small>
                         {{ end }}
                     </td>

--- a/layouts/release-note/single.html
+++ b/layouts/release-note/single.html
@@ -5,11 +5,16 @@
     <h2 id="whats_new"><a class="anchor" href="#whats_new"></a>New and Noteworthy</h2>
     {{ .Content }}
 
+    {{ with .Params.jdk }}
+      <h2 id="jdk"><a class="anchor" href="#jdk"></a>Supported Java version</h2>
+      This version supports Java {{ delimit . ", " " and " }}.
+    {{ end }}
+
     {{ partial (printf "releases/%s.html" (lower (replace .Params.category " " "-"))) . }}
 
     <h2 id="keys"><a class="anchor" href="#keys"></a>Keys</h2>
     <p>You can verify your download by following these <a href="http://www.apache.org/info/verification.html">procedures</a> and using these <a href="https://www.apache.org/dist/camel/KEYS">KEYS</a>.</p>
-    
+
   </article>
 </main role="main">
 {{ partial "footer.html" . }}


### PR DESCRIPTION
This adds the `jdk` parameter to the release notes which will, if set,
display the supported Java version on the download and individual
release pages.
The value is an collection, so multiple versions can be specified.

Fixes #681