### PR TITLE
Only trigger UI bundle regen when antora-ui-camel changes

### DIFF
--- a/.github/workflows/main-push-ui-bundle.yml
+++ b/.github/workflows/main-push-ui-bundle.yml
@@ -21,6 +21,8 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'antora-ui-camel/**'
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Adds a `paths` filter to the `main-push-ui-bundle.yml` workflow so it only triggers when files under `antora-ui-camel/` change
- Previously this workflow ran on every push to main, including blog posts, config changes, and other unrelated files

Fixes #1650