### PR TITLE
chore: reduce camel-kafka-connector docs to main only

### DIFF
--- a/antora-playbook-snippets/antora-playbook.yml
+++ b/antora-playbook-snippets/antora-playbook.yml
@@ -55,8 +55,6 @@ content:
     - url: https://github.com/apache/camel-kafka-connector.git
       branches:
         - main
-        - camel-kafka-connector-4.18.x
-        - camel-kafka-connector-4.14.x
       start_paths:
         - docs
         - connectors


### PR DESCRIPTION
## Summary

- Drop versioned docs (4.18.x, 4.14.x) for camel-kafka-connector, keeping only `main` (next)
- Saves ~48MB and ~900 files from the published site
- Part of the CDN 404 investigation (#1631) — reducing overall site size

## Context

The published site currently includes 3 versions of camel-kafka-connector docs (~24MB each, ~72MB total). Since this sub-project has limited activity, publishing only the latest development version is sufficient.

## Test plan

- [ ] Verify the Antora build completes successfully
- [ ] Confirm camel-kafka-connector docs are available under `/camel-kafka-connector/next/`
- [ ] Verify `/camel-kafka-connector/latest/` redirects correctly


🤖 Generated with [Claude Code](https://claude.com/claude-code)