### PR TITLE
Fix security list year table row heading

### DIFF
--- a/layouts/security/list.html
+++ b/layouts/security/list.html
@@ -19,28 +19,40 @@
                 </thead>
                 <tbody>
               {{ $pages := .Pages.GroupByDate "2006" "desc" }}
-              {{ $latest_year := (index $pages 0).Key }}
-              {{ range seq (now.Format "2006") (add (int $latest_year) 1) }}
+              {{ $earliest_year := (index (.Pages.GroupByDate "2006" "asc") 0).Key }}
+              {{ range $year := seq (now.Format "2006") $earliest_year }}
+                {{ $has_any := false }}
+                {{ range $pages }}
+                  {{ if eq $year (int .Key) }}
+                    {{ $has_any = true}}
+                    {{ break }}
+                  {{ end }}
+                {{ end }}
+                {{ if $has_any }}
+                  {{ range $pages }}
+                    {{ if eq $year (int .Key) }}
+                      <tr>
+                        <th colspan="5" scope="row"><strong>{{ .Key }}</strong></th>
+                      </tr>
+                      {{ range .Pages }}
+                        <tr>
+                          <td><a href="{{ .RelPermalink }}">{{ .Params.cve }}</a></td>
+                          <td>{{ .Params.affected }}</td>
+                          <td>{{ .Params.fixed }}</td>
+                          <td>{{ .Params.severity }}</td>
+                          <td>{{ .Params.summary }}</td>
+                        </tr>
+                      {{ end }}
+                    {{ end }}
+                  {{ end }}
+                {{ else }}
                   <tr>
-                    <th colspan="5" scope="row"><strong>{{ . }}</strong></th>
+                    <th colspan="5" scope="row"><strong>{{ $year }}</strong></th>
                   </tr>
                   <tr>
                     <td colspan="5"><em>No issues reported</em></td>
                   </tr>
-              {{ end }}
-              {{ range $pages }}
-                  <tr>
-                    <th colspan="5" scope="row"><strong>{{ .Key }}</strong></th>
-                  </tr>
-                  {{ range .Pages }}
-                  <tr>
-                    <td><a href="{{ .RelPermalink }}">{{ .Params.cve }}</a></td>
-                    <td>{{ .Params.affected }}</td>
-                    <td>{{ .Params.fixed }}</td>
-                    <td>{{ .Params.severity }}</td>
-                    <td>{{ .Params.summary }}</td>
-                  </tr>
-                  {{ end }}
+                {{ end }}
               {{ end }}
                 </tbody>
               </table>


### PR DESCRIPTION
The year list started showing 2023, this was because a security issue was reported for the year 2022 and previously there weren't any. The sequence to generate the year in the list was generated from the current year to the last reported issue's year plus one. This _kind of_ worked when there was no reports in the current year.

Now the list of years is generated from the current year to the earliest year with a reported issue, and the security pages are searched to determine if there are any issues for that year. From that information it can be determined if the "No issues reported" should be shown or not.