### PR TITLE
feat: quick lookup for kamlet catalog

### DIFF
--- a/antora-ui-camel/public/_/partials/nav-menu.hbs
+++ b/antora-ui-camel/public/_/partials/nav-menu.hbs
@@ -1,6 +1,6 @@
 {{#with page.navigation}}
 <div class="nav-panel-menu is-active">
-  {{#if (eq @root.page.component.name 'components')}}
+  {{#if (or (eq @root.page.component.name 'components') (eq @root.page.component.name 'camel-kamelets'))}}
   <input class="search" placeholder="Quick lookup">
   {{/if}}
   <nav class="nav-menu" data-panel="menu" aria-label="Topics">

--- a/antora-ui-camel/src/partials/nav-menu.hbs
+++ b/antora-ui-camel/src/partials/nav-menu.hbs
@@ -1,6 +1,6 @@
 {{#with page.navigation}}
 <div class="nav-panel-menu is-active">
-  {{#if (eq @root.page.component.name 'components')}}
+  {{#if (or (eq @root.page.component.name 'components') (eq @root.page.component.name 'camel-kamelets'))}}
   <input class="search" placeholder="Quick lookup">
   {{/if}}
   <nav class="nav-menu" data-panel="menu" aria-label="Topics">


### PR DESCRIPTION
Adds the quick lookup for kamlet catalog, reusing the same logic that the component reference already uses.

Fixes #1354