### PR TITLE
fix: GitHub API authantication

### DIFF
--- a/layouts/blog/post.html
+++ b/layouts/blog/post.html
@@ -13,7 +13,7 @@
             Posted on <time itemprop="published" datetime="{{ dateFormat "2006-01-02" .PublishDate }}"
                 title="{{ dateFormat "Monday, January 2, 2006" .PublishDate }}">{{ dateFormat "January 2, 2006" .PublishDate }}</time>,
             by {{ range $author := .Params.authors }}
-            {{ with getJSON "https://api.github.com/users/" $author (dict "Authorization" (printf "%s:%s" $.Site.Params.GitHubUsername $.Site.Params.GitHubToken | base64Encode)) }}
+            {{ with getJSON "https://api.github.com/users/" $author (dict "Authorization" (printf "Basic %s" (printf "%s:%s" $.Site.Params.GitHubUsername $.Site.Params.GitHubToken | base64Encode))) }}
             <figure>
                 <img src="{{ .avatar_url }}" alt="{{ .name }}">
                 <figcaption rel="author">{{ .name }}</figcaption>

--- a/layouts/blog/summary.html
+++ b/layouts/blog/summary.html
@@ -2,7 +2,7 @@
 
     <header>
         <a href="{{ .RelPermalink }}"><h1>{{ .Title }}</h1></a>
-        <time itemprop="published" datetime="{{ dateFormat "2006-01-02" .PublishDate }}" title="{{ dateFormat "Monday, January 2, 2006" .PublishDate }}">{{ dateFormat "January 2, 2006" .PublishDate }}</time>, by {{ range $idx, $author := .Params.authors }}{{ if gt $idx 0 }}, {{ end }}<span rel="author">{{ (getJSON "https://api.github.com/users/" $author (dict "Authorization" (printf "%s:%s" $.Site.Params.GitHubUsername $.Site.Params.GitHubToken | base64Encode))).name }}</span>{{ end }}
+        <time itemprop="published" datetime="{{ dateFormat "2006-01-02" .PublishDate }}" title="{{ dateFormat "Monday, January 2, 2006" .PublishDate }}">{{ dateFormat "January 2, 2006" .PublishDate }}</time>, by {{ range $idx, $author := .Params.authors }}{{ if gt $idx 0 }}, {{ end }}<span rel="author">{{ (getJSON "https://api.github.com/users/" $author (dict "Authorization" (printf "Basic %s" (printf "%s:%s" $.Site.Params.GitHubUsername $.Site.Params.GitHubToken | base64Encode)))).name }}</span>{{ end }}
     </header>
     <p>{{ .Summary }}</p>
     <p><a class="continue" href="{{ .RelPermalink }}">Continue reading &#10095;</a></p>

--- a/layouts/partials/releases/camel-k-runtime.html
+++ b/layouts/partials/releases/camel-k-runtime.html
@@ -11,7 +11,7 @@ git checkout camel-k-runtime-parent-{{ .Params.version }}</pre>
 
 <h2 id="resolved"><a class="anchor" href="#resolved"></a>Resolved issues</h2>
 <p>Here is a list of all the issues that have been resolved for this release</p>
-{{ $issues := getJSON "https://api.github.com/repos/apache/camel-k-runtime/issues?state=closed&milestone=" (string .Params.milestone ) (dict "Authorization" (printf "%s:%s" $.Site.Params.GitHubUsername $.Site.Params.GitHubToken | base64Encode)) }}
+{{ $issues := getJSON "https://api.github.com/repos/apache/camel-k-runtime/issues?state=closed&milestone=" (string .Params.milestone ) (dict "Authorization" (printf "Basic %s" (printf "%s:%s" $.Site.Params.GitHubUsername $.Site.Params.GitHubToken | base64Encode))) }}
 <dl>
 {{ range $issues }}
   <dt><a href="{{ .html_url }}">#{{ .number }}</a></dt><dd>{{ .title }}</dd>

--- a/layouts/partials/releases/camel-k.html
+++ b/layouts/partials/releases/camel-k.html
@@ -11,7 +11,7 @@ git checkout v{{ .Params.version }}</pre>
 
 <h2 id="resolved"><a class="anchor" href="#resolved"></a>Resolved issues</h2>
 <p>Here is a list of all the issues that have been resolved for this release</p>
-{{ $issues := getJSON "https://api.github.com/repos/apache/camel-k/issues?state=closed&milestone=" (string .Params.milestone) (dict "Authorization" (printf "%s:%s" $.Site.Params.GitHubUsername $.Site.Params.GitHubToken | base64Encode)) }}
+{{ $issues := getJSON "https://api.github.com/repos/apache/camel-k/issues?state=closed&milestone=" (string .Params.milestone) (dict "Authorization" (printf "Basic %s" (printf "%s:%s" $.Site.Params.GitHubUsername $.Site.Params.GitHubToken | base64Encode))) }}
 <dl>
 {{ range $issues }}
   <dt><a href="{{ .html_url }}">#{{ .number }}</a></dt><dd>{{ .title }}</dd>

--- a/layouts/partials/releases/camel-kafka-connector.html
+++ b/layouts/partials/releases/camel-kafka-connector.html
@@ -26,7 +26,7 @@ git checkout camel-kafka-connector-{{ .Params.version }}</pre>
 
 <h2 id="resolved"><a class="anchor" href="#resolved"></a>Resolved issues</h2>
 <p>Here is a list of all the issues that have been resolved for this release</p>
-{{ $issues := getJSON "https://api.github.com/repos/apache/camel-kafka-connector/issues?state=closed&labels=" (string .Params.version) (dict "Authorization" (printf "%s:%s" $.Site.Params.GitHubUsername $.Site.Params.GitHubToken | base64Encode)) }}
+{{ $issues := getJSON "https://api.github.com/repos/apache/camel-kafka-connector/issues?state=closed&labels=" (string .Params.version) (dict "Authorization" (printf "Basic %s" (printf "%s:%s" $.Site.Params.GitHubUsername $.Site.Params.GitHubToken | base64Encode))) }}
 <dl>
 {{ range $issues }}
   <dt><a href="{{ .html_url }}">#{{ .number }}</a></dt><dd>{{ .title }}</dd>

--- a/layouts/partials/releases/camel-quarkus.html
+++ b/layouts/partials/releases/camel-quarkus.html
@@ -11,7 +11,7 @@ git checkout {{ .Params.version }}</pre>
 
 <h2 id="resolved"><a class="anchor" href="#resolved"></a>Resolved issues</h2>
 <p>Here is a list of all the issues that have been resolved for this release</p>
-{{ $issues := getJSON "https://api.github.com/repos/apache/camel-quarkus/issues?state=closed&milestone=" (string .Params.milestone) (dict "Authorization" (printf "%s:%s" $.Site.Params.GitHubUsername $.Site.Params.GitHubToken | base64Encode)) }}
+{{ $issues := getJSON "https://api.github.com/repos/apache/camel-quarkus/issues?state=closed&milestone=" (string .Params.milestone) (dict "Authorization" (printf "Basic %s" (printf "%s:%s" $.Site.Params.GitHubUsername $.Site.Params.GitHubToken | base64Encode))) }}
 <dl>
 {{ range $issues }}
   <dt><a href="{{ .html_url }}">#{{ .number }}</a></dt><dd>{{ .title }}</dd>


### PR DESCRIPTION
Seems that we're sending the `Authorization` header without the leading
`Basic ` in the header value. For some reason this seems to have worked
in the past and it most recently stopped working, leading to issues with
running previews locally. This adds the leading `Basic ` to the
`Authorization` header.