### PR TITLE
Resolves #699 hugo docs page directs to latest not next docs

### DIFF
--- a/content/docs/_index.md
+++ b/content/docs/_index.md
@@ -5,7 +5,7 @@ Title: "Documentation"
 
 {{< div "icon" >}}
 
-[![Camel](/_/img/logo-d.svg)](/camel-k/next/)
+[![Camel](/_/img/logo-d.svg)](/camel-k/latest/)
 
 {{< /div >}}
 
@@ -13,7 +13,7 @@ Title: "Documentation"
 
 ## Camel Core
 
-The [User Manual](/manual/) is a comprehensive guide meant to help you with the key concepts of Apache Camel and software integration, from how to [get started](/manual/getting-started.html) with Apache Camel, how to [upgrade to Camel 3.x](/manual/camel-3x-upgrade-guide.html), to [architecture](/manual/architecture.html) or [integration patterns](/components/next/eips/enterprise-integration-patterns.html).
+The [User Manual](/manual/) is a comprehensive guide meant to help you with the key concepts of Apache Camel and software integration, from how to [get started](/manual/getting-started.html) with Apache Camel, how to [upgrade to Camel 3.x](/manual/camel-3x-upgrade-guide.html), to [architecture](/manual/architecture.html) or [integration patterns](/components/latest/eips/enterprise-integration-patterns.html).
 
 <p>
 <a class="button dark" href="/manual/">Documentation</a>
@@ -22,10 +22,10 @@ The [User Manual](/manual/) is a comprehensive guide meant to help you with the 
 </p>
 
 
-Camel is packed with several hundred components that are used to access databases, message queues and APIs. The [Component reference](/components/next/) provides you information about the functionality and configuration of each component.
+Camel is packed with several hundred components that are used to access databases, message queues and APIs. The [Component reference](/components/latest/) provides you information about the functionality and configuration of each component.
 
 <p>
-<a class="button dark" href="/components/next/">Component Reference</a>
+<a class="button dark" href="/components/latest/">Component Reference</a>
 <a class="button light" href="https://www.javadoc.io/doc/org.apache.camel/camel-api/latest/index.html">API Documentation</a>
 </p>
 
@@ -42,7 +42,7 @@ Camel is packed with several hundred components that are used to access database
 Apache Camel K is a lightweight integration framework built on Apache Camel that runs natively on [Kubernetes](https://kubernetes.io/) and is specifically designed for serverless and micro service architectures. It allows you to run integration code written in Camel DSL on your cloud.
 
 <p>
-<a class="button dark" href="/camel-k/next/">Documentation</a>
+<a class="button dark" href="/camel-k/latest/">Documentation</a>
 <a class="button light" href="https://github.com/apache/camel-k/">Source</a>
 <a class="button light" href="https://github.com/apache/camel-k-examples">Examples</a>
 </p>
@@ -51,14 +51,14 @@ Apache Camel K now leverages a catalog of connectors called "Kamelets" (_Kamel_ 
 simplified interface, hiding all the low level details about how those connections are implemented.
 
 <p>
-<a class="button dark" href="/camel-kamelets/next/">Kamelet Catalog</a>
+<a class="button dark" href="/camel-kamelets/latest/">Kamelet Catalog</a>
 </p>
 
 {{< /div >}}
 
 {{< div "icon" >}}
 
-[![Camel](/_/img/logo-d.svg)![Knative](/_/img/knative.svg)](/camel-k/next/)
+[![Camel](/_/img/logo-d.svg)![Knative](/_/img/knative.svg)](/camel-k/latest/)
 
 {{< /div >}}
 
@@ -68,7 +68,7 @@ simplified interface, hiding all the low level details about how those connectio
 
 {{< div "icon" >}}
 
-[![Camel](/_/img/logo-d.svg)![Knative](/_/img/apache-kafka.svg)](/camel-k/next/)
+[![Camel](/_/img/logo-d.svg)![Knative](/_/img/apache-kafka.svg)](/camel-k/latest/)
 
 {{< /div >}}
 
@@ -76,10 +76,10 @@ simplified interface, hiding all the low level details about how those connectio
 
 ## Camel Kafka Connector
 
-Camel Kafka Connector allows you to use all [Camel components](/components/next/) as [Kafka Connect](http://kafka.apache.org/documentation/#connect) connectors, which, as a result, expands Kafka Connect compatibility by allowing all Camel components to be used in the Kafka ecosystem.
+Camel Kafka Connector allows you to use all [Camel components](/components/latest/) as [Kafka Connect](http://kafka.apache.org/documentation/#connect) connectors, which, as a result, expands Kafka Connect compatibility by allowing all Camel components to be used in the Kafka ecosystem.
 
 <p>
-<a class="button dark" href="/camel-kafka-connector/next/">Documentation</a>
+<a class="button dark" href="/camel-kafka-connector/latest/">Documentation</a>
 <a class="button light" href="https://github.com/apache/camel-kafka-connector/">Source</a>
 <a class="button light" href="https://github.com/apache/camel-kafka-connector-examples/">Examples</a>
 </p>
@@ -97,7 +97,7 @@ Camel Kafka Connector allows you to use all [Camel components](/components/next/
 This project hosts the efforts to port and package the 280+ Camel components as Quarkus extensions. [Quarkus](https://quarkus.io/) is a Java platform offering fast boot times and low memory footprint. It targets both stock JVMs and GraalVM.
 
 <p>
-<a class="button dark" href="/camel-quarkus/next/">Documentation</a>
+<a class="button dark" href="/camel-quarkus/latest/">Documentation</a>
 <a class="button light" href="https://github.com/apache/camel-quarkus/">Source</a>
 <a class="button light" href="https://github.com/apache/camel-quarkus-examples/">Examples</a>
 </p>
@@ -106,7 +106,7 @@ This project hosts the efforts to port and package the 280+ Camel components as 
 
 {{< div "icon" >}}
 
-[![Camel](/_/img/logo-d.svg)![Quarkus](/_/img/quarkus.svg)](/camel-quarkus/next/)
+[![Camel](/_/img/logo-d.svg)![Quarkus](/_/img/quarkus.svg)](/camel-quarkus/latest/)
 
 {{< /div >}}
 
@@ -116,7 +116,7 @@ This project hosts the efforts to port and package the 280+ Camel components as 
 
 {{< div "icon" >}}
 
-[![Camel](/_/img/logo-d.svg)![Spring Boot](/_/img/spring-boot.svg)](/camel-spring-boot/next/)
+[![Camel](/_/img/logo-d.svg)![Spring Boot](/_/img/spring-boot.svg)](/camel-spring-boot/latest/)
 
 {{< /div >}}
 
@@ -127,7 +127,7 @@ This project hosts the efforts to port and package the 280+ Camel components as 
 Camel support for Spring Boot provides auto-configuration of the Camel context by auto-detecting Camel routes available in the Spring context and registers the key Camel utilities as beans. It also provides starters for many Camel components.
 
 <p>
-<a class="button dark" href="/camel-spring-boot/next/">Documentation</a>
+<a class="button dark" href="/camel-spring-boot/latest/">Documentation</a>
 <a class="button light" href="https://github.com/apache/camel-spring-boot">Source</a>
 <a class="button light" href="https://github.com/apache/camel-spring-boot-examples">Examples</a>
 </p>
@@ -145,7 +145,7 @@ Camel support for Spring Boot provides auto-configuration of the Camel context b
 [Apache Karaf](https://karaf.apache.org/) makes running Apache Camel in [OSGi](https://www.osgi.org/) container easy, which as a result, expands Apache Camel's compatibility by allowing all Camel components to run in the OSGi environment.
 
 <p>
-<a class="button dark" href="/camel-karaf/next/">Documentation</a>
+<a class="button dark" href="/camel-karaf/latest/">Documentation</a>
 <a class="button light" href="https://github.com/apache/camel-karaf">Source</a>
 <a class="button light" href="https://github.com/apache/camel-karaf-examples">Examples</a>
 </p>
@@ -154,7 +154,7 @@ Camel support for Spring Boot provides auto-configuration of the Camel context b
 
 {{< div "icon" >}}
 
-[![Camel](/_/img/logo-d.svg)![Karaf](/_/img/apache-karaf.svg)](/camel-karaf/next/)
+[![Camel](/_/img/logo-d.svg)![Karaf](/_/img/apache-karaf.svg)](/camel-karaf/latest/)
 
 {{< /div >}}
 

--- a/static/camel-k/latest/index.html
+++ b/static/camel-k/latest/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>Link checker workaround</title>
+</head>
+<body>
+<article>
+    <p>This file exists solely to defeat the limitations of the link checker, that is unaware of the .htaccess redirect from this page to the latest released version.</p>
+    <p>If you see this, you are not viewing the site through httpd or there is something wrong with the .htaccess file: in the latter case please let the camel developers know.</p>
+</article>
+</body>
+</html>
+

--- a/static/camel-kafka-connector/latest/index.html
+++ b/static/camel-kafka-connector/latest/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>Link checker workaround</title>
+</head>
+<body>
+<article>
+    <p>This file exists solely to defeat the limitations of the link checker, that is unaware of the .htaccess redirect from this page to the latest released version.</p>
+    <p>If you see this, you are not viewing the site through httpd or there is something wrong with the .htaccess file: in the latter case please let the camel developers know.</p>
+</article>
+</body>
+</html>
+

--- a/static/camel-kamelets/latest/index.html
+++ b/static/camel-kamelets/latest/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>Link checker workaround</title>
+</head>
+<body>
+<article>
+    <p>This file exists solely to defeat the limitations of the link checker, that is unaware of the .htaccess redirect from this page to the latest released version.</p>
+    <p>If you see this, you are not viewing the site through httpd or there is something wrong with the .htaccess file: in the latter case please let the camel developers know.</p>
+</article>
+</body>
+</html>
+

--- a/static/camel-karaf/latest/index.html
+++ b/static/camel-karaf/latest/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>Link checker workaround</title>
+</head>
+<body>
+<article>
+    <p>This file exists solely to defeat the limitations of the link checker, that is unaware of the .htaccess redirect from this page to the latest released version.</p>
+    <p>If you see this, you are not viewing the site through httpd or there is something wrong with the .htaccess file: in the latter case please let the camel developers know.</p>
+</article>
+</body>
+</html>
+

--- a/static/camel-quarkus/latest/index.html
+++ b/static/camel-quarkus/latest/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>Link checker workaround</title>
+</head>
+<body>
+<article>
+    <p>This file exists solely to defeat the limitations of the link checker, that is unaware of the .htaccess redirect from this page to the latest released version.</p>
+    <p>If you see this, you are not viewing the site through httpd or there is something wrong with the .htaccess file: in the latter case please let the camel developers know.</p>
+</article>
+</body>
+</html>
+

--- a/static/camel-spring-boot/latest/index.html
+++ b/static/camel-spring-boot/latest/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>Link checker workaround</title>
+</head>
+<body>
+<article>
+    <p>This file exists solely to defeat the limitations of the link checker, that is unaware of the .htaccess redirect from this page to the latest released version.</p>
+    <p>If you see this, you are not viewing the site through httpd or there is something wrong with the .htaccess file: in the latter case please let the camel developers know.</p>
+</article>
+</body>
+</html>
+

--- a/static/components/latest/eips/enterprise-integration-patterns.html
+++ b/static/components/latest/eips/enterprise-integration-patterns.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>Link checker workaround</title>
+</head>
+<body>
+    <article>
+        <p>This file exists solely to defeat the limitations of the link checker, that is unaware of the .htaccess redirect from this page to the latest released version.</p>
+        <p>If you see this, you are not viewing the site through httpd or there is something wrong with the .htaccess file: in the latter case please let the camel developers know.</p>
+    </article>
+</body>
+</html>
+

--- a/static/components/latest/index.html
+++ b/static/components/latest/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>Link checker workaround</title>
+</head>
+<body>
+<article>
+    <p>This file exists solely to defeat the limitations of the link checker, that is unaware of the .htaccess redirect from this page to the latest released version.</p>
+    <p>If you see this, you are not viewing the site through httpd or there is something wrong with the .htaccess file: in the latter case please let the camel developers know.</p>
+</article>
+</body>
+</html>
+


### PR DESCRIPTION
 See #699.
The netlify preview won't show this working as it relies on the .htaccess file.  I checked that it worked locally with httpd running in docker.