### PR TITLE
delink references to removed pages in blog articles

### DIFF
--- a/content/blog/2021/02/camel-quarkus-release-1.7.0/index.md
+++ b/content/blog/2021/02/camel-quarkus-release-1.7.0/index.md
@@ -53,7 +53,7 @@ Components newly supported in native mode:
 * [AWS 2 Kinesis and Firehose](/camel-quarkus/next/reference/extensions/aws2-kinesis.html)
 * [Azure Storage Queue Service](/camel-quarkus/next/reference/extensions/azure-storage-queue.html)
 * [Cassandra CQL](/camel-quarkus/next/reference/extensions/cassandraql.html)
-* [IPFS](/camel-quarkus/next/reference/extensions/ipfs.html)
+* IPFS (no longer supported, February 2022)
 * [PubNub](/camel-quarkus/next/reference/extensions/pubnub.html)
 * [StAX](/camel-quarkus/next/reference/extensions/stax.html)
 * [CBOR](/camel-quarkus/next/reference/extensions/cbor.html)

--- a/content/blog/2021/06/camel-quarkus-release-2.0.0/index.md
+++ b/content/blog/2021/06/camel-quarkus-release-2.0.0/index.md
@@ -45,7 +45,7 @@ New extensions:
 * [Google Cloud Functions](/camel-quarkus/next/reference/extensions/google-functions.html) (JVM only)
 * [Google Storage](/camel-quarkus/next/reference/extensions/google-storage.html)
 * [jOOR](/camel-quarkus/next/reference/extensions/joor.html) (JVM only)
-* [Kamelet Reify](/camel-quarkus/next/reference/extensions/kamelet-reify.html) (JVM only)
+* Kamelet Reify (JVM only, no longer supported, February 2022)
 * [Protobuf Jackson](/camel-quarkus/next/reference/extensions/jackson-protobuf.html)
 
 Extensions newly supported in native mode:


### PR DESCRIPTION
A couple pages are gone from camel-quarkus next and there are old blog articles linking to them.  This is one fix.