### PR TITLE
Normalize severity casing in 2026 CVE advisories

### DIFF
--- a/content/security/CVE-2026-27172.md
+++ b/content/security/CVE-2026-27172.md
@@ -5,7 +5,7 @@ url: /security/CVE-2026-27172.html
 draft: false
 type: security-advisory
 cve: CVE-2026-27172
-severity: High
+severity: HIGH
 summary: "Apache Camel: Unsafe Java deserialization in camel-consul ConsulRegistry allows arbitrary code execution via malicious values read from the Consul KV store"
 description: "The ConsulRegistry in the camel-consul component (class org.apache.camel.component.consul.ConsulRegistry and its inner ConsulRegistryUtils.deserialize method) read Java-serialized values from the Consul KV store and passed them to ObjectInputStream.readObject() without configuring an ObjectInputFilter. An attacker who can write to the Consul KV store backing a Camel ConsulRegistry instance could inject a malicious serialized Java object that is deserialized the next time Camel performs a lookup against that registry, leading to arbitrary code execution in the Camel process. The issue mirrors the class of vulnerability already addressed for other Camel components in CVE-2024-22369, CVE-2024-23114 and CVE-2026-25747, and was overlooked during the original remediation of those CVEs."
 mitigation: "Users are recommended to upgrade to version 4.19.0, which fixes the issue. If users are on the 4.14.x LTS releases stream, then they are suggested to upgrade to 4.14.6. If users are on the 4.18.x releases stream, then they are suggested to upgrade to 4.18.1."

--- a/content/security/CVE-2026-27172.txt.asc
+++ b/content/security/CVE-2026-27172.txt.asc
@@ -1,31 +1,31 @@
 -----BEGIN PGP SIGNED MESSAGE-----
 Hash: SHA512
 
-----
+- ----
 title: "Apache Camel Security Advisory - CVE-2026-27172"
 date: 2026-04-24T09:00:00+02:00
 url: /security/CVE-2026-27172.html
 draft: false
 type: security-advisory
 cve: CVE-2026-27172
-severity: High
+severity: HIGH
 summary: "Apache Camel: Unsafe Java deserialization in camel-consul ConsulRegistry allows arbitrary code execution via malicious values read from the Consul KV store"
 description: "The ConsulRegistry in the camel-consul component (class org.apache.camel.component.consul.ConsulRegistry and its inner ConsulRegistryUtils.deserialize method) read Java-serialized values from the Consul KV store and passed them to ObjectInputStream.readObject() without configuring an ObjectInputFilter. An attacker who can write to the Consul KV store backing a Camel ConsulRegistry instance could inject a malicious serialized Java object that is deserialized the next time Camel performs a lookup against that registry, leading to arbitrary code execution in the Camel process. The issue mirrors the class of vulnerability already addressed for other Camel components in CVE-2024-22369, CVE-2024-23114 and CVE-2026-25747, and was overlooked during the original remediation of those CVEs."
 mitigation: "Users are recommended to upgrade to version 4.19.0, which fixes the issue. If users are on the 4.14.x LTS releases stream, then they are suggested to upgrade to 4.14.6. If users are on the 4.18.x releases stream, then they are suggested to upgrade to 4.18.1."
 credit: "This issue was discovered and fixed by Andrea Cosentino of Apache Software Foundation"
 affected:  "From 3.0.0 before 4.14.6 and from 4.15.0 before 4.18.1"
 fixed: 4.14.6, 4.18.1 and 4.19.0
-----
+- ----
 
 The JIRA ticket: https://issues.apache.org/jira/browse/CAMEL-23029 refers to the commits that resolved the issue and has more details. The vulnerability is of the same class as CVE-2024-22369, CVE-2024-23114 and CVE-2026-25747: a Camel component reads Java-serialized bytes from a backing store and passes them to ObjectInputStream.readObject() without any class allowlist, so an attacker who can influence the bytes in that store can trigger arbitrary code execution via a gadget chain. In camel-consul, the affected path is ConsulRegistry.lookupByName (and transitively lookupByNameAndType, findByTypeWithName and findByType), which reads a Base64-encoded Java-serialized object from the Consul key/value store and deserializes it.
 -----BEGIN PGP SIGNATURE-----
 
-iQEzBAEBCgAdFiEEJ2Y0ButtuvUpHyYV406fOAL/QQAFAmnrYfQACgkQ406fOAL/
-QQDsKwgAqsMrvPWan7CZogcFAl+l+j/4OptR5em9OW694dV9gD4/9ecjVP+jNZRr
-dzN1ARbYkMWx+gxxqBQURdnhKuM5hJ/PdfAXTezdiIYRmVppBa9FnhI3vi4aDMvX
-8YJJD4bzmPU1rYY/hKuE28Dkk/FHhf+PVhGZKXurkLPvBcb3aUDZ06H91r8N5GjH
-bv+yC9XAspJmKZUDQ08GMYDF89EYmXMeP7XpPmM9BxQsCb4IacAJDrkmBAnFdFqR
-iNgxc2Zq88BYjyNLRwLQrRqmWdbeYITNjZ6INEmfl4fGcL3FtbpPmV/AIkh42ozU
-N1R+I9WnbtWiYLQN2nmZNCFlgtASOg==
-=Ep8I
+iQEzBAEBCgAdFiEEJ2Y0ButtuvUpHyYV406fOAL/QQAFAmn69IsACgkQ406fOAL/
+QQAoyQgAqlF++sHrt+R2JpKuWKE9aspgIrDRFXlc4whtTYT99RgkhCojJNK9OX+0
+LtjqL9X+jKd7jvIkVLyrdnZu2f3nINtA4+u536FMqmi94OLSnC4sj83/KY9euDeE
+N1Xbv2HXBSh01MJNHl6h0fYpkbmPmPA8br4slZkPJzcrSQt9Y8Iqc6TQyvlaH9Qb
+1G7BLczet5PXqHiwvfnOskie/LOpmP6NWHQK78L9WCWsZkZrNJCrE8KVGm4ZN2+F
+m2o3y/wcYmkW3zksDD6g4/6HR/p4LbTvbDIJ11b///rk/uDSDPO/u0AZMow1AU8a
+vChysjFIDm2E6A+WubBxbh9CawtyAA==
+=IHRI
 -----END PGP SIGNATURE-----

--- a/content/security/CVE-2026-40453.md
+++ b/content/security/CVE-2026-40453.md
@@ -5,7 +5,7 @@ url: /security/CVE-2026-40453.html
 draft: false
 type: security-advisory
 cve: CVE-2026-40453
-severity: Medium
+severity: MEDIUM
 summary: "Incomplete fix for CVE-2025-27636 in non-HTTP HeaderFilterStrategies (camel-jms, camel-sjms, camel-coap, camel-google-pubsub) allows case-variant header injection"
 description: "The fix for CVE-2025-27636 added setLowerCase(true) to HttpHeaderFilterStrategy so that case-variant header names such as 'CAmelExecCommandExecutable' are filtered out alongside 'CamelExecCommandExecutable'. The same setLowerCase(true) call was not applied to five non-HTTP HeaderFilterStrategy implementations: JmsHeaderFilterStrategy and ClassicJmsHeaderFilterStrategy in camel-jms, SjmsHeaderFilterStrategy in camel-sjms, CoAPHeaderFilterStrategy in camel-coap, and GooglePubsubHeaderFilterStrategy in camel-google-pubsub. Because those strategies use case-sensitive String.startsWith('Camel'/'camel') filtering while the Camel Exchange stores headers in a case-insensitive map, an attacker with JMS (or equivalent) producer access to the broker consumed by a Camel route can inject case-variant Camel internal headers, which are then resolved by downstream components such as camel-exec and camel-file using their canonical casing. This enables remote code execution and arbitrary file write on routes that forward JMS messages to header-driven components."
 mitigation: "Users are recommended to upgrade to version 4.20.0, which fixes the issue. If users are on the 4.14.x LTS releases stream, then they are suggested to upgrade to 4.14.6. If users are on the 4.18.x releases stream, then they are suggested to upgrade to 4.18.2."

--- a/content/security/CVE-2026-40453.txt.asc
+++ b/content/security/CVE-2026-40453.txt.asc
@@ -8,7 +8,7 @@ url: /security/CVE-2026-40453.html
 draft: false
 type: security-advisory
 cve: CVE-2026-40453
-severity: Medium
+severity: MEDIUM
 summary: "Incomplete fix for CVE-2025-27636 in non-HTTP HeaderFilterStrategies (camel-jms, camel-sjms, camel-coap, camel-google-pubsub) allows case-variant header injection"
 description: "The fix for CVE-2025-27636 added setLowerCase(true) to HttpHeaderFilterStrategy so that case-variant header names such as 'CAmelExecCommandExecutable' are filtered out alongside 'CamelExecCommandExecutable'. The same setLowerCase(true) call was not applied to five non-HTTP HeaderFilterStrategy implementations: JmsHeaderFilterStrategy and ClassicJmsHeaderFilterStrategy in camel-jms, SjmsHeaderFilterStrategy in camel-sjms, CoAPHeaderFilterStrategy in camel-coap, and GooglePubsubHeaderFilterStrategy in camel-google-pubsub. Because those strategies use case-sensitive String.startsWith('Camel'/'camel') filtering while the Camel Exchange stores headers in a case-insensitive map, an attacker with JMS (or equivalent) producer access to the broker consumed by a Camel route can inject case-variant Camel internal headers, which are then resolved by downstream components such as camel-exec and camel-file using their canonical casing. This enables remote code execution and arbitrary file write on routes that forward JMS messages to header-driven components."
 mitigation: "Users are recommended to upgrade to version 4.20.0, which fixes the issue. If users are on the 4.14.x LTS releases stream, then they are suggested to upgrade to 4.14.6. If users are on the 4.18.x releases stream, then they are suggested to upgrade to 4.18.2."
@@ -20,12 +20,12 @@ fixed: 4.14.6, 4.18.2 and 4.20.0
 The JIRA ticket: https://issues.apache.org/jira/browse/CAMEL-23313 refers to the various commits that resolved the issue, and have more details. This advisory completes the fix for CVE-2025-27636 by extending setLowerCase(true) to the non-HTTP HeaderFilterStrategy implementations that were not updated in the original 2025-03-09 advisory.
 -----BEGIN PGP SIGNATURE-----
 
-iQEzBAEBCgAdFiEEJ2Y0ButtuvUpHyYV406fOAL/QQAFAmnrXigACgkQ406fOAL/
-QQCWZQf/Rv3yq4EvaPy6Da+ITk9Ef/JWO7B+6/3w2jrC/JMWZM4wO62stVtZUA6V
-W5T2YRBlCueEI+NoO2xE6W+3+qrKvO/1lSehmPvIs200wVDkC1MFA+ecmKXHFWbn
-ILH6H0kqSnoKUem1FqlzmRiMom1AkSZHOKQvGMB+R+U0NbGr7iwc/bBeRJfpEh4Q
-rpokk7YK5p4j2VaiAZQ3hEthbLdynIyR+kLNW3OuEPva67kki4Q0sUF0ndWwpNxx
-0HXXqjqW4ms4LzEaZ434HBnPh7Dm5H85QGL60CidKpq7EkOlL1V4DcJlz8dgunVl
-si5chMIQo+h2hldDuHzahHKAqrr4nQ==
-=t64t
+iQEzBAEBCgAdFiEEJ2Y0ButtuvUpHyYV406fOAL/QQAFAmn69J0ACgkQ406fOAL/
+QQC42AgAn7UbY2Uga0/YBGzYNj0+jKybmG/Oh+D4uwbM9CcvmE9b03s9nigITmYG
+aS7jsixRGPeYjfYSccUacKzJ8GyEw2p3Mx7uTQzggATfXI9+DmwDFg6qPeLzSLtw
+iSSuTdDXHXVVp/u0pHkncMGmv0kzOJC8OiJeZp3+Rvs+JGFjyv4TchqiEXQsZzJU
+O1TCXnbx/QdLRuc2LC6kxpXFryCRqLpZm1pM0XGzwimphau2JlGCRw80jTnUvd2b
+5+0gN/0q7qkibEtxWhYEC2+wl0drep+1wIfTWYxs/wO3T9NMnw3Cvmo7cwXedMVb
+ZX1ApP7NhHkG55t3BtTy9qdGxwPGYg==
+=ApgL
 -----END PGP SIGNATURE-----

--- a/content/security/CVE-2026-40473.md
+++ b/content/security/CVE-2026-40473.md
@@ -5,7 +5,7 @@ url: /security/CVE-2026-40473.html
 draft: false
 type: security-advisory
 cve: CVE-2026-40473
-severity: Medium
+severity: MEDIUM
 summary: "Camel-Mina: Unsafe Deserialization in MinaConverter.toObjectInput() via TCP/UDP"
 description: "The camel-mina component's MinaConverter.toObjectInput(IoBuffer) type converter wraps an IoBuffer in a java.io.ObjectInputStream without applying any ObjectInputFilter or class-loading restrictions. When a Camel route uses camel-mina as a TCP or UDP consumer and requests conversion to ObjectInput (for example via getBody(ObjectInput.class) or @Body ObjectInput), an attacker sending a crafted serialized Java object over the network to the MINA consumer port can trigger arbitrary code execution in the context of the application during readObject()."
 mitigation: "Users are recommended to upgrade to version 4.20.0, which fixes the issue. If users are on the 4.14.x LTS releases stream, then they are suggested to upgrade to 4.14.6. If users are on the 4.18.x releases stream, then they are suggested to upgrade to 4.18.2."

--- a/content/security/CVE-2026-40473.txt.asc
+++ b/content/security/CVE-2026-40473.txt.asc
@@ -8,7 +8,7 @@ url: /security/CVE-2026-40473.html
 draft: false
 type: security-advisory
 cve: CVE-2026-40473
-severity: Medium
+severity: MEDIUM
 summary: "Camel-Mina: Unsafe Deserialization in MinaConverter.toObjectInput() via TCP/UDP"
 description: "The camel-mina component's MinaConverter.toObjectInput(IoBuffer) type converter wraps an IoBuffer in a java.io.ObjectInputStream without applying any ObjectInputFilter or class-loading restrictions. When a Camel route uses camel-mina as a TCP or UDP consumer and requests conversion to ObjectInput (for example via getBody(ObjectInput.class) or @Body ObjectInput), an attacker sending a crafted serialized Java object over the network to the MINA consumer port can trigger arbitrary code execution in the context of the application during readObject()."
 mitigation: "Users are recommended to upgrade to version 4.20.0, which fixes the issue. If users are on the 4.14.x LTS releases stream, then they are suggested to upgrade to 4.14.6. If users are on the 4.18.x releases stream, then they are suggested to upgrade to 4.18.2."
@@ -20,12 +20,12 @@ fixed: 4.14.6, 4.18.2 and 4.20.0
 The JIRA ticket: https://issues.apache.org/jira/browse/CAMEL-23319 refers to the various commits that resolved the issue, and have more details. This follows the same hardening pattern applied in CAMEL-23297 (camel-netty), CAMEL-23321 (camel-jms), and CAMEL-23322 (camel-infinispan), and matches the class of vulnerability previously addressed in CVE-2024-22369, CVE-2024-23114 and CVE-2026-25747.
 -----BEGIN PGP SIGNATURE-----
 
-iQEzBAEBCgAdFiEEJ2Y0ButtuvUpHyYV406fOAL/QQAFAmnrMiQACgkQ406fOAL/
-QQAm5gf9EVk98npgzdZLftTDg5VmMcsaBVOQWgC1BpDcwlcA40G3m5V45CpX+hV7
-BvVicrIcJ2WeLGv8XeuFlZYkkasMVoe2Lc5tKaLCFIogY7fc7+QnEBtbT0RPqmPP
-RAwG35k+Uip0SEDSQWE+FDFZUk9QF7G9cskcCr9nZutYb+/8msXb7QOjwF5EYj39
-P8Hktd4m2uaR1XcbIMe26i90MqMfcGngDjSjwlkZ1gu91E4vLF0an6NSkGZIWq84
-4fLXb/EQwHVFUb1Hmf6OTuIwIgKcVmxiqCskXqGImf9Rpn76Gca2VhOC7n9n3vna
-GdaQT7QWDo1U9pyNAZ0iK02Zsh6muQ==
-=r+2d
+iQEzBAEBCgAdFiEEJ2Y0ButtuvUpHyYV406fOAL/QQAFAmn69J0ACgkQ406fOAL/
+QQDeIwf/aKlnBJWdxnTtd2ttygDGiBQIneXbZhFEmqi9pe0iE9SZyOq6DJR2lJTs
+nS1FqHsl8yzzM6SbH2mbWCHTfEi2pBZVpG7cTdvb4JL1MM0iN6z3Kj01pzCDXi5c
+lK5fRpp6Z3g6sknFjGtExYu0Tyut+oykgEXJwj/D88UhrZChMWGjZFBxmqdGhpgV
+i9GwNecYPlpK4wq2JS8r97mUr1MowrYg0djXrk8qqa/nE3tdCgGpgKeJmWx+llHy
+v39G7sZzkTARvGmPzGOOz1XR5jExWCYX78XJGS0r/7lX8ZgksU/U39DYPgh82a5n
+Szad7cdiciey72RVTRj88NmZoThbZw==
+=Zd6k
 -----END PGP SIGNATURE-----

--- a/content/security/CVE-2026-40858.md
+++ b/content/security/CVE-2026-40858.md
@@ -5,7 +5,7 @@ url: /security/CVE-2026-40858.html
 draft: false
 type: security-advisory
 cve: CVE-2026-40858
-severity: High
+severity: HIGH
 summary: "Camel-Infinispan: Unsafe Deserialization in ProtoStream Remote Aggregation Repository"
 description: "The camel-infinispan component's ProtoStream-based remote aggregation repository deserializes data read from a remote Infinispan cache using java.io.ObjectInputStream without applying any ObjectInputFilter. An attacker who can write to the Infinispan cache used by a Camel application can inject a crafted serialized Java object that, when read during normal aggregation repository operations such as get or recover, results in arbitrary code execution in the context of the application."
 mitigation: "Users are recommended to upgrade to version 4.20.0, which fixes the issue. If users are on the 4.14.x LTS releases stream, then they are suggested to upgrade to 4.14.7. If users are on the 4.18.x releases stream, then they are suggested to upgrade to 4.18.2."

--- a/content/security/CVE-2026-40858.txt.asc
+++ b/content/security/CVE-2026-40858.txt.asc
@@ -8,7 +8,7 @@ url: /security/CVE-2026-40858.html
 draft: false
 type: security-advisory
 cve: CVE-2026-40858
-severity: High
+severity: HIGH
 summary: "Camel-Infinispan: Unsafe Deserialization in ProtoStream Remote Aggregation Repository"
 description: "The camel-infinispan component's ProtoStream-based remote aggregation repository deserializes data read from a remote Infinispan cache using java.io.ObjectInputStream without applying any ObjectInputFilter. An attacker who can write to the Infinispan cache used by a Camel application can inject a crafted serialized Java object that, when read during normal aggregation repository operations such as get or recover, results in arbitrary code execution in the context of the application."
 mitigation: "Users are recommended to upgrade to version 4.20.0, which fixes the issue. If users are on the 4.14.x LTS releases stream, then they are suggested to upgrade to 4.14.7. If users are on the 4.18.x releases stream, then they are suggested to upgrade to 4.18.2."
@@ -20,12 +20,12 @@ fixed: 4.14.7, 4.18.2 and 4.20.0
 The JIRA ticket: https://issues.apache.org/jira/browse/CAMEL-23322 refers to the various commits that resolved the issue, and have more details. This issue follows the same class of vulnerability previously addressed in CVE-2024-22369, CVE-2024-23114 and CVE-2026-25747.
 -----BEGIN PGP SIGNATURE-----
 
-iQEzBAEBCgAdFiEEJ2Y0ButtuvUpHyYV406fOAL/QQAFAmnrKXoACgkQ406fOAL/
-QQBKcwf/VnhED7P26PLmhPBkIIaHeRXsqt1YE+OqXX4qaVc3TpxYrx38qGGQ3zGD
-PZJZree7Wc/OCN14fIzznf2sZ3Ate6ZUU3RRChYz/O3tfYUr96uoLcO4IpDnvGUv
-8W3wOMolA8HIMGDllT0KT8TDxnAd56zMVbGbYYQD+Lk82vVDjvxeZv2L99fzfLIX
-0hU0SmE41/lRzttDL24sDDdrMBRhYG32YKbtfRbyotEeUrSQ8h009byKja6zI0jk
-Kyzkb0lsQtxyMMpxz4Zxt/Gqa0KNYNsDlEpuQ7525chU5H54pCwPqHFvskCunxVl
-UuVV0U5oi1FpT5lYzsg6cdyn59aB7w==
-=GjQi
+iQEzBAEBCgAdFiEEJ2Y0ButtuvUpHyYV406fOAL/QQAFAmn69J0ACgkQ406fOAL/
+QQCzhwf/ee5QEPq6by/sp8MT1y8kKbiCoO5Ce0JJITzw7lxVHTTE2X7EUj+W4IUW
+Em3l18E0gQIj4I+Ld5IyVG3cZs3p2NLvGsIfoWajjurlcozPFnRPQ/NluZzgEhMT
+LXlvcCPIQ3xyLG20vxxh2AU9XxDQAFGwS9jiljS965KX0kEzMdc+qWvZZZLxjYBv
+4xWomZI1oa8mtioGZg76wszhO3hwHrwA136IC5O3YrTUQEFvKPveBpG80jr2PunK
+BLIKSX34J5aDtJMMIVXISjsLW0QnUCk44ihyD/nlSAoPXJFb0Xf45M2bkbViV4w3
+vRW1dWhXd/+eonHhB7Cx0ddleMcQDw==
+=r8AI
 -----END PGP SIGNATURE-----


### PR DESCRIPTION
## Summary
- Four advisories under `content/security/` (`CVE-2026-27172`, `CVE-2026-40453`, `CVE-2026-40473`, `CVE-2026-40858`) used Title Case for the `severity` field (`High` / `Medium`), while every other CVE in the directory uses UPPERCASE (`HIGH` / `MEDIUM` / `LOW` / `CRITICAL`).
- This PR normalizes the severity values to UPPERCASE in both the `.md` front matter and the clearsigned `.txt.asc` bodies so the convention is consistent across all advisories.
- The `.txt.asc` files have been re-signed after the edit, so signature verification continues to pass.

## Test plan
- [ ] `grep -E '^severity:' content/security/CVE-*.md content/security/CVE-*.txt.asc` shows only UPPERCASE values (ignoring the WIP `CVE-2026-42527.md` placeholder of `TODO`).
- [ ] `gpg --verify content/security/CVE-2026-27172.txt.asc` (and the other three modified `.txt.asc` files) reports a good signature.
- [ ] Hugo site build is unaffected (no front-matter consumers depend on case).