### PR TITLE
Promote the usage of yarn in docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,6 +373,22 @@ This is most likely what you want.
 If you need to link to a specific non-latest version of a page, specify the version in the xref.
 - A link from anywhere to a camel-quarkus 2.0.0 page would be xref:2.0.0@camel-quarkus::reference/extensions/activemq.adoc[].
 
+## Build with Yarn in Docker
+
+To avoid having to install everything on your local machine or if you are a Mac or Windows user, you still have the possibility to launch the `yarn` commands directly inside a Docker container in which all the required tools have been preinstalled.
+
+Assuming that Docker is properly installed on your local machine and the Docker daemon is started, all you need to do is to call the script `yarn-in-docker.sh` or `yarn-in-docker.bat` with the arguments that you would like to pass to the `yarn` command.
+
+For example to launch `yarn` with `build-all` as argument inside a Docker container, the corresponding command is then:
+
+    $ ./yarn-in-docker.sh build-all
+
+Equivalent for Windows
+
+    > yarn-in-docker.bat build-all
+
+Note - The environment variables `GITHUB_TOKEN` and `CAMEL_ENV` locally set are automatically propagated to the Docker container.
+
 ## Build with Maven
 
 The project provides a simple way to build the website sources locally using the build tool [Maven](https://maven.apache.org/).

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "update:cache": "yarn workspaces foreach install --check-cache",
     "update:dedupe": "yarn workspaces foreach dedupe",
     "preview": "run-s -l build:antora preview:hugo",
-    "preview:hugo": "hugo server -D",
+    "preview:hugo": "hugo server --bind=0.0.0.0 -D",
     "preview:netlify": "netlify deploy --dir public",
     "build:antora-local-full": "antora local-antora-playbook-full.yml --stacktrace --clean --fetch",
     "build:antora-local-partial": "antora local-antora-playbook-partial.yml --stacktrace",

--- a/yarn-in-docker.bat
+++ b/yarn-in-docker.bat
@@ -1,0 +1,6 @@
+@rem Run yarn in docker.
+@rem supply the yarn arga/script on the command line, e.g.
+@rem yarn-in-docker.bat workspace antora-ui-camel run build
+
+docker build -t camel-website .
+docker run --rm -it -p 1313:1313 -e "GITHUB_TOKEN=%GITHUB_TOKEN%" -e "CAMEL_ENV=%CAMEL_ENV%" -v "%CD%:/work:Z" --workdir /work camel-website yarn %*

--- a/yarn-in-docker.sh
+++ b/yarn-in-docker.sh
@@ -5,4 +5,4 @@
 # $yarn-in-docker.sh workspace antora-ui-camel run build
 
 docker build -t camel-website .
-docker run --rm -it -v $(pwd):/work:Z --workdir /work camel-website yarn $*
+docker run --rm -it -p 1313:1313 -e "GITHUB_TOKEN=${GITHUB_TOKEN}" -e "CAMEL_ENV=${CAMEL_ENV}" -v $(pwd):/work:Z --workdir /work camel-website yarn $*


### PR DESCRIPTION
## Motivation

Having the ability to launch the `yarn`  commands inside a Docker container is very handy especially if we don't want to install everything or we use Mac OS, so it could be nice to promote it in the Readme

## Modifications

* Describe how to use it in the readme
* Add a file of environment variables to easily set the GitHub token inside the container
* Add bat file for Windows users
* Publish the port 1313 to have access to the preview
* Bind the Hugo server to `0.0.0.0` to have access to the preview from the Docker host