### PR TITLE
chore: upgrade node version to v18 in maven pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-    <node.version>v16.13.2</node.version>
+    <node.version>v18.12.0</node.version>
     <yarn.version>v1.22.17</yarn.version>
 
     <theme.basedir>antora-ui-camel</theme.basedir>


### PR DESCRIPTION
Fix maven build error:
```
[INFO] --- frontend:1.13.4:yarn (theme install) @ camel-website ---
[INFO] Running 'yarn install' in /home/gfournie/work/sources/gansheer/camel-website/antora-ui-camel
[INFO] Usage Error: This tool requires a Node version compatible with >=18.12.0 (got 16.13.2). Upgrade Node, or set `YARN_IGNORE_NODE=1` in your environment.
```