### PR TITLE
Remove all the formatting characters from the id to prevent invalid url generation

### DIFF
--- a/util/jsonpath-util.js
+++ b/util/jsonpath-util.js
@@ -38,7 +38,8 @@ module.exports = {
   },
 
   boldLink: (text, idPrefix, suffix = '') => {
-    const idText = `_${idPrefix}_${text.split('.').join('_')}`
+    // Remove all the formatting characters from the id to prevent invalid url generation
+    const idText = `_${idPrefix}_${text.split(/[*_`#~^]*/g).join('').split('.').join('_')}`
     text = suffix ? `*${text}* (${suffix})` : `*${text}*`
     return  `[[${idText}]]\nxref:#${idText}['',role=anchor]${text}`
   },


### PR DESCRIPTION
## Motivation

If the text provided to the `boldLink` function contains special formatting characters of asciidoc, the generation of the URL fails, consequently the website cannot be built due to an error of the next type:

```
[check:links ] Found invalid urls in components/next/mongodb-component.html:
[check:links ] Fragment #_endpoint_header%3C/em%3Eid at components/next/mongodb-component.html does not exist!
```
In the previous example the provided text is `_id` which contains an underscore that is one of the formatting character of asciidoc

## Modification

* Update the `boldLink` function to remove all the special characters from the provided text used to generate the link