### PR TITLE
chore(deps): bump js-yaml versions

### DIFF
--- a/antora-ui-camel/package.json
+++ b/antora-ui-camel/package.json
@@ -51,7 +51,7 @@
     "gulp-terser": "^1.2.0",
     "handlebars": "^4.7.8",
     "highlight.js": "~11",
-    "js-yaml": "~3.13",
+    "js-yaml": "~3.14.2",
     "merge-stream": "~2.0",
     "plugin-error": "~1.0",
     "postcss-calc": "~7.0",

--- a/antora-ui-camel/yarn.lock
+++ b/antora-ui-camel/yarn.lock
@@ -813,7 +813,7 @@ __metadata:
     gulp-terser: "npm:^1.2.0"
     handlebars: "npm:^4.7.8"
     highlight.js: "npm:~11"
-    js-yaml: "npm:~3.13"
+    js-yaml: "npm:~3.14.2"
     merge-stream: "npm:~2.0"
     plugin-error: "npm:~1.0"
     postcss-calc: "npm:~7.0"
@@ -6502,15 +6502,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-yaml@npm:^3.13.0, js-yaml@npm:^3.13.1, js-yaml@npm:^3.9.0, js-yaml@npm:~3.13":
-  version: 3.13.1
-  resolution: "js-yaml@npm:3.13.1"
+"js-yaml@npm:^3.13.0, js-yaml@npm:^3.13.1, js-yaml@npm:^3.9.0, js-yaml@npm:~3.14.2":
+  version: 3.14.2
+  resolution: "js-yaml@npm:3.14.2"
   dependencies:
     argparse: "npm:^1.0.7"
     esprima: "npm:^4.0.0"
   bin:
     js-yaml: bin/js-yaml.js
-  checksum: 10/cec89175b065743875fce53e63adc8b89aded77e18d00e54ff80c57ab730f22ccfddaf2fe3e6adab1d6dff59a3d55dd9ae6fc711d46335b7e94c32d3583a5627
+  checksum: 10/172e0b6007b0bf0fc8d2469c94424f7dd765c64a047d2b790831fecef2204a4054eabf4d911eb73ab8c9a3256ab8ba1ee8d655b789bf24bf059c772acc2075a1
   languageName: node
   linkType: hard
 

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "gulp-inject": "^5.0.2",
     "html-validate": "^8.9.1",
     "hugo-extended": "^0.121.2",
-    "js-yaml": "~4.1.0",
+    "js-yaml": "~4.1.1",
     "jsdom": "^27.1.0",
     "netlify-cli": "17.26.3",
     "node-html-parser": "^7.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3630,7 +3630,7 @@ __metadata:
     gulp-terser: "npm:^1.2.0"
     handlebars: "npm:^4.7.8"
     highlight.js: "npm:~11"
-    js-yaml: "npm:~3.13"
+    js-yaml: "npm:~3.14.2"
     merge-stream: "npm:~2.0"
     plugin-error: "npm:~1.0"
     postcss-calc: "npm:~7.0"
@@ -3709,7 +3709,7 @@ __metadata:
     gulp-inject: "npm:^5.0.2"
     html-validate: "npm:^8.9.1"
     hugo-extended: "npm:^0.121.2"
-    js-yaml: "npm:~4.1.0"
+    js-yaml: "npm:~4.1.1"
     jsdom: "npm:^27.1.0"
     netlify-cli: "npm:17.26.3"
     node-html-parser: "npm:^7.0.1"
@@ -12949,7 +12949,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-yaml@npm:4.1.0, js-yaml@npm:^4.0.0, js-yaml@npm:^4.1.0, js-yaml@npm:~4.1, js-yaml@npm:~4.1.0":
+"js-yaml@npm:4.1.0":
   version: 4.1.0
   resolution: "js-yaml@npm:4.1.0"
   dependencies:
@@ -12960,27 +12960,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-yaml@npm:^3.13.0, js-yaml@npm:^3.13.1":
-  version: 3.14.1
-  resolution: "js-yaml@npm:3.14.1"
+"js-yaml@npm:^3.13.0, js-yaml@npm:^3.13.1, js-yaml@npm:~3.14.2":
+  version: 3.14.2
+  resolution: "js-yaml@npm:3.14.2"
   dependencies:
     argparse: "npm:^1.0.7"
     esprima: "npm:^4.0.0"
   bin:
     js-yaml: bin/js-yaml.js
-  checksum: 10/9e22d80b4d0105b9899135365f746d47466ed53ef4223c529b3c0f7a39907743fdbd3c4379f94f1106f02755b5e90b2faaf84801a891135544e1ea475d1a1379
+  checksum: 10/172e0b6007b0bf0fc8d2469c94424f7dd765c64a047d2b790831fecef2204a4054eabf4d911eb73ab8c9a3256ab8ba1ee8d655b789bf24bf059c772acc2075a1
   languageName: node
   linkType: hard
 
-"js-yaml@npm:~3.13":
-  version: 3.13.1
-  resolution: "js-yaml@npm:3.13.1"
+"js-yaml@npm:^4.0.0, js-yaml@npm:^4.1.0, js-yaml@npm:~4.1, js-yaml@npm:~4.1.1":
+  version: 4.1.1
+  resolution: "js-yaml@npm:4.1.1"
   dependencies:
-    argparse: "npm:^1.0.7"
-    esprima: "npm:^4.0.0"
+    argparse: "npm:^2.0.1"
   bin:
     js-yaml: bin/js-yaml.js
-  checksum: 10/cec89175b065743875fce53e63adc8b89aded77e18d00e54ff80c57ab730f22ccfddaf2fe3e6adab1d6dff59a3d55dd9ae6fc711d46335b7e94c32d3583a5627
+  checksum: 10/a52d0519f0f4ef5b4adc1cde466cb54c50d56e2b4a983b9d5c9c0f2f99462047007a6274d7e95617a21d3c91fde3ee6115536ed70991cd645ba8521058b78f77
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fix versions for https://github.com/advisories/GHSA-mh29-5h37-fv8m

Let's see if it breaks anything.