### PR TITLE
chore(docs): remove Kamelet 4.4.x

### DIFF
--- a/antora-playbook-snippets/antora-playbook.yml
+++ b/antora-playbook-snippets/antora-playbook.yml
@@ -35,7 +35,6 @@ content:
         - release-2.6.x
         - release-2.5.x
         - release-2.4.x
-        - release-2.3.x
       start_path: docs
 
     - url: https://github.com/apache/camel-k-runtime.git
@@ -49,7 +48,6 @@ content:
         - main
         - 4.10.x
         - 4.8.x
-        - 4.4.x
       start_path: docs
 
     - url: https://github.com/apache/camel-quarkus.git


### PR DESCRIPTION
It should be no longer required now with 4.8 and 4.10 LTS. It has references to camel k which we want to remove to simplify the website management.