### PR TITLE
chore: additional check that website is up

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "check:html": "html-validate public",
     "check:links": "deadlinks-linux public",
     "check:redirects": "tests/redirect.sh -s",
-    "checks": "run-s check:links check:html",
+    "checks": "run-s check:links check:html check:redirects",
     "clean": "gulp clean",
     "check:dependencies": "run-p check:cache check:dedupe",
     "check:cache": "yarn workspaces foreach install --immutable --immutable-cache --check-cache",

--- a/tests/redirect.sh
+++ b/tests/redirect.sh
@@ -130,12 +130,18 @@ function test {
   fi
 }
 
+HTACCESS_FILE="$GIT_ROOT/documentation/.htaccess"
+if [ ! -f "$HTACCESS_FILE" ]; then
+  echo "No $HTACCESS_FILE found, using last published version. If you have made changes to the Antora playbook make sure to build the site first to test those."
+  $CURL_CMD -s -o "$HTACCESS_FILE" 'https://gitbox.apache.org/repos/asf?p=camel-website.git;a=blob_plain;f=.htaccess;hb=refs/heads/asf-site'
+fi
+
 # determine current _latest_ versions
-COMPONENTS_VERSION="$(grep 'components/latest' "$GIT_ROOT/documentation/.htaccess" | grep -Z -o '[^/]*$')"
-CAMEL_K_VERSION="$(grep 'camel-k/latest' "$GIT_ROOT/documentation/.htaccess" | grep -Z -o '[^/]*$')"
-CAMEL_KAFKA_CONNECTOR_VERSION="$(grep 'camel-kafka-connector/latest' "$GIT_ROOT/documentation/.htaccess" | grep -Z -o '[^/]*$')"
-CAMEL_QUARKUS_VERSION="$(grep 'camel-quarkus/latest' "$GIT_ROOT/documentation/.htaccess" | grep -Z -o '[^/]*$')"
-CAMEL_KAMELETS_VERSION="$(grep 'camel-kamelets/latest' "$GIT_ROOT/documentation/.htaccess" | grep -Z -o '[^/]*$')"
+COMPONENTS_VERSION="$(grep '^Redirect 302 /components/latest' "$HTACCESS_FILE" | grep -Z -o '[^/]*$')"
+CAMEL_K_VERSION="$(grep '^Redirect 302 /camel-k/latest' "$HTACCESS_FILE" | grep -Z -o '[^/]*$')"
+CAMEL_KAFKA_CONNECTOR_VERSION="$(grep '^Redirect 302 /camel-kafka-connector/latest' "$HTACCESS_FILE" | grep -Z -o '[^/]*$')"
+CAMEL_QUARKUS_VERSION="$(grep '^Redirect 302 /camel-quarkus/latest' "$HTACCESS_FILE" | grep -Z -o '[^/]*$')"
+CAMEL_KAMELETS_VERSION="$(grep '^Redirect 302 /camel-kamelets/latest' "$HTACCESS_FILE" | grep -Z -o '[^/]*$')"
 
 #
 # TESTS


### PR DESCRIPTION
When running the web server in a container for the redirect tests there
could be some network issues reaching it. This adds detection of that
situation and switches to using curl from inside of the web server
container.

This issue has occurred once on ASF Jenkins in build 622[1],
unfortunately without details allowing us to troubleshot this issue.

[1] [ci-builds.apache.org/job/Camel/job/Camel.website/job/main/622](https://ci-builds.apache.org/job/Camel/job/Camel.website/job/main/622/)

Also includes in 0d483cb1b86ad0f695d8055c17ae9fdb4bb16648:

chore: fetch .htaccess from git

If the website wasn't built we can still run the redirect checks by
loading the live `.htaccess` file from the `asf-site` branch in git.
This way we can run the redirect checks independent of the build if we
need to.