### PR TITLE
Fix search box overflow by limiting input to 200 chars and increase result cap (#1459)

### DIFF
--- a/antora-ui-camel/src/css/header.css
+++ b/antora-ui-camel/src/css/header.css
@@ -380,6 +380,10 @@ html:not([data-scroll='0']) .navbar {
 .result_summary {
   color: var(--color-jet-50);
   padding-top: 0.3rem;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 3;
+  overflow: hidden;
 }
 
 #search_results div.footer-search {


### PR DESCRIPTION
This PR resolves issue #1459 by limiting search result snippet text.

Changes:
- Each search result description truncated to 200 characters max
- CSS line-clamp limits visible lines to 3 for cleaner display  
- Increased search result cap from 5 → 10 for better visibility

Verification:
✔ Result snippets no longer overflow
✔ Dropdown shows more compact results
✔ 10 results visible
✔ No console or UI errors

<img width="1719" height="1069" alt="image" src="https://github.com/user-attachments/assets/19548d68-632d-48dd-be1c-ec54c4b72413" />


Closes: #1459