### PR TITLE
Add CVE-2026-33453 security advisory for camel-coap header injection

### DIFF
--- a/content/security/CVE-2026-33453.md
+++ b/content/security/CVE-2026-33453.md
@@ -1,0 +1,17 @@
+---
+title: "Apache Camel Security Advisory - CVE-2026-33453"
+date: 2026-05-06T09:00:00+02:00
+url: /security/CVE-2026-33453.html
+draft: false
+type: security-advisory
+cve: CVE-2026-33453
+severity: HIGH
+summary: "Apache Camel: Improperly Controlled Modification of Dynamically-Determined Object Attributes vulnerability in Camel-Coap component."
+description: "Improperly Controlled Modification of Dynamically-Determined Object Attributes vulnerability in Apache Camel Camel-Coap component. Apache Camel's camel-coap component is vulnerable to Camel message header injection, leading to remote code execution when routes forward CoAP requests to header-sensitive producers (e.g. camel-exec). The camel-coap component maps incoming CoAP request URI query parameters directly into Camel Exchange In message headers without applying any HeaderFilterStrategy. Specifically, CamelCoapResource.handleRequest() iterates over OptionSet.getUriQuery() and calls camelExchange.getIn().setHeader(...) for every query parameter. CoAPEndpoint extends DefaultEndpoint rather than DefaultHeaderFilterStrategyEndpoint, and CoAPComponent does not implement HeaderFilterStrategyComponent; the component contains no references to HeaderFilterStrategy at all. As a result, an unauthenticated attacker who can send a single CoAP UDP packet to a Camel route consuming from coap:// can inject arbitrary Camel internal headers (those prefixed with Camel*) into the Exchange. When the route delivers the message to a header-sensitive producer such as camel-exec, camel-sql, camel-bean, camel-file, or template components (camel-freemarker, camel-velocity), the injected headers can alter the producer's behavior. In the case of camel-exec, the CamelExecCommandExecutable and CamelExecCommandArgs headers override the executable and arguments configured on the endpoint, resulting in arbitrary OS command execution under the privileges of the Camel process. The producer's output is written back to the Exchange body and returned in the CoAP response payload by CamelCoapResource, giving the attacker an interactive RCE channel without any need for out-of-band exfiltration. Exploitation prerequisites are minimal: a single unauthenticated UDP datagram to the CoAP port (default 5683). CoAP (RFC 7252) has no built-in authentication, and DTLS is optional and disabled by default. Because the protocol is UDP-based, HTTP-layer WAF/IDS controls do not apply."
+mitigation: "Users are recommended to upgrade to version 4.18.1, which fixes the issue. If users are on the 4.14.x LTS releases stream, then they are suggested to upgrade to 4.14.6. The 4.19.0 development release also contains the fix."
+credit: "This issue was discovered by Hyunwoo Kim (@v4bel)"
+affected: "From 4.14.0 before 4.14.6, from 4.15.0 before 4.18.1."
+fixed: 4.14.6, 4.18.1 and 4.19.0
+---
+
+The JIRA ticket: https://issues.apache.org/jira/browse/CAMEL-23222 refers to the various commits that resolved the issue, and have more details.

--- a/content/security/CVE-2026-33453.txt.asc
+++ b/content/security/CVE-2026-33453.txt.asc
@@ -1,0 +1,31 @@
+-----BEGIN PGP SIGNED MESSAGE-----
+Hash: SHA512
+
+- ---
+title: "Apache Camel Security Advisory - CVE-2026-33453"
+date: 2026-05-06T09:00:00+02:00
+url: /security/CVE-2026-33453.html
+draft: false
+type: security-advisory
+cve: CVE-2026-33453
+severity: HIGH
+summary: "Apache Camel: Improperly Controlled Modification of Dynamically-Determined Object Attributes vulnerability in Camel-Coap component."
+description: "Improperly Controlled Modification of Dynamically-Determined Object Attributes vulnerability in Apache Camel Camel-Coap component. Apache Camel's camel-coap component is vulnerable to Camel message header injection, leading to remote code execution when routes forward CoAP requests to header-sensitive producers (e.g. camel-exec). The camel-coap component maps incoming CoAP request URI query parameters directly into Camel Exchange In message headers without applying any HeaderFilterStrategy. Specifically, CamelCoapResource.handleRequest() iterates over OptionSet.getUriQuery() and calls camelExchange.getIn().setHeader(...) for every query parameter. CoAPEndpoint extends DefaultEndpoint rather than DefaultHeaderFilterStrategyEndpoint, and CoAPComponent does not implement HeaderFilterStrategyComponent; the component contains no references to HeaderFilterStrategy at all. As a result, an unauthenticated attacker who can send a single CoAP UDP packet to a Camel route consuming from coap:// can inject arbitrary Camel internal headers (those prefixed with Camel*) into the Exchange. When the route delivers the message to a header-sensitive producer such as camel-exec, camel-sql, camel-bean, camel-file, or template components (camel-freemarker, camel-velocity), the injected headers can alter the producer's behavior. In the case of camel-exec, the CamelExecCommandExecutable and CamelExecCommandArgs headers override the executable and arguments configured on the endpoint, resulting in arbitrary OS command execution under the privileges of the Camel process. The producer's output is written back to the Exchange body and returned in the CoAP response payload by CamelCoapResource, giving the attacker an interactive RCE channel without any need for out-of-band exfiltration. Exploitation prerequisites are minimal: a single unauthenticated UDP datagram to the CoAP port (default 5683). CoAP (RFC 7252) has no built-in authentication, and DTLS is optional and disabled by default. Because the protocol is UDP-based, HTTP-layer WAF/IDS controls do not apply."
+mitigation: "Users are recommended to upgrade to version 4.18.1, which fixes the issue. If users are on the 4.14.x LTS releases stream, then they are suggested to upgrade to 4.14.6. The 4.19.0 development release also contains the fix."
+credit: "This issue was discovered by Hyunwoo Kim (@v4bel)"
+affected: "From 4.14.0 before 4.14.6, from 4.15.0 before 4.18.1."
+fixed: 4.14.6, 4.18.1 and 4.19.0
+- ---
+
+The JIRA ticket: https://issues.apache.org/jira/browse/CAMEL-23222 refers to the various commits that resolved the issue, and have more details.
+-----BEGIN PGP SIGNATURE-----
+
+iQEzBAEBCgAdFiEEJ2Y0ButtuvUpHyYV406fOAL/QQAFAmn6+WMACgkQ406fOAL/
+QQBAXwf/Ru6CDW6Y15NOXugMuaypmpGVkEfKO1GPq6Bcvx1SluynpwYphJpfrMSJ
+/mnCz/iSgP3ZpfHtZNNXHwIE/X+wHS56arBJPqp2Hn5mrZtKj5OrTpVkZnYEht2M
+mcmJG5OlVr6zJGwoMpO1jvNu7AJZD+iSPWY5xP+SsGDBnF400Z++Fz5EGMlqK91A
+omQ/7+5ROlyGSVe8XsJ6SdwgiAijHnjcz5Enalu5q5k3a8Oe8WHx0mQ4UcvNlUiP
+LqQXWfvRUsbeP9DRKND9TWQFM/uNCDayYYYEWcWCQrf6UrCM4zzlBWMOgfYcrMxh
+4oVJMCuhqyRGcqlrFSZzI2HCIncqwA==
+=wdJp
+-----END PGP SIGNATURE-----


### PR DESCRIPTION
## Summary

- Adds the `CVE-2026-33453` security advisory under `content/security/` (Markdown source + clearsigned `.txt.asc`).
- HIGH-severity advisory for an Improperly Controlled Modification of Dynamically-Determined Object Attributes vulnerability in the `camel-coap` component. Unauthenticated attackers can inject arbitrary `Camel*` internal headers via CoAP URI query parameters and reach RCE when routes forward to header-sensitive producers (e.g. `camel-exec`).
- Tracked in [CAMEL-23222](https://issues.apache.org/jira/browse/CAMEL-23222). Reported by Hyunwoo Kim (@v4bel).

| Field | Value |
| --- | --- |
| Affected | 4.14.0 before 4.14.6, 4.15.0 before 4.18.1 |
| Fixed | 4.14.6, 4.18.1, 4.19.0 |

## Test plan

- [ ] Hugo build renders `/security/CVE-2026-33453.html` without errors
- [ ] `.txt.asc` PGP signature verifies against the release-signing key
- [ ] Front matter fields (`severity`, `affected`, `fixed`, `cve`) match the existing site styling
- [ ] Advisory appears in the security index page