### PR TITLE
fix:Overlapping UI on the Blog Page

### DIFF
--- a/antora-ui-camel/src/css/blog.css
+++ b/antora-ui-camel/src/css/blog.css
@@ -24,6 +24,8 @@
   list-style: none;
   padding: 0;
   margin-top: 1rem;
+  max-height: 990px;
+  overflow-y: auto;
   display: inline-block;
 }
 


### PR DESCRIPTION
Resolved the overlapping UI issue on the Blog Page by setting a max-height and enabling overflow-y: auto

also see the view of fixed issue..
![Screenshot 2025-03-19 142415](https://github.com/user-attachments/assets/e5cf84a7-4b5d-4430-8cb0-bc4326c686c2)
