### PR TITLE
chore: remove link to unpublished camel-dna page

### DIFF
--- a/content/what-is-apache-camel/_index.md
+++ b/content/what-is-apache-camel/_index.md
@@ -113,8 +113,6 @@ These aren't theoretical — they're production-tested patterns used by thousand
 
 The very first Camel route ever written was `from("jms:queue:test.queue").to("file://test")` — one line, June 2007. Nearly two decades later, that same idea powers every Camel route: take data from here, send it there. The framework grew from 19 components to 350+, from a handful of contributors to 1,600+ — but the DNA never changed.
 
-**[Read the full origin story — Camel DNA →](/camel-dna/)**
-
 ---
 
 ## Trusted in production


### PR DESCRIPTION
## Summary
- Remove the `camel-dna` link from the What is Apache Camel page — the target page is not yet merged, causing the link checker to fail and blocking the website build

## Test plan
- [ ] `yarn checks` passes without `camel-dna does not exist` error

🤖 Generated with [Claude Code](https://claude.com/claude-code)