### PR TITLE
Use internal rewrite on the same host instead of redirect

### DIFF
--- a/static/.htaccess
+++ b/static/.htaccess
@@ -3,9 +3,9 @@ RewriteEngine on
 RewriteBase "/"
 
 # Content negotiation for LLM-friendly Markdown
-# When Accept header requests text/markdown, redirect .html to .md
+# When Accept header requests text/markdown, serve .md instead of .html
 RewriteCond %{HTTP_ACCEPT} text/markdown [NC]
-RewriteRule ^(.+)\.html$ /$1.md [R=303,L]
+RewriteRule ^(.+)\.html$ $1.md [L]
 
 RewriteRule "^security-advisories.data/(.+)$" "security/$1" [R=permanent,L]
 


### PR DESCRIPTION
I noticed that Claude's Fetch tool is not able to download the html. in particular, as far as I understand, the tool Fetch uses the header `Accept: text/markdown` but it does not follow the redirects, therefore, it always get error 303, after some tries another tool is used.

Using internal rewrite we should overcome this issue by providing the .md directly, without the redirect.