### PR TITLE
Add "When to use Apache Camel" page

### DIFF
--- a/antora-ui-camel/public/_/partials/head-meta.hbs
+++ b/antora-ui-camel/public/_/partials/head-meta.hbs
@@ -2,7 +2,7 @@
 <meta property="og:title" content="{{page.title}}">
 <meta property="og:site_name" content="Apache Camel">
 <meta property="og:url" content="https://camel.apache.org">
-<meta property="og:description" content="Apache Camel is an open source integration framework with 300+ connectors for databases, APIs, message brokers, and cloud services. Write routes in Java, YAML, or XML. Run on Spring Boot, Quarkus, or standalone with the Camel CLI. In production since 2007. Apache License 2.0.">
+<meta property="og:description" content="Apache Camel is an open source integration framework with 350+ connectors for databases, APIs, message brokers, and cloud services. Write routes in Java, YAML, or XML. Run on Spring Boot, Quarkus, or standalone with the Camel CLI. In production since 2007. Apache License 2.0.">
 <meta property="og:type" content="website">
 <meta property="og:image" content="{{site.url}}/_/img/logo-d-a567cee6fa.svg">
 <link rel="manifest" href="{{siteRootPath}}/site.webmanifest">

--- a/config.toml
+++ b/config.toml
@@ -20,7 +20,7 @@ defaultMarkdownHandler = "goldmark"
 [params]
     socialProfiles = ["https://twitter.com/ApacheCamel"]
     organizationLogo = "https://camel.apache.org/_/img/logo-d.svg"
-    organizationDescription = "Apache Camel is an open source integration framework with 300+ connectors for databases, APIs, message brokers, and cloud services. Write routes in Java, YAML, or XML. Run on Spring Boot, Quarkus, or standalone with the Camel CLI. In production since 2007. Apache License 2.0."
+    organizationDescription = "Apache Camel is an open source integration framework with 350+ connectors for databases, APIs, message brokers, and cloud services. Write routes in Java, YAML, or XML. Run on Spring Boot, Quarkus, or standalone with the Camel CLI. In production since 2007. Apache License 2.0."
     GitHubUsername = ""
     GitHubToken = ""
 

--- a/content/_index.md
+++ b/content/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Home
-description: Apache Camel is an open source integration framework with 300+ connectors for databases, APIs, message brokers, and cloud services. Write routes in Java, YAML, or XML. Run on Spring Boot, Quarkus, or standalone with the Camel CLI. In production since 2007. Apache License 2.0.
+description: Apache Camel is an open source integration framework with 350+ connectors for databases, APIs, message brokers, and cloud services. Write routes in Java, YAML, or XML. Run on Spring Boot, Quarkus, or standalone with the Camel CLI. In production since 2007. Apache License 2.0.
 keywords:
 - apache camel
 - integration framework

--- a/content/what-is-apache-camel/_index.md
+++ b/content/what-is-apache-camel/_index.md
@@ -181,6 +181,7 @@ Or design visually: [Kaoto](https://kaoto.io) | [Karavan](https://github.com/apa
 
 ## Go deeper
 
+- [When to use Apache Camel](/when-to-use/) — common use cases and when Camel is the right fit
 - [Getting Started Guide](/manual/getting-started.html) — build your first integration
 - [Component Catalog](/components/next/) — browse 350+ connectors
 - [Enterprise Integration Patterns](/components/next/eips/enterprise-integration-patterns.html) — the pattern library

--- a/content/when-to-use/_index.md
+++ b/content/when-to-use/_index.md
@@ -176,11 +176,11 @@ Custom code gives you full control but no reuse. Every new integration — Kafka
 
 ### vs Spring Integration
 
-Spring Integration is a good choice when integration is a small part of a larger Spring application — polling an SFTP folder, processing a JMS queue. Camel is the better choice when integration is your core problem: many systems, complex routing, diverse protocols. Camel has 350+ connectors vs Spring Integration's significantly fewer adapters, richer EIP support (saga, circuit breaker, dynamic routing), and the YAML DSL for non-Java use. Both run on Spring Boot — they're not mutually exclusive.
+Spring Integration is a good choice when integration is a small part of a larger Spring application — polling an SFTP folder, processing a JMS queue. Camel is the better choice when integration is your core problem: many systems, complex routing, diverse protocols. Camel has 350+ connectors vs Spring Integration's ~40 adapters, richer EIP support (saga, circuit breaker, dynamic routing), and the YAML DSL for non-Java use. Both run on Spring Boot — they're not mutually exclusive.
 
 ### vs managed iPaaS platforms
 
-Managed platforms (MuleSoft, Dell Boomi, Informatica) provide a cloud-hosted environment with visual tools, monitoring, and governance. Camel is open source with zero license fees — you manage the infrastructure. Choose a managed platform if you need a turnkey solution for non-developer teams. Choose Camel if you want full control, no vendor lock-in, and your team is comfortable with code. Some enterprises use both — Camel for developer-built integrations, a managed platform for citizen integrators. Notably, Camel is the runtime engine inside SAP Integration Suite, a Gartner iPaaS Leader.
+Managed platforms (MuleSoft, Dell Boomi, Informatica) provide a cloud-hosted environment with visual tools, monitoring, and governance. Camel is open source with zero license fees — you manage the infrastructure. Choose a managed platform if you need a turnkey solution for non-developer teams. Choose Camel if you want full control, no vendor lock-in, and your team is comfortable with code. Some enterprises use both — Camel for developer-built integrations, a managed platform for citizen integrators. Notably, Camel is the runtime engine inside a Gartner iPaaS Leader (SAP Integration Suite).
 
 ## Go deeper
 

--- a/content/when-to-use/_index.md
+++ b/content/when-to-use/_index.md
@@ -1,0 +1,198 @@
+---
+title: "When to use Apache Camel"
+description: "When and why to use Apache Camel — common integration use cases, real-world scenarios, and when alternatives might be a better fit."
+keywords:
+- apache camel
+- integration use cases
+- when to use camel
+- event-driven architecture
+- data pipeline
+- legacy modernization
+- api mediation
+- etl
+- iot integration
+- microservices integration
+---
+
+## The short answer
+
+Use Apache Camel when you need to move data between two or more systems and you want the protocol handling, error recovery, and transformation logic handled for you. You describe *what* should happen — Camel handles *how*.
+
+If you're writing code to read from Kafka, transform JSON, and write to a database — that's a Camel route.
+If you're polling an FTP server, filtering files, and pushing to an API — that's a Camel route.
+If you're bridging a legacy SOAP service to a modern REST API — that's a Camel route.
+
+Camel is a library, not a platform. It embeds in your existing Spring Boot or Quarkus application. You deploy it the same way you deploy any Java application.
+
+## Common use cases
+
+### Connecting systems that speak different protocols
+
+One system sends messages over Kafka. Another expects REST calls. A third reads from an SFTP share. Camel lets you connect them without writing protocol-specific code for each pair. You swap `kafka:` for `sftp:` or `rest:` in the URI — the route logic stays the same.
+
+This is Camel's original purpose and still its strongest use case.
+
+### Event-driven microservices
+
+Consume events from Kafka, AMQP, or JMS. Transform, enrich, filter, or route them to downstream services. Camel's Enterprise Integration Patterns — content-based router, splitter, aggregator, dead letter channel — handle the complexity that custom code makes painful. Java and YAML are the most commonly used DSLs:
+
+**YAML:**
+
+```yaml
+- route:
+    from:
+      uri: kafka:order-events
+      steps:
+        - choice:
+            when:
+              - expression:
+                  simple:
+                    expression: "${body[type]} == 'priority'"
+                steps:
+                  - to:
+                      uri: direct:fast-track
+            otherwise:
+              steps:
+                - to:
+                    uri: seda:standard-queue
+```
+
+**Java:**
+
+```java
+from("kafka:order-events")
+    .choice()
+        .when(simple("${body[type]} == 'priority'"))
+            .to("direct:fast-track")
+        .otherwise()
+            .to("seda:standard-queue");
+```
+
+### File and batch processing
+
+Poll a directory, FTP server, or cloud storage bucket. Pick up new files, transform them (CSV to JSON, XML to database rows), and deliver them downstream. Handle duplicates, retries, and partial failures. Camel's file and FTP components include idempotent consumers, move-on-completion, and read locks out of the box.
+
+### API mediation
+
+Sit between API consumers and providers. Transform request/response formats, handle authentication, throttle traffic, and route to different backends based on content. Camel provides REST DSL for exposing APIs and 350+ components for calling backends.
+
+### Data pipelines and ETL
+
+Extract data from databases, APIs, files, or message brokers. Transform it — filter, enrich, aggregate, split, reformat. Load it into data warehouses, lakes, or downstream systems. Camel's data formats (JSON, XML, CSV, Avro, Protobuf) and type converters make transformation straightforward.
+
+### Legacy system modernization
+
+You have a mainframe, an old SOAP service, or an ERP system that isn't going away. Camel bridges it to modern systems without touching the legacy side. Expose mainframe data as REST. Convert SOAP to JSON. Poll legacy databases and publish changes to Kafka. The legacy system doesn't know Camel exists.
+
+### Hybrid cloud synchronization
+
+Bridge on-premise systems — SAP, mainframes, internal databases — to cloud-native applications running on AWS, Azure, or GCP. Camel runs wherever Java runs: in the data center next to the legacy system, or in a container in the cloud. Same routes, same connectors, different deployment.
+
+### Cloud service orchestration
+
+Coordinate workflows across cloud services — trigger a Lambda function when a file lands in S3, process the result, store it in DynamoDB, and notify via SNS. Camel has native connectors for AWS, Azure, and GCP services so you can orchestrate across clouds without vendor-specific SDKs in your business logic.
+
+### IoT and edge data ingestion
+
+Collect telemetry from IoT devices via MQTT, CoAP, or HTTP. Filter, aggregate, and route sensor data to analytics platforms, databases, or alerting systems. Camel's small footprint and Quarkus native compilation make it viable at the edge.
+
+### AI-powered integration workflows
+
+Build AI agent workflows: triage incoming emails with an LLM, classify and route support tickets, orchestrate multi-agent systems. Camel's MCP server gives AI coding assistants full catalog context. LangChain4j and OpenAI components connect to LLMs. The A2A protocol enables agent-to-agent communication. YAML DSL + Camel CLI lets you prototype AI workflows without writing Java.
+
+## Common integration patterns
+
+### Scheduled jobs and batch runs
+
+Generate nightly reports, run periodic data syncs, poll for changes on a schedule. Camel's timer, cron, and scheduler components trigger routes at intervals. Combined with the file, SQL, or HTTP components, you build scheduled workflows without external cron infrastructure.
+
+### Data synchronization
+
+Keep multiple systems in sync — CRM, ERP, warehouse, billing. Poll for changes, consume change-data-capture events, or listen for webhooks. Route updates to every system that needs them, handle conflicts and retries. Camel's idempotent consumer pattern prevents duplicate processing.
+
+### Notification and alerting
+
+Aggregate events from monitoring systems, application logs, or business processes. Route alerts to Slack, email, SMS, PagerDuty, or Microsoft Teams based on severity, source, or content. Camel's content-based router and throttle patterns prevent alert storms.
+
+### Message format translation
+
+Convert between data formats that different systems expect — EDI to JSON, XML to CSV, HL7 to FHIR, fixed-width to Avro. Camel's data format components and type converters handle serialization so your route logic stays clean.
+
+### Content enrichment
+
+Call external services mid-route to add data to a message — look up a customer record, fetch a price, validate an address. Camel's enrich and pollEnrich EIPs integrate external calls without breaking the route flow.
+
+## Industry scenarios
+
+Camel has been in production for nearly two decades across virtually every industry — from startups to Fortune 500 companies, from government agencies to NGOs. Every industry has systems that need to talk to each other, and Camel is the glue. Below are some examples, but Camel is used far beyond these.
+
+### Healthcare
+
+Route HL7v2 and FHIR messages between hospital information systems, labs, pharmacies, and insurance providers. Handle patient admission, discharge, and transfer events. Camel's HL7 and FHIR components speak the native healthcare protocols.
+
+### Financial services
+
+Process payments, route transactions, generate regulatory reports. Connect trading systems via FIX protocol. Integrate with SWIFT, payment gateways, and fraud detection services. Camel's transactional support and error handling meet the reliability requirements of financial processing.
+
+### Telecom
+
+Process call detail records (CDRs), provision services, route network events. Integrate OSS/BSS systems, billing platforms, and network management tools. Handle high-volume event streams from network infrastructure.
+
+### Retail and e-commerce
+
+Manage orders across channels — web, mobile, point-of-sale, marketplaces. Synchronize inventory between warehouses, stores, and online catalogs. Route fulfillment requests to the right distribution center. Process returns, refunds, and exchanges across systems.
+
+### Logistics and supply chain
+
+Track shipments across carriers and borders. Integrate warehouse management, transportation management, and customs systems. Process EDI documents (EDIFACT, X12) for purchase orders, invoices, and shipping notices. Camel's AS2 component handles B2B document exchange.
+
+### Government and public sector
+
+Exchange data between agencies — citizen records, tax filings, benefits, permits. Integrate legacy mainframe systems with modern web portals. Handle secure, auditable data flows with compliance requirements.
+
+### Energy and utilities
+
+Collect meter readings and SCADA data from field devices. Route smart grid events to analytics and control systems. Integrate customer billing, outage management, and asset management platforms.
+
+### Insurance
+
+Route claims between agents, adjusters, and payment systems. Integrate policy administration, underwriting, and actuarial systems. Process regulatory filings and compliance data across jurisdictions.
+
+## When Camel might not be the best fit
+
+Camel isn't the right tool for everything.
+
+**Single point-to-point HTTP call** — if you're just calling one REST API from your application, use your framework's built-in HTTP client. Camel adds value when there's routing, transformation, or error handling beyond a simple request/response.
+
+**Your only integration is trivial** — if you need to read one file and write it somewhere, a few lines of standard library code may be simpler than adding a framework. Camel's value compounds as integrations grow in number and complexity.
+
+**You need a full iPaaS with a management console** — Camel is a developer framework, not a managed platform. If you need a drag-and-drop cloud iPaaS with built-in monitoring, dashboards, and governance for non-technical users, look at managed platforms. (Some of them, like SAP Integration Suite, run Camel under the hood.)
+
+## Camel vs alternatives
+
+### vs custom integration code
+
+Custom code gives you full control but no reuse. Every new integration — Kafka, FTP, database, cloud service — means writing and maintaining protocol-specific code, error handling, retry logic, and connection management from scratch. Camel provides this out of the box for 350+ systems with significantly less code, and the error handling is more robust. Camel also includes a built-in test framework — mock endpoints, adviceWith, and auto-wired test support — so you can unit test routes without deploying them.
+
+### vs Spring Integration
+
+Spring Integration is a good choice when integration is a small part of a larger Spring application — polling an SFTP folder, processing a JMS queue. Camel is the better choice when integration is your core problem: many systems, complex routing, diverse protocols. Camel has 350+ connectors vs Spring Integration's significantly fewer adapters, richer EIP support (saga, circuit breaker, dynamic routing), and the YAML DSL for non-Java use. Both run on Spring Boot — they're not mutually exclusive.
+
+### vs managed iPaaS platforms
+
+Managed platforms (MuleSoft, Dell Boomi, Informatica) provide a cloud-hosted environment with visual tools, monitoring, and governance. Camel is open source with zero license fees — you manage the infrastructure. Choose a managed platform if you need a turnkey solution for non-developer teams. Choose Camel if you want full control, no vendor lock-in, and your team is comfortable with code. Some enterprises use both — Camel for developer-built integrations, a managed platform for citizen integrators. Notably, Camel is the runtime engine inside SAP Integration Suite, a Gartner iPaaS Leader.
+
+## Go deeper
+
+- [What is Apache Camel?](/what-is-apache-camel/) — introduction, architecture, and getting started
+- [Getting Started Guide](/manual/getting-started.html) — build your first integration
+- [Component Catalog](/components/next/) — browse 350+ connectors
+- [Enterprise Integration Patterns](/components/next/eips/enterprise-integration-patterns.html) — the pattern library
+- [User Stories](/community/user-stories/) — companies using Camel in production
+- [Camel CLI](/manual/camel-jbang.html) — prototype integrations from the command line
+
+**Examples:**
+- [CLI Examples](https://github.com/apache/camel-jbang-examples) — ready-to-run YAML and script examples
+- [Standalone Examples](https://github.com/apache/camel-examples) — Camel Standalone integration examples
+- [Spring Boot Examples](https://github.com/apache/camel-spring-boot-examples) — Spring Boot integration examples
+- [Quarkus Examples](https://github.com/apache/camel-quarkus-examples) — Quarkus integration examples

--- a/llms-txt-template.md
+++ b/llms-txt-template.md
@@ -1,6 +1,6 @@
 # Apache Camel
 
-> Apache Camel is an open source integration framework with 300+ connectors for databases, APIs, message brokers, and cloud services. Write routes in Java, YAML, or XML. Deploy on Spring Boot, Quarkus, or standalone with the Camel CLI. In production since 2007, used by thousands of companies worldwide. 91,000+ commits, 1,100+ contributors, median 1-day bug fix time. Apache License 2.0 — zero license fees.
+> Apache Camel is an open source integration framework with 350+ connectors for databases, APIs, message brokers, and cloud services. Write routes in Java, YAML, or XML. Deploy on Spring Boot, Quarkus, or standalone with the Camel CLI. In production since 2007, used by thousands of companies worldwide. 91,000+ commits, 1,100+ contributors, median 1-day bug fix time. Apache License 2.0 — zero license fees.
 
 All Apache Camel documentation pages are available in LLM-friendly Markdown format by replacing `.html` with `.md` in any URL.
 For example:
@@ -10,7 +10,7 @@ For example:
 ## Key facts
 
 - Apache Camel is a **library**, not a platform — it embeds in your existing Spring Boot or Quarkus application
-- 300+ connectors included out of the box: Kafka, REST, JDBC, AWS (S3, SQS, Lambda), Azure, GCP, Salesforce, MongoDB, AMQP, FTP/SFTP, and many more
+- 350+ connectors included out of the box: Kafka, REST, JDBC, AWS (S3, SQS, Lambda), Azure, GCP, Salesforce, MongoDB, AMQP, FTP/SFTP, and many more
 - 65+ Enterprise Integration Patterns (EIPs) for routing, transformation, and error handling
 - Write routes in Java DSL, YAML DSL, or XML DSL — same routes, same connectors, your choice of syntax
 - YAML DSL + Camel CLI lets non-Java developers build integrations without writing or compiling Java
@@ -23,6 +23,7 @@ For example:
 ## What is Apache Camel
 
 - [What is Apache Camel](https://camel.apache.org/what-is-apache-camel/): Introduction for newcomers — what Camel does, why it matters, and how to get started.
+- [When to use Apache Camel](https://camel.apache.org/when-to-use/): Common use cases, real-world scenarios, when Camel fits, and when alternatives might be better.
 - [Getting Started](https://camel.apache.org/manual/getting-started.md): Quick start guide for Apache Camel.
 - [User Manual](https://camel.apache.org/manual/index.md): Complete user guide and reference documentation.
 - [Architecture (CamelContext)](https://camel.apache.org/manual/camelcontext.md): How Camel works — routes, components, endpoints, processors, producers, consumers, and the DSL.
@@ -37,12 +38,12 @@ For example:
 
 ## Runtimes
 
-- [Camel Spring Boot](https://camel.apache.org/camel-spring-boot/next/index.md): Camel on Spring Boot with starters for 300+ connectors. The most popular way to run Camel in production.
+- [Camel Spring Boot](https://camel.apache.org/camel-spring-boot/next/index.md): Camel on Spring Boot with starters for 350+ connectors. The most popular way to run Camel in production.
 - [Camel Quarkus](https://camel.apache.org/camel-quarkus/next/index.md): Cloud-native Camel with Quarkus extensions. Fast startup, low memory, native compilation.
 
 ## Components and Patterns
 
-- [Components Index](https://camel.apache.org/components/next/index.md): Complete list of all Camel connectors (300+).
+- [Components Index](https://camel.apache.org/components/next/index.md): Complete list of all Camel connectors (350+).
 - [Enterprise Integration Patterns (EIPs)](https://camel.apache.org/components/next/eips/index.md): 65+ message routing and transformation patterns.
 - [YAML DSL](https://camel.apache.org/components/next/others/yaml-dsl.md): Writing Camel routes in YAML — syntax, structure, and examples.
 - [YAML DSL Schema](https://github.com/apache/camel/blob/main/dsl/camel-yaml-dsl/camel-yaml-dsl/src/generated/resources/schema/camelYamlDsl-canonical.json): Complete JSON Schema for YAML DSL routes — the canonical spec for validating and generating Camel YAML.


### PR DESCRIPTION
## Summary

- New standalone page at `/when-to-use/` answering the most common AI and developer question: "when should I use Apache Camel?"
- Covers 10 common use cases, 5 integration patterns, 8 industry scenarios, honest "when not to use" guidance, and vs-alternatives positioning
- Updates connector count from 300+ to 350+ across all metadata files (front page, og:description, JSON-LD, llms.txt)
- Adds cross-link from "What is Apache Camel" page and llms-txt-template.md

## Motivation

The best "when to use Camel" content currently lives on third-party domains. Putting this on apache.org gives it maximum weight in AI training data and makes it the canonical answer for AI models evaluating integration tools.

## Test plan

- [ ] Run `hugo server` and verify `/when-to-use/` renders correctly with auto-generated TOC
- [ ] Verify cross-links from "What is Apache Camel" → "When to use" work
- [ ] Verify YAML code example renders with syntax highlighting
- [ ] Check `llms.txt` includes the new page link

🤖 Generated with [Claude Code](https://claude.com/claude-code)