### PR TITLE
feat: add 'Supports Java 11' for Kamelets

### DIFF
--- a/content/releases/kamelets/release-0.3.0.md
+++ b/content/releases/kamelets/release-0.3.0.md
@@ -7,4 +7,5 @@ title: "Kamelets 0.3.0"
 preview: ""
 changelog: ""
 category: "camel-kamelets"
+jdk: [11]
 ---

--- a/content/releases/kamelets/release-0.4.0.md
+++ b/content/releases/kamelets/release-0.4.0.md
@@ -7,4 +7,5 @@ title: "Kamelets 0.4.0"
 preview: ""
 changelog: ""
 category: "camel-kamelets"
+jdk: [11]
 ---

--- a/content/releases/kamelets/release-0.5.0.md
+++ b/content/releases/kamelets/release-0.5.0.md
@@ -7,4 +7,5 @@ title: "Kamelets 0.5.0"
 preview: ""
 changelog: ""
 category: "camel-kamelets"
+jdk: [11]
 ---

--- a/content/releases/kamelets/release-0.6.0.md
+++ b/content/releases/kamelets/release-0.6.0.md
@@ -7,4 +7,5 @@ title: "Kamelets 0.6.0"
 preview: ""
 changelog: ""
 category: "camel-kamelets"
+jdk: [11]
 ---

--- a/content/releases/kamelets/release-0.7.0.md
+++ b/content/releases/kamelets/release-0.7.0.md
@@ -7,4 +7,5 @@ title: "Kamelets 0.7.0"
 preview: ""
 changelog: ""
 category: "camel-kamelets"
+jdk: [11]
 ---


### PR DESCRIPTION
Given that Kamelets have an Catalog API we should inform folk that Java
11 is required.