### PR TITLE
fix: Admonition style for deprecated component

### DIFF
--- a/antora-ui-camel/src/partials/article.hbs
+++ b/antora-ui-camel/src/partials/article.hbs
@@ -14,6 +14,7 @@ If you typed the URL of this page manually, please double check that you entered
 {{/with}}
 {{#if page.attributes.deprecated}}
 <div class="admonitionblock warning">
+<div class="table-wrapper">
 <table>
 <tr>
 <td class="icon">
@@ -26,6 +27,7 @@ If you typed the URL of this page manually, please double check that you entered
 </td>
 </tr>
 </table>
+</div>
 </div>
 {{/if}}
 {{{page.contents}}}


### PR DESCRIPTION
Let's check if what is done in other pages WARNING works. My guess is that the responsiveTables postprocessor is not applied.

Ref https://github.com/apache/camel-website/issues/1477