### PR TITLE
fix: pass only the PR number and validate it

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -39,7 +39,6 @@ jobs:
         run: |
           mkdir pull_request
           echo ${{ github.event.pull_request.number }} > ./pull_request/number
-          echo ${{ github.event.pull_request.html_url }} > ./pull_request/html_url
       - name: Upload artifacts
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -26,6 +26,8 @@ on:
 jobs:
   preview:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
     if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
     steps:
       - name: Checkout
@@ -57,9 +59,12 @@ jobs:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
         run: |
-          DEPLOY_URL=$(yarn preview:netlify --alias="pr-$(cat pull_request/number)" --message="Preview for $(cat pull_request/html_url)" --json 2> /dev/null |jq -r .deploy_url)
+          PR_NUMBER=$(head -1 pull_request/number)
+          PR_NUMBER=${PR_NUMBER//[^0-9]/}
+          PR_URL="https://github.com/apache/camel-website/pull/${PR_NUMBER}"
+          DEPLOY_URL=$(yarn preview:netlify --alias="pr-${PR_NUMBER}" --message="Preview for ${PR_URL}" --json 2> /dev/null |jq -r .deploy_url)
           echo "DEPLOY_URL=${DEPLOY_URL}" >> $GITHUB_ENV
-          echo "ISSUE_NUMBER=$(cat pull_request/number)" >> $GITHUB_ENV
+          echo "ISSUE_NUMBER=${PR_NUMBER}" >> $GITHUB_ENV
       - uses: actions/github-script@v3
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
We don't need to pass `github.event.pull_request.html_url` in
`./pull_request/html_url` in the archive, and we should validate that
`./pull_request/number` is a number and we should read only the first
line from that file.