### PR TITLE
Main 701 ri tables

### DIFF
--- a/antora-playbook-snippets/antora-playbook.yml
+++ b/antora-playbook-snippets/antora-playbook.yml
@@ -38,6 +38,7 @@ content:
     - url: https://github.com/apache/camel-k.git
       branches:
         - main
+        - release-1.8.x
         - release-1.7.x
         - release-1.6.x
         - release-1.4.x
@@ -46,6 +47,7 @@ content:
     - url: https://github.com/apache/camel-k-runtime.git
       branches:
         - main
+        - release-1.11.x
         - release-1.10.x
         - release-1.9.x
       start_path: docs
@@ -53,6 +55,7 @@ content:
     - url: https://github.com/apache/camel-kamelets.git
       branches:
         - main
+        - 0.7.x
         - 0.6.x
         - 0.5.x
       start_path: docs

--- a/util/jsonpath-util.js
+++ b/util/jsonpath-util.js
@@ -105,6 +105,41 @@ module.exports = {
   valueAsString: (value) => {
     return value === undefined ? '' : `${value}`
   },
+
+//  Compatibility table support
+  camelRef: (version, docVersion) => (docVersion === 'none') ? version : `xref:${docVersion}@components:ROOT:index.adoc[${version}]`,
+
+  ckRef: (version, docVersion) => (docVersion === 'none') ? version : `xref:${docVersion}@camel-k:ROOT:index.adoc[${version}]`,
+
+  ckcRef: (version, docVersion) => (docVersion === 'none') ? version : `xref:${docVersion}@camel-kafka-connector:ROOT:index.adoc[${version}]`,
+
+  kameletsRef: (version, docVersion) => (docVersion === 'none') ? version : `xref:${docVersion}@camel-kamelets:ROOT:index.adoc[${version}]`,
+
+  camelQuarkusRef: (version, docVersion) => (docVersion === 'none') ? version : `xref:${docVersion}@camel-quarkus:ROOT:index.adoc[${version}]`,
+
+// External dependency links for compatibility tables
+  graalvmRef: (version, docVersion) => `https://www.graalvm.org/${docVersion}/docs/[${version}]`,
+
+  kafkaRef: (version, docVersion) => `https://kafka.apache.org/${docVersion}/documentation.html[${version}]`,
+
+  quarkusRef: (version) => `https://quarkus.io/guides[${version}]`,
+
+  //Sorts next, then versions descending
+  sortCompatibilityItems: (items) => items.sort((t1, t2) => {
+    const v1 = t1['page-component-version']
+    const v2 = t2['page-component-version']
+    if (v1 === v2) return 0
+    if ((v1 === 'next') || !v2) return -1
+    if ((v2 === 'next') || !v1) return 1
+    const v1s = v1.split('.').map((t) => Number(t))
+    const v2s = v2.split('.').map((t) => Number(t))
+    let i
+    for (i = 0; i < v1s.length; i++) {
+      if (i === v2s.length) return -1
+      if (v1s[i] !== v2s[i]) return v2s[i] - v1s[i] // could be a problem with NaN?
+    }
+    return 1
+  })
 }
 
 function trueEnough (value) {


### PR DESCRIPTION
This must be merged in coordination with several other PRs.

This sets up some global helper functions for the RI tables and adds the new branches for camel-k 1.8.x,camel-k-runtime 1.11.x, and kamelets 0.7.x releases. As of this PR creation, the vote has gone on for more than 72 hours but has not concluded.