### PR TITLE
Use modern www.cve.org link instead of old cve.mitre.org

### DIFF
--- a/layouts/security-advisory/single.html
+++ b/layouts/security-advisory/single.html
@@ -26,7 +26,7 @@
             <h3>References</h3>
             <dl>
               <dt>PGP signed advisory data: <a href="{{ .Params.cve }}.txt.asc">{{ .Params.cve }}.txt.asc</a></dt>
-              <dt>Mitre CVE Entry: <a href="https://cve.mitre.org/cgi-bin/cvename.cgi?name={{ .Params.cve }}">https://cve.mitre.org/cgi-bin/cvename.cgi?name={{ .Params.cve }}</a></dt>
+              <dt>Mitre CVE Entry: <a href="https://www.cve.org/CVERecord?id={{ .Params.cve }}">https://www.cve.org/CVERecord?id={{ .Params.cve }}</a></dt>
             </dl>
 
         </article>


### PR DESCRIPTION
See the migration note at https://cve.mitre.org/