### PR TITLE
fix: preview for the UI

### DIFF
--- a/antora-ui-camel/gulp.d/tasks/serve.js
+++ b/antora-ui-camel/gulp.d/tasks/serve.js
@@ -1,19 +1,45 @@
 'use strict'
 
+const { readFileSync } = require('fs')
 const connect = require('gulp-connect')
 const os = require('os')
+const path = require('path')
 
 const ANY_HOST = '0.0.0.0'
 const URL_RX = /(https?):\/\/(?:[^/: ]+)(:\d+)?/
 
+let base
+
 module.exports = (root, opts = {}, watch = undefined) => (done) => {
-  connect.server({ ...opts, middleware: opts.host === ANY_HOST ? decorateLog : undefined, root }, function () {
+  base = root
+  connect.server({ ...opts, middleware, root }, function () {
     this.server.on('close', done)
     if (watch) watch()
   })
 }
 
+function middleware (_, app) {
+  decorateLog(_, app)
+
+  return [versionedResources]
+}
+
+function versionedResources (req, res, next) {
+  // parse for each request to fetch the latest revisions
+  const rev = JSON.parse(readFileSync(path.join(base, '_', 'data', 'rev-manifest.json')))
+  const pathname = req.originalUrl.substring(3) // remove leading '/_/'
+  const replacement = rev[pathname]
+  if (replacement) {
+    req.url = req.originalUrl.replace(pathname, replacement)
+  }
+  return next()
+}
+
 function decorateLog (_, app) {
+  if (app.host !== ANY_HOST) {
+    return
+  }
+
   const _log = app.log
   app.log = (msg) => {
     if (msg.startsWith('Server started ')) {
@@ -23,7 +49,6 @@ function decorateLog (_, app) {
     }
     _log(msg)
   }
-  return []
 }
 
 function getLocalIp () {


### PR DESCRIPTION
The `yarn preview` in the UI did not account for the versioned assets,
this adds looking up the current resource version using the revision
manifest.