### PR TITLE
Use /bin/bash as interpreter for antora-local-build.sh

### DIFF
--- a/antora-local-build.sh
+++ b/antora-local-build.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more


### PR DESCRIPTION
Since the script uses shell builtin variable `BASH_SOURCE`.