### PR TITLE
Revert "chore(deps): bump copy-props from 2.0.4 to 2.0.5"

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -6099,12 +6099,12 @@ __metadata:
   linkType: hard
 
 "copy-props@npm:^2.0.1":
-  version: 2.0.5
-  resolution: "copy-props@npm:2.0.5"
+  version: 2.0.4
+  resolution: "copy-props@npm:2.0.4"
   dependencies:
-    each-props: "npm:^1.3.2"
-    is-plain-object: "npm:^5.0.0"
-  checksum: 10/eba7486dc0ba0b5bbb0e98805849a60e0a0c14c362b1baece69d86c8460aabe03d4f271d34ac41d8f5f9b3302703ca75bab34227ff6fbfedc47646f47288aaa0
+    each-props: "npm:^1.3.0"
+    is-plain-object: "npm:^2.0.1"
+  checksum: 10/8187deba82c99a49fdbf50ebf6c202383d7bcea6c356e912b6d41bd6e2a8cb57c53209d01e6f8eeb1e6f93cf87f4a8c0bde9f3d97bcce310d86a8bae747b7526
   languageName: node
   linkType: hard
 
@@ -7499,7 +7499,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"each-props@npm:^1.3.2":
+"each-props@npm:^1.3.0":
   version: 1.3.2
   resolution: "each-props@npm:1.3.2"
   dependencies:


### PR DESCRIPTION
Reverts apache/camel-website#1435