### PR TITLE
Reduce deploy diff size with rsync and add CDN nudge push

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -93,11 +93,13 @@ pipeline {
                 dir('deploy/live') {
                     deleteDir()
                     sh 'git clone -b asf-site https://gitbox.apache.org/repos/asf/camel-website-pub.git .'
-                    sh 'git rm -q -r *'
-                    sh "cp -R $WORKSPACE/camel-website/public/. ."
-                    sh 'git add .'
+                    sh "rsync -a --delete --exclude='.git' --exclude='.asf.yaml' $WORKSPACE/camel-website/public/ ."
+                    sh 'git add -A'
                     sh "git checkout $VALID_ASF_YAML -- ./.asf.yaml" // force revert to commit containing the valid .asf.yml
-                    sh 'git commit -m "Website updated to $GIT_COMMIT"'
+                    sh 'git diff-index --quiet HEAD || git commit -m "Website updated to $GIT_COMMIT"'
+                    sh 'git push origin asf-site'
+                    sh 'sleep 5'
+                    sh 'git commit --allow-empty -m "CDN cache invalidation"'
                     sh 'git push origin asf-site'
                 }
             }


### PR DESCRIPTION
## Summary

- Use `rsync` instead of `git rm -r * && cp -R` in the deploy stage so git only sees actually-changed files rather than marking all ~15,000+ files as changed on every build
- Add a follow-up empty "nudge" commit + push after the main deploy to reliably trigger CDN cache purge

## Why

Per [INFRA-27679](https://issues.apache.org/jira/browse/INFRA-27679), the ASF message queue has a **256KB event payload limit**. Large pushes with 15,000+ changed files exceed this limit, causing the CDN PURGE request to be **silently dropped**. The CDN then serves stale content (including cached 404s) indefinitely.

The `rsync --delete` approach only produces git diffs for files that actually changed. A blog-only update might change 10 files instead of 15,000, staying well within the 256KB payload limit.

The follow-up nudge push (after a 5-second delay) provides a safety net: even if the main push exceeds the limit, this tiny second push will trigger the CDN purge.

## Test plan

- [ ] Verify rsync is available in the Jenkins Docker build environment
- [ ] Test that `.asf.yaml` is still correctly restored from `$VALID_ASF_YAML`
- [ ] Confirm the nudge push triggers CDN cache invalidation
- [ ] Monitor next deploy for 404 recurrence

Fixes #1631