### PR TITLE
feat: set OpenGraph title metadata

### DIFF
--- a/antora-ui-camel/public/_/partials/head-meta.hbs
+++ b/antora-ui-camel/public/_/partials/head-meta.hbs
@@ -1,5 +1,5 @@
 <meta name="application-name" content="Apache Camel">
-<meta property="og:title" content="Apache Camel helps you integrate over 300 different systems!">
+<meta property="og:title" content="{{page.title}}">
 <meta property="og:site_name" content="Apache Camel">
 <meta property="og:url" content="https://camel.apache.org">
 <meta property="og:description" content="Camel is an open source integration framework that empowers you to quickly and easily integrate various systems consuming or producing data.">

--- a/antora-ui-camel/src/partials/head-meta.hbs
+++ b/antora-ui-camel/src/partials/head-meta.hbs
@@ -1,5 +1,5 @@
 <meta name="application-name" content="Apache Camel">
-<meta property="og:title" content="Apache Camel helps you integrate over 300 different systems!">
+<meta property="og:title" content="{{page.title}}">
 <meta property="og:site_name" content="Apache Camel">
 <meta property="og:url" content="https://camel.apache.org">
 <meta property="og:description" content="Camel is an open source integration framework that empowers you to quickly and easily integrate various systems consuming or producing data.">


### PR DESCRIPTION
Sets the `og:title` metadata to the page's title. Makes for a nicer
preview when sharing a link to the website.