### PR TITLE
UI | Fix for Unwanted Underscores Bug

### DIFF
--- a/content/docs/_index.md
+++ b/content/docs/_index.md
@@ -193,7 +193,7 @@ when you need to quickly build a prototype with Camel.
 
 ## Kamelets
 
-Apache Camel now leverages a catalog of connectors called "Kamelets" (_Kamel_ route snipp_ets_) that allow creating sources or sinks towards external systems via a
+Apache Camel now leverages a catalog of connectors called "Kamelets" (_Kamel_ route snipp-_ets_) that allow creating sources or sinks towards external systems via a
 simplified interface, hiding all the low level details about how those connections are implemented.
 
 <p>


### PR DESCRIPTION
### Issue Description
Currently, after the [`docs`](https://camel.apache.org/docs/) page is rendered, under the `Kamelets` description, the phrase, "Kamel route snippets" is coming as "_Kamel_ route snipp_ets_" which was expected to come without the underscores around "ets" and instead, it was probably expected to be just italicised, like the word "Kamel", to highlight that to form the name "Kamelets", we're picking the "Kamel" and the "ets" from that phrase.
<img width="1322" alt="image" src="https://github.com/user-attachments/assets/0d994cf4-1860-4422-baa6-86a6f44c684b" />
___

### Resolution
I can fix this in two ways (in both ways, "ets" will be italicised):
1. Adding a hyphen between "snipp" and italicized "ets" to properly highlight "ets".
2. Just removing the space from between "snipp" and "ets" and still keeping "ets" as italicized.

_**Please note that current change in this PR follows the first resolution, if the second resolution is preferred, let me know, I can make that change.**_
___
_Thank you!_
___