### PR TITLE
Fix broken link in apache website after camel quarkus change in fragment ids

### DIFF
--- a/content/blog/2021/11/camel-quarkus-release-2.5.0/index.md
+++ b/content/blog/2021/11/camel-quarkus-release-2.5.0/index.md
@@ -38,7 +38,7 @@ to cover all major use cases mentioned in the main Camel documentation.
 We have improved the user guide with :
 
 * New section for additional configuration in the [AWS 2 Lambda documentation](/camel-quarkus/next/reference/extensions/aws2-lambda.html#extensions-aws2-lambda-additional-camel-quarkus-configuration)
-* New section explaining how to [generate Salesforce DTOs With the Salesforce-Maven-Plugin](/camel-quarkus/next/reference/extensions/salesforce.html#extensions-usage-generating-salesforce-dtos-with-the-salesforce-maven-plugin)
+* New section explaining how to [generate Salesforce DTOs With the Salesforce-Maven-Plugin](/camel-quarkus/next/reference/extensions/salesforce.html#extensions-salesforce-usage-generating-salesforce-dtos-with-the-salesforce-maven-plugin)
 * Update section for [additional configuration in Avro](/camel-quarkus/next/reference/extensions/avro.html#extensions-avro-additional-camel-quarkus-configuration)
 
 


### PR DESCRIPTION
For now I'm just changing the build error but I'll see if there's more links that need to be changed as there were a lot of changed ids

Related diff to this issue: https://github.com/apache/camel-quarkus/commit/69ab601560da76905f2b0c5a4ce79717ab34faf0#diff-a9ba43156900f4d5d3778408aa046939aa2b69d125cb025467141eb0c960d943R50 (Thanks @apupier )