### PR TITLE
fix: Overlapping UI - blog tags

### DIFF
--- a/antora-ui-camel/src/css/blog.css
+++ b/antora-ui-camel/src/css/blog.css
@@ -24,9 +24,9 @@
   list-style: none;
   padding: 0;
   margin-top: 1rem;
-  max-height: 990px;
+  display: inline-block;    
   overflow-y: auto;
-  display: inline-block;
+  max-height: 740px;
 }
 
 article.blog:first-child {


### PR DESCRIPTION
Closes #1176 

On firefox:
<img width="1024" height="521" alt="Firefox before fix" src="https://github.com/user-attachments/assets/83994a16-3900-4338-94e7-e5be11ec768e" />Before fix</img>

***

<img width="1024" height="521" alt="Firefox after fix" src="https://github.com/user-attachments/assets/bd0ab341-1dfb-4f7b-b835-1dc3d01f3ad4" >After fix</img>

On chrome:
<img width="1024" height="521" alt="Chrome before fix" src="https://github.com/user-attachments/assets/9278db2a-788f-4a86-b1fa-e4c357427d47"/>Before fix</img>

***

<img width="1024" height="521" alt="Chrome after fix" src="https://github.com/user-attachments/assets/a2c02efc-19ea-4caf-929b-ba386d414ae2" />After fix</img>
