### PR TITLE
Remove newline after the link

### DIFF
--- a/layouts/_default/_markup/render-link.html
+++ b/layouts/_default/_markup/render-link.html
@@ -1,1 +1,2 @@
 <a href="{{ .Destination | safeURL }}"{{ with .Title}} title="{{ . }}"{{ end }}{{ if strings.HasPrefix .Destination "http" }} rel="noopener nofollow noreferrer"{{ end }}>{{ .Text | safeHTML }}</a>
+{{- /**/ -}}


### PR DESCRIPTION
We need to add custom comment to remove the newline at the end of the file in the `render-link.html` so that there is no newline after the rendered link, leading to an additional whitespace before the next character. Most commonly this results in a " ." instead of "." following the link.