### PR TITLE
Fix links to Camel Quarkus extension configuration sections

### DIFF
--- a/content/blog/2020/08/camel-quarkus-release-1.0.0/index.md
+++ b/content/blog/2020/08/camel-quarkus-release-1.0.0/index.md
@@ -95,7 +95,7 @@ On Camel Quarkus, the extensions roughly correspond to camel components - i.e. i
 need `camel-sql` you add the `camel-quarkus-sql` extension as a dependency to your application and it takes
 care for both pulling the `camel-sql` artifact and configuring the native compiler. Extension pages document any
 further configuration that needs to be done by the application developer. E.g. in case of the
-[SQL extension](/camel-quarkus/next/reference/extensions/sql.html#_additional_camel_quarkus_configuration),
+[SQL extension](/camel-quarkus/next/reference/extensions/sql.html#extensions-sql-additional-camel-quarkus-configuration),
 the `quarkus.camel.sql.script-files` property needs to be set.
 
 Check the [Native mode](/camel-quarkus/next/user-guide/native-mode.html) section of the Camel

--- a/content/blog/2021/06/camel-quarkus-release-2.0.0/index.md
+++ b/content/blog/2021/06/camel-quarkus-release-2.0.0/index.md
@@ -74,7 +74,7 @@ The extent of this effort can be assessed by running [this GitHub issues query](
 
 ## Deprecations
 
-* Avro extension: `@BuildTimeAvroDataFormat` is deprecated - see the [Avro extension](/camel-quarkus/next/reference/extensions/avro.html#_additional_camel_quarkus_configuration) page.
+* Avro extension: `@BuildTimeAvroDataFormat` is deprecated - see the [Avro extension](/camel-quarkus/next/reference/extensions/avro.html#extensions-avro-additional-camel-quarkus-configuration) page.
 
 
 ## Breaking changes and migration steps

--- a/content/blog/2021/11/camel-quarkus-release-2.5.0/index.md
+++ b/content/blog/2021/11/camel-quarkus-release-2.5.0/index.md
@@ -37,9 +37,9 @@ to cover all major use cases mentioned in the main Camel documentation.
 
 We have improved the user guide with :
 
-* New section for additional configuration in the [AWS 2 Lambda documentation](/camel-quarkus/next/reference/extensions/aws2-lambda.html#_additional_camel_quarkus_configuration)
-* New section explaining how to [generate Salesforce DTOs With the Salesforce-Maven-Plugin](/camel-quarkus/next/reference/extensions/salesforce.html#_generating_salesforce_dtos_with_the_salesforce_maven_plugin)
-* Update section for [additional configuration in Avro](/camel-quarkus/next/reference/extensions/avro.html#_additional_camel_quarkus_configuration)
+* New section for additional configuration in the [AWS 2 Lambda documentation](/camel-quarkus/next/reference/extensions/aws2-lambda.html#extensions-aws2-lambda-additional-camel-quarkus-configuration)
+* New section explaining how to [generate Salesforce DTOs With the Salesforce-Maven-Plugin](/camel-quarkus/next/reference/extensions/salesforce.html#extensions-usage-generating-salesforce-dtos-with-the-salesforce-maven-plugin)
+* Update section for [additional configuration in Avro](/camel-quarkus/next/reference/extensions/avro.html#extensions-avro-additional-camel-quarkus-configuration)
 
 
 ## Release notes


### PR DESCRIPTION
Some section IDs were updated in the CQ docs. Hopefully this fixes the broken links.