### PR TITLE
oops, left out a commit... Main site manifest

### DIFF
--- a/antora-playbook-snippets/playbook-import-site-manifest-local.yml
+++ b/antora-playbook-snippets/playbook-import-site-manifest-local.yml
@@ -3,7 +3,7 @@
       import_manifests:
         - primary_site_manifest_url: ./documentation/site-manifest.json
       local_urls: true
-      # Turn on partial_components if you further restict source-watch to build less than the full subproject.
+      # Turn on partial_components if you further restrict source-watch to build less than the full subproject.
 #      partial_components: true
 
     - require: '@djencks/antora-timer'

--- a/antora-playbook-snippets/playbook-import-site-manifest-remote.yml
+++ b/antora-playbook-snippets/playbook-import-site-manifest-remote.yml
@@ -1,9 +1,6 @@
     - require: "@djencks/antora-site-manifest"
       import-manifests:
-# Until PR is merged
-        - primary-site-manifest-url: https://pr-735--camel.netlify.app/site-manifest.json
-# After PR is merged
-#        - primary-site-manifest-url: https://camel.apache.org/site-manifest.json
+        - primary-site-manifest-url: https://camel.apache.org/site-manifest.json
 
     - require: '@djencks/antora-timer'
       log_level: info


### PR DESCRIPTION
I meant to adjust this to use the actual production site for the site manifest, but got confused and didn't commit it.