### PR TITLE
chore: POM version upgrades

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,8 +36,8 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-    <node.version>v10.15.3</node.version>
-    <yarn.version>v1.14.0</yarn.version>
+    <node.version>v16.13.2</node.version>
+    <yarn.version>v1.22.17</yarn.version>
 
     <theme.basedir>antora-ui-camel</theme.basedir>
     <skip.theme>false</skip.theme>
@@ -54,7 +54,7 @@
         <plugin>
           <groupId>com.github.eirslett</groupId>
           <artifactId>frontend-maven-plugin</artifactId>
-          <version>1.7.5</version>
+          <version>1.12.1</version>
         </plugin>
       </plugins>
     </pluginManagement>
@@ -121,7 +121,7 @@
             </goals>
             <configuration>
               <skip>${skip.theme}</skip>
-              <arguments>install --no-progress --force</arguments>
+              <arguments>install</arguments>
               <workingDirectory>${theme.basedir}</workingDirectory>
               <installDirectory>${project.basedir}</installDirectory>
             </configuration>
@@ -144,7 +144,7 @@
               <goal>yarn</goal>
             </goals>
             <configuration>
-              <arguments>install --no-progress --force</arguments>
+              <arguments>install</arguments>
             </configuration>
           </execution>
           <execution>


### PR DESCRIPTION
We need to keep the POM file updated with the versions of node/Yarn
used. This is work by @Steve973 taken from #753.