### PR TITLE
chore: add row for empty data on security page

### DIFF
--- a/antora-ui-camel/src/css/security.css
+++ b/antora-ui-camel/src/css/security.css
@@ -1,0 +1,7 @@
+.security td:only-child {
+  text-align: center;
+}
+
+.security td:first-child {
+  white-space: nowrap;
+}

--- a/antora-ui-camel/src/css/site.css
+++ b/antora-ui-camel/src/css/site.css
@@ -28,3 +28,4 @@
 @import 'download.css';
 @import 'catalog.css';
 @import 'sharingbuttons.css';
+@import 'security.css';

--- a/layouts/security/list.html
+++ b/layouts/security/list.html
@@ -2,7 +2,7 @@
 
 <div class="body">
     <main>
-        <article class="static doc">
+        <article class="static doc security">
 
             {{ .Content }}
             <div class="table-wrapper">
@@ -18,7 +18,17 @@
                   </tr>
                 </thead>
                 <tbody>
-              {{ range .Pages.GroupByDate "2006" "desc" }}
+              {{ $pages := .Pages.GroupByDate "2006" "desc" }}
+              {{ $latest_year := (index $pages 0).Key }}
+              {{ range seq (now.Format "2006") (add (int $latest_year) 1) }}
+                  <tr>
+                    <th colspan="5" scope="row"><strong>{{ . }}</strong></th>
+                  </tr>
+                  <tr>
+                    <td colspan="5"><em>No issues reported</em></td>
+                  </tr>
+              {{ end }}
+              {{ range $pages }}
                   <tr>
                     <th colspan="5" scope="row"><strong>{{ .Key }}</strong></th>
                   </tr>


### PR DESCRIPTION
To appear the data on the security page is up to date add a row for any
year from now till the latest reported security issue indicating that no
issues were reported in that year. Also cleans up the table so that the
CVE number doesn't word-wrap.

Fixes #710