### PR TITLE
chore: failed build notification on Zulip

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -110,5 +110,11 @@ pipeline {
         always {
             sh "$WORKSPACE/docker-pipe/teardown.sh"
         }
+        fixed {
+            mail subject: 'Website build status', body: "🥳 Build succeeded!", to: 'camel-website.874fb06555c2b4407efde9f9a3b13c13.show-sender@streams.zulipchat.com'
+        }
+        unsuccessful {
+            mail subject: 'Website build status', body: "😞 Build failed. Please have a look at the build output at: ${env.BUILD_URL}", to: 'camel-website.874fb06555c2b4407efde9f9a3b13c13.show-sender@streams.zulipchat.com'
+        }
     }
 }


### PR DESCRIPTION
This uses the Zulip mail-in functionality to send messages for failed builds.