### PR TITLE
Improve documentation navigation

### DIFF
--- a/antora-ui-camel/src/css/nav.css
+++ b/antora-ui-camel/src/css/nav.css
@@ -128,16 +128,46 @@ html.is-clipped--nav {
   padding: 0;
 }
 
-.nav-panel-menu input.search:valid ~ .nav-menu .filtered {
-  display: none;
-}
-
 .nav-panel-menu input.search:valid ~ .nav-menu button {
   display: none;
 }
 
-.nav-panel-menu input.search:valid ~ .nav-menu a.nav-link:not(.filtered) {
-  line-height: 1.5rem;
+/* 1st navigation level */
+.nav-item[data-depth="1"] > a.nav-link,
+.nav-item[data-depth="1"] > .nav-text {
+  line-height: 1.8rem;
+  font-weight: var(--body-font-weight-bold);
+  color: var(--nav-heading-font-color);
+}
+
+/* 2nd navigation level */
+.nav-item[data-depth="1"] > .nav-list a {
+  padding-left: 10px;
+}
+
+.nav-item[data-depth="2"] > a.nav-link {
+  line-height: 1.3rem;
+}
+
+.nav-item[data-depth="2"] > .nav-item-toggle {
+  margin-left: calc(var(--nav-line-height) * -0.5em);
+}
+
+.nav-item[data-depth="2"] > .filtered {
+  display: none;
+}
+
+/* 3rd navigation level */
+.nav-item[data-depth="2"] > .nav-list a {
+  padding-left: 20px
+}
+
+.nav-item[data-depth="3"] > a.nav-link {
+  line-height: 1.2rem;
+}
+
+.nav-item[data-depth="3"] > .filtered {
+  display: none;
 }
 
 .nav-menu {
@@ -227,7 +257,7 @@ html.is-clipped--nav {
   position: absolute;
   height: calc(var(--nav-line-height) * 1em);
   width: calc(var(--nav-line-height) * 1em);
-  margin-top: -0.05em;
+  margin-top: 0.3em;
   margin-left: calc(var(--nav-line-height) * -1em);
 }
 


### PR DESCRIPTION
- Improve reference doc navigation with css styles
- Proper sublist indent
- Always highlight top level categories (components, dataformats, languages, eips)
- Display top level categories in filtered search results

## Top Level Categories

One of the biggest issues in reference doc navigation was that different top level categories have not been highlighted in the navigation. As seen in this example where `Data Formats` is just like an arbitrary nav item.

<img width="614" height="565" alt="reference_nav_sublist" src="https://github.com/user-attachments/assets/27458be5-4d5b-45af-8885-e83c2ad4f0fd" />

The update highlights the categories in the navigation so users can see that a new category begins in the navigation:

<img width="617" height="600" alt="reference_nav_sublist_update" src="https://github.com/user-attachments/assets/2ed46aaa-2f77-40cc-a164-a59c22968f02" />

## Sublists

Also, sublists of Camel components are displayed on the same navigation level as seen in this example about `AI` components (chatscript, kserve, ...):

<img width="612" height="579" alt="reference_nav" src="https://github.com/user-attachments/assets/6d7a89c0-127e-4a15-a6c8-a64c18f22235" />

This has been improved with proper indentation of sublists:

<img width="613" height="593" alt="reference_nav_update" src="https://github.com/user-attachments/assets/a9b81652-3486-41e0-8511-e20b356775e8" />

## Search results

When searching the navigation mixed the different categories, sometimes producing duplicates when component and dataformat results match.

<img width="619" height="593" alt="search_filter" src="https://github.com/user-attachments/assets/f5444a18-c6c6-4d50-ba74-23350abeff14" />

Now top level categories are also displayed in the search results for better separation

<img width="626" height="654" alt="search_filter_update" src="https://github.com/user-attachments/assets/43df428f-2d51-4d48-bc1e-2ba12064f2f8" />

## User Manual

The user manual navigation also benefits from the updates:

<img width="623" height="507" alt="user_manual" src="https://github.com/user-attachments/assets/d2271203-f4b5-40d4-9595-67c85cba4be1" />

<img width="615" height="510" alt="user_manual_update" src="https://github.com/user-attachments/assets/197d4740-3661-4d4e-9235-d5adf53336c4" />

## User Manual (expanded)

<img width="622" height="539" alt="user_manual_expanded" src="https://github.com/user-attachments/assets/c188eb01-15ca-49d6-b8ec-10a3b94682fc" />

<img width="618" height="593" alt="user_manual_expanded_update" src="https://github.com/user-attachments/assets/22b3eb39-51a7-4e41-83e7-394331542e9a" />

## Sublist naming

As a follow-up task I suggest to remove the duplication in sublist component names, like seen in AWS* components (skip the AWS prefix in the sublist).

<img width="611" height="560" alt="aws_sublist_naming" src="https://github.com/user-attachments/assets/10a83fca-40d3-4ac5-9214-5cb427f4c5e3" />
