### PR TITLE
fix: generate the assets.js helper

### DIFF
--- a/antora-ui-camel/gulp.d/tasks/build.js
+++ b/antora-ui-camel/gulp.d/tasks/build.js
@@ -134,7 +134,7 @@ module.exports = (src, dest, preview) => () => {
     .pipe(
       map((file, enc, next) => {
         manifest = file.contents.toString()
-        next(null, null)
+        next(null, file)
       })
     )
     .pipe(vfs.src('helpers/*.js.template', opts))

--- a/antora-ui-camel/src/partials/footer-content.hbs
+++ b/antora-ui-camel/src/partials/footer-content.hbs
@@ -4,7 +4,7 @@
     <footer>
         <div class="footer">
             <figure class="logo">
-                <img src="{{uiRootPath}}/{{asset 'img/logo-d.svg'}}" class="logo-small mt-60" alt="Apache Camel Logo"
+                <img src="{{uiRootPath}}/img/logo-d.svg" class="logo-small mt-60" alt="Apache Camel Logo"
                     aria-label="white silhouette of a camel in front of a sand dune">
             </figure>
             <input id="footer-toggle-overview" type="checkbox" title="Show/Hide Overview section" />
@@ -66,10 +66,10 @@
                 </div>
             </div>
             <div class="footer-icons">
-                <a rel="noopener noreferrer nofollow" href="https://github.com/apache/camel/" title="Collaborate on GitHub"><svg class="brand-icon" focusable="false"><use xlink:href="{{uiRootPath}}/{{asset 'img/brand-logos.svg'}}#github" /></svg></a>
-                <a rel="noopener noreferrer nofollow" href="https://camel.zulipchat.com" title="Chat on Zulip"><svg class="brand-icon" focusable="false"><use xlink:href="{{uiRootPath}}/{{asset 'img/brand-logos.svg'}}#zulip" /></svg></a>
-                <a rel="noopener noreferrer nofollow" href="https://twitter.com/ApacheCamel" title="Follow Apache Camel on Twitter"><svg class="brand-icon" focusable="false"><use xlink:href="{{uiRootPath}}/{{asset 'img/brand-logos.svg'}}#twitter" /></svg></a>
-                <a rel="noopener noreferrer nofollow" href="https://www.linkedin.com/groups/2447439/" title="Apache Camel group on Linkedin"><svg class="brand-icon" focusable="false"><use xlink:href="{{uiRootPath}}/{{asset 'img/brand-logos.svg'}}#linkedin" /></svg></a>
+                <a rel="noopener noreferrer nofollow" href="https://github.com/apache/camel/" title="Collaborate on GitHub"><svg class="brand-icon" focusable="false"><use xlink:href="{{uiRootPath}}/img/brand-logos.svg#github" /></svg></a>
+                <a rel="noopener noreferrer nofollow" href="https://camel.zulipchat.com" title="Chat on Zulip"><svg class="brand-icon" focusable="false"><use xlink:href="{{uiRootPath}}/img/brand-logos.svg#zulip" /></svg></a>
+                <a rel="noopener noreferrer nofollow" href="https://twitter.com/ApacheCamel" title="Follow Apache Camel on Twitter"><svg class="brand-icon" focusable="false"><use xlink:href="{{uiRootPath}}/img/brand-logos.svg#twitter" /></svg></a>
+                <a rel="noopener noreferrer nofollow" href="https://www.linkedin.com/groups/2447439/" title="Apache Camel group on Linkedin"><svg class="brand-icon" focusable="false"><use xlink:href="{{uiRootPath}}/img/brand-logos.svg#linkedin" /></svg></a>
             </div>
         </div>
     </footer>

--- a/antora-ui-camel/src/partials/footer-scripts.hbs
+++ b/antora-ui-camel/src/partials/footer-scripts.hbs
@@ -1,6 +1,5 @@
-<script src="{{uiRootPath}}{{asset 'js/vendor/algoliasearch.js'}}"></script>
-<script src="{{uiRootPath}}{{asset 'js/site.js'}}"></script>
-<script async src="{{uiRootPath}}{{asset 'js/vendor/highlight.js'}}"></script>
-<script async src="{{uiRootPath}}{{asset 'js/vendor/svg4everybody.js'}}"></script>
+<script src="{{uiRootPath}}/js/vendor/algoliasearch.js"></script>
+<script src="{{uiRootPath}}/js/site.js"></script>
+<script async src="{{uiRootPath}}/js/vendor/highlight.js"></script>
+<script async src="{{uiRootPath}}/js/vendor/svg4everybody.js"></script>
 {{> seo-main}}
-

--- a/antora-ui-camel/src/partials/head-styles.hbs
+++ b/antora-ui-camel/src/partials/head-styles.hbs
@@ -1,1 +1,1 @@
-    <link rel="stylesheet" href="{{uiRootPath}}{{asset 'css/site.css'}}">
+    <link rel="stylesheet" href="{{uiRootPath}}/css/site.css">

--- a/antora-ui-camel/src/partials/header-content.hbs
+++ b/antora-ui-camel/src/partials/header-content.hbs
@@ -18,14 +18,14 @@
       <div class="break-row"></div>
       <div class="navbar-search results-hidden">
         <input id="search" class="search" placeholder="Search" autocomplete="off">
-        <img src="{{uiRootPath}}{{asset 'img/cancel.svg'}}" alt="Clear" id="search-cancel">
+        <img src="{{uiRootPath}}/img/cancel.svg" alt="Clear" id="search-cancel">
         <div id="search_results"></div>
       </div>
       <div class="navbar-tools">
-        <a rel="noopener noreferrer nofollow" href="https://github.com/apache/camel/" title="Collaborate on GitHub"><svg focusable="false" class="brand-icon"><use xlink:href="{{uiRootPath}}{{asset 'img/brand-logos.svg'}}#github" /></svg></a>
-        <a rel="noopener noreferrer nofollow" href="https://camel.zulipchat.com" title="Chat on Zulip"><svg focusable="false" class="brand-icon"><use xlink:href="{{uiRootPath}}{{asset 'img/brand-logos.svg'}}#zulip" /></svg></a>
-        <a rel="noopener noreferrer nofollow" href="https://twitter.com/ApacheCamel" title="Follow Apache Camel on Twitter"><svg focusable="false" class="brand-icon"><use xlink:href="{{uiRootPath}}{{asset 'img/brand-logos.svg'}}#twitter" /></svg></a>
-        <a rel="noopener noreferrer nofollow" href="https://www.linkedin.com/groups/2447439/" title="Apache Camel group on Linkedin"><svg focusable="false" class="brand-icon"><use xlink:href="{{uiRootPath}}{{asset 'img/brand-logos.svg'}}#linkedin" /></svg></a>
+        <a rel="noopener noreferrer nofollow" href="https://github.com/apache/camel/" title="Collaborate on GitHub"><svg focusable="false" class="brand-icon"><use xlink:href="{{uiRootPath}}/img/brand-logos.svg#github" /></svg></a>
+        <a rel="noopener noreferrer nofollow" href="https://camel.zulipchat.com" title="Chat on Zulip"><svg focusable="false" class="brand-icon"><use xlink:href="{{uiRootPath}}/img/brand-logos.svg#zulip" /></svg></a>
+        <a rel="noopener noreferrer nofollow" href="https://twitter.com/ApacheCamel" title="Follow Apache Camel on Twitter"><svg focusable="false" class="brand-icon"><use xlink:href="{{uiRootPath}}/img/brand-logos.svg#twitter" /></svg></a>
+        <a rel="noopener noreferrer nofollow" href="https://www.linkedin.com/groups/2447439/" title="Apache Camel group on Linkedin"><svg focusable="false" class="brand-icon"><use xlink:href="{{uiRootPath}}/img/brand-logos.svg#linkedin" /></svg></a>
       </div>
       <button class="navbar-burger" data-target="topbar-nav" type="button" aria-label="Menu">
         <span></span>


### PR DESCRIPTION
With #702 the Gulp pipeline changed behavior, previously invoking
`next(null, null)` was generating the `assets.js` helper now that is no
longer sufficient. By design of `through2` invoking the callback with
`null, null` doesn't emit the file, so not sure why that was working
previously.

Also since adding `rev-rewrite` to the pipeline we no longer need to use
the `asset` helper for non-dynamic resource usage, i.e. those that
specify the file name, as those will be replaced by `rev-rewrite` for
their hashed counterparts.

Fixes apache#718