### PR TITLE
feat: switch to using Goldmark

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -9,10 +9,13 @@ enableRobotsTXT = true
 timeout = 300000
 
 [markup]
-defaultMarkdownHandler = "blackfriday"
-    [markup.blackfriday]
-        nofollowLinks = true
-        noreferrerLinks = true
+defaultMarkdownHandler = "goldmark"
+    [markup.goldmark]
+        autoHeadingIDType = "blackfriday"
+    [markup.goldmark.renderer]
+      unsafe = true
+    [markup.highlight]
+      noClasses = false
 
 [params]
     socialProfiles = ["https://twitter.com/ApacheCamel"]

--- a/content/security/CVE-2015-5344.md
+++ b/content/security/CVE-2015-5344.md
@@ -16,5 +16,4 @@ fixed: 2.15.5, 2.16.1 and newer
 
 The JIRA ticket: https://issues.apache.org/jira/browse/CAMEL-9297 refers to the various commits that resovoled the issue, and have more details.
 
-A related xstream de-serialization vulnerability was recently reported for Apache ActiveMQ: http://activemq.apache.org/security-advisories.data/CVE-2015-5254-announcement.txt?version=1&modificationDate=1449589734000&api=v2
-
+A related xstream de-serialization vulnerability was recently reported for Apache ActiveMQ: http://activemq.apache.org/security-advisories.data/CVE-2015-5254-announcement.txt

--- a/layouts/_default/_markup/render-link.html
+++ b/layouts/_default/_markup/render-link.html
@@ -1,0 +1,1 @@
+<a href="{{ .Destination | safeURL }}"{{ with .Title}} title="{{ . }}"{{ end }}{{ if strings.HasPrefix .Destination "http" }} rel="noopener nofollow noreferrer"{{ end }}>{{ .Text | safeHTML }}</a>


### PR DESCRIPTION
Hugo deprecated Blackfriday Markdown renderer in favor of Goldmark which is the new default. A warning that Blackfriday will be removed in a future version is displayed when rendering the pages. To achieve the same functionality as we had with Blackfriday, as the `rel` attribute for links is not configurable, we need to add `render-link.html` partial.
Other changes include enabling inline HTML
(`markup.goldmark.renderer.unsafe=true`) and disabling inline CSS for syntax higlighting. We did not allow inline CSS on the production site, but in previews are not able to set HTTP headers, so the Content Security Policy header can't be set to disable inline CSS. We can set the option `markup.higlight.noClasses=false` that the inline CSS is not added to the `<code>` blocks and the styling is performed via `higlight.js`. This helps the preview to render syntax higlighted code blocks as they would be rendered on the production site.