### PR TITLE
add kamelets 0.5.x

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -52,6 +52,7 @@ content:
     - url: https://github.com/apache/camel-kamelets.git
       branches:
         - main
+        - 0.5.x
       start_path: docs
 
     - url: https://github.com/apache/camel-quarkus.git


### PR DESCRIPTION
Add 0.5.x kamelets to docs.
I think there are more versions being used, e.g. I think camel-kaka-connector uses version 0.3.x, but lets start here.