### PR TITLE
Add a Trust by Default page and header navigation link

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -82,6 +82,13 @@ defaultMarkdownHandler = "goldmark"
     url = "/security/"
     pre = "img/security.svg"
 
+[[menu.main]]
+    name = "Trust"
+    weight = 8
+    identifier = "trust"
+    url = "/trust/"
+    pre = "img/security.svg"
+
 [module]
 
   [[module.mounts]]

--- a/content/trust/_index.md
+++ b/content/trust/_index.md
@@ -1,0 +1,119 @@
+---
+title: "Trust by Default"
+description: "Why teams trust Apache Camel in production: a predictable, near-monthly release cadence with long term support, security vulnerabilities fixed proactively and disclosed openly through the Apache process, and a vendor-neutral community. In production since 2007 at UPS, CERN, SAP, banks, governments, and healthcare providers worldwide."
+keywords:
+- apache camel
+- trust
+- security
+- release cadence
+- long term support
+- LTS
+- CVE
+- responsible disclosure
+- open source governance
+- apache software foundation
+- enterprise integration
+- production
+---
+
+Apache Camel has been running in production since 2007. Some of the largest organizations in
+the world — banks, airlines, hospitals, government agencies, and Fortune 10 companies — route
+business-critical traffic through Camel every second of every day.
+
+That kind of reliance has to be earned, and it cannot be claimed with a logo or a badge. We earn
+it the same way on every release: in the open, on a predictable schedule, with security handled
+transparently, and as a community that answers to no single vendor. Everything below is a matter
+of public record — you do not have to take our word for any of it. That is what *trust by
+default* means for Apache Camel.
+
+{{< div "box" >}}
+
+<a href="/download/" class="icon" title="Releases and Long Term Support">{{< icon "download" "Down arrow" >}}</a>
+
+{{< div "content" >}}
+
+## A predictable release cadence
+
+Camel ships a new release almost every month, so fixes and improvements reach you in weeks rather
+than years. Designated **Long Term Support (LTS)** releases receive bug and security fixes for up
+to a year, giving you a stable target you can plan around. We treat backward compatibility as a
+feature: the rare breaking change is always documented in the
+[Migration and Upgrade](/manual/migration-and-upgrade.html) guide, so an upgrade never holds a
+surprise.
+
+<p>
+<a class="button dark" href="/download/">See the releases</a>
+</p>
+
+{{< /div >}}
+
+{{< /div >}}
+
+{{< div "box" >}}
+
+<a href="/security/" class="icon" title="Security advisories and the Camel security model">{{< icon "security" "Padlock" >}}</a>
+
+{{< div "content" >}}
+
+## Security handled in the open
+
+Every reported vulnerability is handled through the Apache Software Foundation's coordinated
+disclosure process and published as a full, PGP-signed advisory — an unbroken public track record
+that goes back to 2013. A canonical [Security Model](/manual/security-model.html) documents
+exactly where the trust boundaries sit and what is in or out of scope, fixes are delivered across
+every supported LTS line, and we proactively review and harden the framework rather than wait for
+someone else to find the problem.
+
+<p>
+<a class="button dark" href="/security/">Security &amp; advisories</a>
+</p>
+
+{{< /div >}}
+
+{{< /div >}}
+
+{{< div "box" >}}
+
+<a href="/community/" class="icon" title="The Apache Camel community">{{< icon "community" "People" >}}</a>
+
+{{< div "content" >}}
+
+## A vendor-neutral community
+
+Camel is an Apache Software Foundation project, governed by a meritocratic community under the
+ASF's open and vendor-neutral model. No single company controls its roadmap, and no one can take
+it away from you. Development happens entirely in the open on public mailing lists and chat, and
+anyone is free to read the code, propose a change, review a release, or verify a fix for
+themselves.
+
+<p>
+<a class="button dark" href="/community/">Meet the community</a>
+</p>
+
+{{< /div >}}
+
+{{< /div >}}
+
+{{< div "box" >}}
+
+<a href="/community/user-stories/" class="icon" title="Who uses Apache Camel">{{< icon "user-stories" "Person talking" >}}</a>
+
+{{< div "content" >}}
+
+## Proven in production
+
+More than 100 known organizations run Apache Camel in production — UPS processing tens of billions
+of messages a day, CERN, SAP's Integration Suite, alongside banks, airlines, healthcare providers,
+and national governments across six continents. Commercial platforms from Red Hat, SAP, and others
+are built directly on Camel.
+
+<p>
+<a class="button dark" href="/community/user-stories/">Who uses Camel</a>
+</p>
+
+{{< /div >}}
+
+{{< /div >}}
+
+Trust is not a feeling — it is a record. Camel's is public and unbroken: every release, every
+advisory, and every line of code is out in the open for you to check.


### PR DESCRIPTION
## What

Adds a new **Trust** entry to the main navigation linking to a new `/trust/` page titled **"Trust by Default"**.

The page makes the case for why teams can rely on Apache Camel in production, organised around four pillars — each linking to the relevant existing page:

| Pillar | Links to |
|---|---|
| A predictable, near-monthly release cadence with up to 1 year of LTS | `/download/` |
| Security vulnerabilities fixed proactively and disclosed openly via the ASF coordinated-disclosure process (PGP-signed advisories) | `/security/` |
| A vendor-neutral, ASF-governed community | `/community/` |
| A production track record (UPS, CERN, SAP, banks, governments, …) | `/community/user-stories/` |

## Notes for reviewers

- The security section deliberately avoids a hardcoded advisory count (it would go stale as new CVEs are published); it leans on the *practice* and the public track record going back to **2013** instead.
- The new nav item **reuses the existing shield icon** (`img/security.svg`) so no Antora UI theme rebuild is required. Happy to add a dedicated glyph in a follow-up if preferred.
- Page uses the same icon-card layout as the Community landing page.
- A Netlify preview will be attached automatically once checks run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)