### PR TITLE
Remove 2.x legacy releases and feature milestone/release candidate releases

### DIFF
--- a/content/releases/release-3.0.0-RC1.md
+++ b/content/releases/release-3.0.0-RC1.md
@@ -9,6 +9,7 @@ apiBreaking: ""
 knownIssues: ""
 jiraVersionId: 12345723
 category: camel
+kind: RC
 jdk: [8,11]
 ---
 

--- a/content/releases/release-3.0.0-RC1.md
+++ b/content/releases/release-3.0.0-RC1.md
@@ -1,9 +1,8 @@
 ---
 date: 2019-09-01
-draft: false 
+draft: false
 type: release-note
 version: 3.0.0-RC1
-rc: true
 title: "Release 3.0.0-RC1"
 preview: "First release candidate for 3.0.0"
 apiBreaking: ""

--- a/content/releases/release-3.0.0-RC2.md
+++ b/content/releases/release-3.0.0-RC2.md
@@ -1,9 +1,8 @@
 ---
 date: 2019-10-06
-draft: false 
+draft: false
 type: release-note
 version: 3.0.0-RC2
-rc: true
 title: "Release 3.0.0-RC2"
 preview: "Second release candidate for 3.0.0"
 apiBreaking: ""

--- a/content/releases/release-3.0.0-RC2.md
+++ b/content/releases/release-3.0.0-RC2.md
@@ -9,6 +9,7 @@ apiBreaking: ""
 knownIssues: ""
 jiraVersionId: 12345998
 category: camel
+kind: RC
 jdk: [8,11]
 ---
 

--- a/content/releases/release-3.0.0-RC3.md
+++ b/content/releases/release-3.0.0-RC3.md
@@ -9,6 +9,7 @@ apiBreaking: ""
 knownIssues: ""
 jiraVersionId: 12346354
 category: camel
+kind: RC
 jdk: [8,11]
 ---
 

--- a/content/releases/release-3.0.0-RC3.md
+++ b/content/releases/release-3.0.0-RC3.md
@@ -1,9 +1,8 @@
 ---
 date: 2019-10-25
-draft: false 
+draft: false
 type: release-note
 version: 3.0.0-RC3
-rc: true
 title: "Release 3.0.0-RC3"
 preview: "Third release candidate for 3.0.0"
 apiBreaking: ""

--- a/content/releases/release-4.0.0-M1.md
+++ b/content/releases/release-4.0.0-M1.md
@@ -9,6 +9,7 @@ apiBreaking: ""
 knownIssues: ""
 jiraVersionId: 12352867
 category: camel
+kind: RC
 jdk: [17]
 ---
 

--- a/content/releases/release-4.0.0-M1.md
+++ b/content/releases/release-4.0.0-M1.md
@@ -1,9 +1,8 @@
 ---
 date: 2023-02-04
-draft: false 
+draft: false
 type: release-note
 version: 4.0.0-M1
-rc: true
 title: "Release 4.0.0-M1"
 preview: "First milestone for 4.0.0"
 apiBreaking: ""

--- a/data/release-categories.yaml
+++ b/data/release-categories.yaml
@@ -30,8 +30,8 @@ camel:
       filter: 'lts'
     - name: 'latest'
       filter: 'latest'
-    - name: 'legacy'
-      filter: 'legacy'
+    - name: 'RC'
+      filter: 'RC'
   downloads:
     - name: 'Sources'
       path_format: 'camel/apache-camel/{version}/apache-camel-{version}-src.zip'

--- a/layouts/partials/releases/downloads.html
+++ b/layouts/partials/releases/downloads.html
@@ -9,7 +9,7 @@
 {{ $versions := slice }}
 
 {{/* all versions from a category (camel, camel-k...) */}}
-{{ $category_releases := where (where (where .Pages "Section" "releases") ".Params.rc" "ne" "true") ".Params.category" $.Category.id }}
+{{ $category_releases := where (where .Pages "Section" "releases") ".Params.category" $.Category.id }}
 
 {{/* are we featuring a current versions or an archived ones */}}
 {{ $is_current_versions := false }}

--- a/layouts/partials/releases/version_sort.html
+++ b/layouts/partials/releases/version_sort.html
@@ -6,8 +6,20 @@
     {{ $version := .Params.version }}
     {{/* version as number, e.g. 1.2.3 -> 100020003 */}}
     {{ $version_num := 0 }}
-    {{ range $version_part := split $version "." }}
-        {{ $version_num = add (mul $version_num 1000) (int $version_part) }}
+    {{ range split $version "." }}
+        {{ if strings.ContainsAny . "-RCM" }}
+            {{ range split . "-" }}
+                {{ range split . "M" }}
+                    {{ range split . "RC" }}
+                        {{ if . }}
+                            {{ $version_num = add (mul $version_num 1000) (int .) }}
+                        {{ end }}
+                    {{ end }}
+                {{ end }}
+            {{ end }}
+        {{ else }}
+            {{ $version_num = add (mul $version_num 1000000) (mul (int .) 1000) }}
+        {{ end }}
     {{ end }}
     {{ $versions = $versions | append (dict "version_num" $version_num "page" .) }}
 {{ end }}


### PR DESCRIPTION
chore: support -M and -RC versions

Sorting now supports `-M` and `-RC` versions. This eliminates the need
for `rc: true` filter on versions needed for sorting.

chore: remove `legacy` and add `RC` category

For releases the `RC` category can be used to signify the milestone or
release candidate categories. These will now be featured on the
downloads page. Legacy (Camel 2.x) releases will not be featured on the
downloads page.

Fixes #973 