### PR TITLE
ci: Set commit number as last .asf.yml modification in camel-website-pub

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,7 +17,7 @@
  * under the License.
  */
 def NODE = 'git-websites'
-def STOP_SQUASH_AT = 'edd7b1147123f44b62fdb27be5d993bbdeacbc73'
+def STOP_SQUASH_AT = '3381ad5637eb525502df319e84b7208e8f2a977b'
 
 pipeline {
     agent {


### PR DESCRIPTION
PR #1410

This will force the camel-website-pub deploy step in jenkins to start squashing after the last change on the .ash.yml file: https://github.com/apache/camel-website-pub/commit/3381ad5637eb525502df319e84b7208e8f2a977b.

Force some reason there has been some change on the .asf.yml file since the old commit https://github.com/apache/camel-website-pub/commit/edd7b1147123f44b62fdb27be5d993bbdeacbc73.

Let's cross fingers :crossed_fingers: 