### PR TITLE
CAMEL-19012: Remove Camel v2 documentation

### DIFF
--- a/antora-playbook-snippets/antora-playbook.yml
+++ b/antora-playbook-snippets/antora-playbook.yml
@@ -28,14 +28,6 @@ content:
         # main components doc
         - docs/components
 
-    - url: https://github.com/apache/camel.git
-      branches: camel-2.x
-      start_paths:
-        # main components doc
-        - docs/components
-        # languages
-        - camel-core/src/main/docs
-
 # sub-projects
     - url: https://github.com/apache/camel-k.git
       # Let's keep latest active development + LTS active versions only


### PR DESCRIPTION
Fixes https://issues.apache.org/jira/browse/CAMEL-19012

## Motivation

Camel 2 is EOL a long time and should be removed to speed up a bit the website build

## Modifications:

* Removes Camel v2 documentation