### PR TITLE
refactor: set UI regeneration workflow name

### DIFF
--- a/.github/workflows/main-push-ui-bundle.yml
+++ b/.github/workflows/main-push-ui-bundle.yml
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-name: build
+name: Regenerate UI bundle
 
 on:
   push:


### PR DESCRIPTION
Best have a descriptive name instead of `build`.