### PR TITLE
Link the Camel security model from the security page

### DIFF
--- a/content/security/_index.md
+++ b/content/security/_index.md
@@ -4,6 +4,22 @@ title: "Security"
 
 # Apache Camel security information
 
+## Security model and report scope
+
+Before reporting, please read the **[Apache Camel Security Model](/manual/security-model.html)**.
+
+It is the canonical reference the Apache Camel PMC uses when triaging security reports. It
+documents who is trusted, where the trust boundaries sit, which vulnerability classes are
+accepted as framework vulnerabilities, and which categories are out of scope — route-author or
+operator responsibility, explicit opt-ins, denial of service through unthrottled routes,
+third-party transitive CVEs not reachable through Camel code, management surfaces placed on an
+untrusted network, and automated-scanner output with no proof of concept. Reports that fall
+outside the documented scope are closed with a reference to that page.
+
+The Camel subprojects — Camel Quarkus, Camel Spring Boot, Camel Karaf, Camel Kamelets, Camel
+Kafka Connector and Camel K — inherit the same trust model; report scope for them is governed
+by the same document unless a subproject publishes its own security model.
+
 ## Reporting new security problems with Apache Camel
 
 The Apache Software Foundation takes a very active stance in eliminating security problems.


### PR DESCRIPTION
## Context

The ASF Security Team asked us to make the Apache Camel security model more
prominent for reporters, so https://camel.apache.org/security/ gives them a
stable anchor before they file.

## Change

Adds a "Security model and report scope" section at the **top** of
`content/security/_index.md` (above the reporting instructions) linking the
canonical model at `/manual/security-model.html`, summarising the out-of-scope
categories, and stating that the subprojects (Camel Quarkus, Spring Boot,
Karaf, Kamelets, Kafka Connector, Camel K) inherit the same trust model.

Single-file, content-only change (`content/security/_index.md`, +16 lines).
The advisory table and reporting section are unchanged.

Companion to apache/camel#23253, which folds two triage clarifications into the
model itself and adds the Security pages to the user-manual navigation.

---
_Claude Code on behalf of Andrea Cosentino_