### PR TITLE
#1645: Parallelize build post-steps and checks for faster CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "1.0.0-SNAPSHOT",
   "license": "Apache-2.0",
   "scripts": {
-    "build": "run-s -l build:antora build:hugo build:sitemap build:htaccess build:markdown build:minify",
+    "build": "run-s -l build:antora build:hugo build:post",
+    "build:post": "run-p -l build:sitemap build:htaccess build:markdown build:minify",
     "build-all": "yarn workspaces foreach --all --topological-dev run build",
     "build:antora": "run-s -l build:antora-prep build:antora-perf",
     "build:antora-prep": "yarn exec antora-playbook-snippets/assemble-playbook.sh antora-playbook-production.yml playbook-export-site-manifest.yml",
@@ -16,7 +17,7 @@
     "check:html": "html-validate public",
     "check:links": "deadlinks-linux public",
     "check:redirects": "tests/redirect.sh -s",
-    "checks": "run-s -l check:links check:html check:redirects",
+    "checks": "run-p -l check:links check:html check:redirects",
     "clean": "gulp clean",
     "check:dependencies": "run-p check:cache check:dedupe",
     "check:cache": "yarn workspaces foreach --all install --immutable --immutable-cache --check-cache",

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "1.0.0-SNAPSHOT",
   "license": "Apache-2.0",
   "scripts": {
-    "build": "run-s -l build:antora build:hugo build:post",
-    "build:post": "run-p -l build:sitemap build:htaccess build:markdown build:minify",
+    "build": "run-s -l build:antora build:hugo build:post build:minify",
+    "build:post": "run-p -l build:sitemap build:htaccess build:markdown",
     "build-all": "yarn workspaces foreach --all --topological-dev run build",
     "build:antora": "run-s -l build:antora-prep build:antora-perf",
     "build:antora-prep": "yarn exec antora-playbook-snippets/assemble-playbook.sh antora-playbook-production.yml playbook-export-site-manifest.yml",


### PR DESCRIPTION
## Summary

Fixes #1645

- **Checks (`yarn checks`):** switch from `run-s` (sequential) to `run-p` (parallel) — link checking, HTML validation, and redirect tests are independent read-only tasks
- **Build post-steps:** after Antora + Hugo complete, run sitemap, htaccess, and markdown generation in parallel via a new `build:post` step. Minify remains sequential (last) to avoid a race condition with markdown — both read `public/**/*.html`

Pipeline: `antora → hugo → (sitemap + htaccess + markdown) → minify`

🤖 Generated with [Claude Code](https://claude.com/claude-code)