### PR TITLE
Redirect rule, when the header Accept: text/markdown is set, than red…

### DIFF
--- a/static/.htaccess
+++ b/static/.htaccess
@@ -1,6 +1,12 @@
 # Redirect security advisories to new location
 RewriteEngine on
 RewriteBase "/"
+
+# Content negotiation for LLM-friendly Markdown
+# When Accept header requests text/markdown, redirect .html to .md
+RewriteCond %{HTTP_ACCEPT} text/markdown [NC]
+RewriteRule ^(.+)\.html$ /$1.md [R=303,L]
+
 RewriteRule "^security-advisories.data/(.+)$" "security/$1" [R=permanent,L]
 
 # Customize what Apache returns to the client in case of an error.


### PR DESCRIPTION
…irect to the .md page

Add Accept: `text/markdown` content negotiation for LLM access.

Requests with `Accept: text/markdown` header are redirected (303) to the corresponding .md file.

Example:
```
curl -H "Accept: text/markdown" .../direct-component.html → 303 redirect to direct-component.md
```

For reference:
```
  [NC] - No Case
  - Makes the pattern match case-insensitive
  - So text/markdown, Text/Markdown, TEXT/MARKDOWN all match

  [R=303,L] - Two flags combined:
  - R=303 - Redirect with HTTP status code 303 (See Other)
  - L - Last rule
    - Stop processing further rewrite rules if this one matches
    - Without this, Apache continues checking subsequent rules
```