### PR TITLE
Blog: Why AI Already Knows Apache Camel

### DIFF
--- a/content/blog/2026/06/camel-ai-trained/index.md
+++ b/content/blog/2026/06/camel-ai-trained/index.md
@@ -91,7 +91,7 @@ Beyond the prose documentation, Camel ships structured data that AI tools can co
   served by the [Camel MCP server](/manual/camel-jbang-mcp.html).
 - **YAML DSL JSON Schema** — the canonical schema for validating and generating Camel YAML
   routes. An AI agent can use this to produce syntactically valid YAML without guessing.
-- **[llms.txt](https://camel.apache.org/llms.txt)** — a structured index of all Camel
+- **[llms.txt](/llms.txt)** — a structured index of all Camel
   documentation, designed for LLM discovery.
 - **Offline documentation bundles** — versioned zip archives of all Markdown docs and catalog
   JSON, available as

--- a/content/blog/2026/06/camel-ai-trained/index.md
+++ b/content/blog/2026/06/camel-ai-trained/index.md
@@ -1,0 +1,144 @@
+---
+title: "Why AI Already Knows Apache Camel"
+date: 2026-06-19
+draft: false
+authors: [davsclaus]
+categories: ["AI"]
+keywords: ["apache camel", "AI", "LLM", "coding assistant", "training data", "YAML DSL", "MCP", "Claude", "Copilot", "Cursor"]
+preview: "AI coding assistants are remarkably good at Apache Camel — and it is not an accident. 19 years of stable APIs, 11,700+ Stack Overflow answers, 100,000+ public commits, and a predictable component model give LLMs exactly the kind of training data they learn best from. Most frameworks cannot say this."
+---
+
+Ask an AI coding assistant to write an Apache Camel route and you will likely get working code
+on the first try. Ask it to configure a Kafka consumer, wire up an error handler, or transform
+a message with the Simple language, and the result is usually correct — often surprisingly so.
+
+This is not because AI models were specifically trained on Camel. It is because Camel's
+19-year track record has produced exactly the kind of public, high-quality, consistent data
+that large language models learn best from. Most integration frameworks cannot say this.
+
+## A stable API is accurate training data
+
+The single biggest factor is **API stability**. When a framework reinvents itself every few
+years — new APIs, new abstractions, new ways of doing the same thing — the training data
+becomes a minefield. The LLM has seen five different ways to define a route, three of which
+no longer compile. It cannot tell which era the code is from, so it guesses, and it guesses
+wrong.
+
+Camel does not have this problem. The `from().to()` pattern from the
+[very first commit in 2007](/blog/2026/06/camel-dna-19-years/) still compiles and runs today.
+A Stack Overflow answer from 2012 about configuring a File component is still largely correct
+in 2026. An LLM trained on 19 years of Camel content is drawing from a corpus where the vast
+majority of examples still work — not a corpus full of deprecated patterns and obsolete APIs
+that silently produce wrong answers.
+
+This is a structural advantage that no amount of prompt engineering can replicate for an
+unstable framework. **Stability is not just good for humans — it is good for AI.**
+
+## 19 years of high-quality public data
+
+LLMs learn from what is public and well-structured. Camel has an unusually deep corpus:
+
+- **100,000+ commits** in a public git repository, with clear commit messages, since 2007
+- **11,700+ Stack Overflow questions and answers** — real implementation questions from
+  engineers building real systems, not toy examples
+- **350+ component documentation pages**, each following the same structure: description,
+  URI format, options table, examples
+- **Hundreds of blog posts, conference talks, and tutorials** spanning 19 years
+- **Books** — multiple published books on Apache Camel across editions
+- **Open source examples** — thousands of GitHub repositories using Camel in `pom.xml` files,
+  providing real-world usage patterns the model can learn from
+
+This is not a framework that appeared three years ago with a getting-started guide and a
+handful of Medium posts. The volume and quality of Camel's public content give AI models a
+statistical base that few integration technologies can match.
+
+## A predictable pattern language
+
+Camel's architecture is unusually regular, which matters more than most people realize for AI.
+
+**Every component follows the same pattern.** Whether it is Kafka, HTTP, SQL, AWS S3, or any
+of the 350+ connectors, the shape is the same:
+
+```java
+from("component:destination?option=value")
+    .to("component:destination?option=value");
+```
+
+```yaml
+- from:
+    uri: component:destination?option=value
+    steps:
+      - to:
+          uri: component:destination?option=value
+```
+
+An LLM that understands one Camel component can generalize to all of them. The URI format, the
+option naming conventions, the endpoint resolution — it is all consistent. Compare this to a
+framework where every connector has its own builder API, its own configuration style, and its
+own set of conventions. The AI has to learn each one separately.
+
+**The EIP vocabulary is finite and well-defined.** Camel implements 65+ Enterprise Integration
+Patterns — `filter`, `choice`, `split`, `aggregate`, `marshal`, `unmarshal` — each with a
+clear name and a clear purpose. LLMs handle bounded vocabularies with consistent semantics
+extremely well.
+
+## Machine-readable metadata
+
+Beyond the prose documentation, Camel ships structured data that AI tools can consume directly:
+
+- **Camel Catalog** — JSON metadata for every component, data format, language, and EIP:
+  parameters, types, defaults, descriptions, and valid enum values. This is the same data
+  served by the [Camel MCP server](/manual/camel-jbang-mcp.html).
+- **YAML DSL JSON Schema** — the canonical schema for validating and generating Camel YAML
+  routes. An AI agent can use this to produce syntactically valid YAML without guessing.
+- **[llms.txt](https://camel.apache.org/llms.txt)** — a structured index of all Camel
+  documentation, designed for LLM discovery.
+- **Offline documentation bundles** — versioned zip archives of all Markdown docs and catalog
+  JSON, available as
+  [GitHub Release assets](https://github.com/apache/camel-website/releases/tag/docs-4.18)
+  for AI agents in air-gapped or restricted environments.
+- **[MCP server](/manual/camel-jbang-mcp.html)** — a Model Context Protocol server that lets
+  AI coding assistants (Claude Code, GitHub Copilot, Cursor, Gemini CLI) query component
+  documentation and catalog metadata in real time.
+
+This is not just documentation — it is infrastructure designed for AI-assisted development.
+
+## The YAML DSL advantage
+
+Camel's [YAML DSL](/components/next/others/yaml-dsl.html) deserves special mention. It lets
+developers — and AI agents — write integration routes without any Java at all:
+
+```yaml
+- route:
+    from:
+      uri: timer:tick?period=5000
+    steps:
+      - setBody:
+          simple: "Hello from Camel at ${header.CamelTimerFiredTime}"
+      - log:
+          message: "${body}"
+      - to:
+          uri: file:output
+```
+
+The YAML DSL is validated by a JSON Schema, which means an AI agent can generate routes that
+are not just plausible but **verifiably correct** against the schema. Combined with the
+[Camel CLI](/manual/camel-jbang.html), a developer can go from an AI-generated YAML route to
+a running integration in seconds — no project setup, no compilation, no IDE required.
+
+## Why this matters for your team
+
+When evaluating an integration framework for AI-assisted development, the question is not
+just "does the AI tool support it?" — it is "how well does the AI actually know it?"
+
+An AI coding assistant is only as good as the training data behind it. A framework with
+unstable APIs produces training data full of outdated patterns. A framework with inconsistent
+conventions forces the model to memorize rather than generalize. A framework with limited
+public usage gives the model few examples to learn from.
+
+Camel has none of these problems. Nineteen years of stability, a predictable component model,
+11,700+ Stack Overflow answers, 100,000+ public commits, and a growing set of machine-readable
+metadata make it one of the best-trained integration frameworks available to AI coding
+assistants today.
+
+The AI already knows Camel. The question is whether your framework can say the same.

--- a/content/trust/_index.md
+++ b/content/trust/_index.md
@@ -183,5 +183,28 @@ upgrade.
 
 {{< /div >}}
 
+{{< div "box" >}}
+
+<a href="/blog/2026/06/camel-ai-trained/" class="icon" title="AI-ready integration">{{< icon "cli" "Terminal" >}}</a>
+
+{{< div "content" >}}
+
+## AI already knows Camel
+
+AI coding assistants are remarkably good at Apache Camel — and it is not an accident. Nineteen
+years of stable APIs mean training data does not go stale, 11,700+ Stack Overflow answers
+provide real-world examples, and a predictable component model lets LLMs generalize across
+350+ connectors. Add a built-in [MCP server](/manual/camel-jbang-mcp.html), machine-readable
+catalog metadata, and a schema-validated YAML DSL, and Camel is one of the best-trained
+integration frameworks for AI-assisted development today.
+
+<p>
+<a class="button dark" href="/blog/2026/06/camel-ai-trained/">Read why</a>
+</p>
+
+{{< /div >}}
+
+{{< /div >}}
+
 Trust is not a feeling. It is a record. Camel's is public and unbroken: every release, every
 advisory, and every line of code is out in the open for you to check.

--- a/content/trust/_index.md
+++ b/content/trust/_index.md
@@ -39,7 +39,8 @@ than years. Designated **Long Term Support (LTS)** releases receive bug and secu
 to a year, giving you a stable target you can plan around. We treat backward compatibility as a
 feature: the rare breaking change is always documented in the
 [Migration and Upgrade](/manual/migration-and-upgrade.html) guide, so an upgrade never holds a
-surprise.
+surprise. The data backs this up: [272 releases over 19 years with zero gaps](/blog/2026/06/camel-always-on/)
+and a core API so stable that [code from the first commit in 2007 still compiles unchanged](/blog/2026/06/camel-dna-19-years/).
 
 <p>
 <a class="button dark" href="/download/">See the releases</a>
@@ -84,7 +85,7 @@ Camel is an Apache Software Foundation project, governed by a meritocratic commu
 ASF's open and vendor-neutral model. No single company controls its roadmap, and no one can take
 it away from you. Development happens entirely in the open on public mailing lists and chat, and
 anyone is free to read the code, propose a change, review a release, or verify a fix for
-themselves.
+themselves. The numbers tell the story: [1,500+ contributors from 450+ companies across 20+ countries](/blog/2026/06/camel-by-the-numbers/).
 
 <p>
 <a class="button dark" href="/community/">Meet the community</a>
@@ -105,10 +106,77 @@ themselves.
 More than 100 known organizations run Apache Camel in production: UPS processing tens of billions
 of messages a day, CERN, SAP's Integration Suite, alongside banks, airlines, healthcare providers,
 and national governments across six continents. Commercial platforms from Red Hat, SAP, and others
-are built directly on Camel.
+are built directly on Camel. Companies don't contribute patches to software they evaluate —
+[450+ corporate email domains in the git history](/blog/2026/06/camel-by-the-numbers/) prove production usage
+no case study can match.
 
 <p>
 <a class="button dark" href="/community/user-stories/">Who uses Camel</a>
+</p>
+
+{{< /div >}}
+
+{{< /div >}}
+
+{{< div "box" >}}
+
+<a href="/blog/2026/06/camel-dna-19-years/" class="icon" title="Built to last">{{< icon "docs" "Document" >}}</a>
+
+{{< div "content" >}}
+
+## Built to last, not to rewrite
+
+Some frameworks reinvent themselves every few years — new APIs, new concepts, painful migrations.
+Camel does not. The `from().to()` pattern from the very first commit in 2007 still compiles and
+runs unchanged today. Four major versions, five technology eras (ESBs, SOA, microservices,
+cloud-native, AI), and the core DNA has stayed stable. You learn Camel once. Your routes,
+your patterns, and your team's expertise carry forward — they do not expire with the next major
+release.
+
+<p>
+<a class="button dark" href="/blog/2026/06/camel-dna-19-years/">Read the story</a>
+</p>
+
+{{< /div >}}
+
+{{< /div >}}
+
+{{< div "box" >}}
+
+<a href="/blog/2026/06/camel-bug-fix-track-record/" class="icon" title="Bug fix track record">{{< icon "support" "Wrench" >}}</a>
+
+{{< div "content" >}}
+
+## A proven bug fix track record
+
+The community has fixed 7,070 out of 7,081 reported bugs — a **99.8% resolution rate** — with a
+median fix time of **1 day**. That track record has been sustained for 17 of the last 19 years
+across 350+ connectors and 272 production releases. Only 6 bugs are open today. When something
+breaks, it gets fixed fast, and the data is there to prove it.
+
+<p>
+<a class="button dark" href="/blog/2026/06/camel-bug-fix-track-record/">See the data</a>
+</p>
+
+{{< /div >}}
+
+{{< /div >}}
+
+{{< div "box" >}}
+
+<a href="/blog/2026/06/camel-dependency-updates/" class="icon" title="Dependency maintenance">{{< icon "tooling" "Gear" >}}</a>
+
+{{< div "content" >}}
+
+## 500+ dependencies kept current
+
+Camel manages over 500 third-party dependencies. Across 20 minor releases, the community made
+**2,449 dependency version updates** — an average of 122 per release. This quiet, invisible work
+keeps the framework secure and compatible, so you are not stuck waiting for a critical library
+upgrade.
+
+<p>
+<a class="button dark" href="/blog/2026/06/camel-dependency-updates/">See the numbers</a>
 </p>
 
 {{< /div >}}

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "update:dedupe": "yarn workspaces foreach --all dedupe",
     "preview": "run-s -l build:antora preview:hugo",
     "preview:hugo": "hugo server --bind=0.0.0.0 -D",
-    "preview:netlify": "netlify deploy --dir public --cwd .",
+    "preview:netlify": "netlify deploy --dir public --cwd . --filter apache-camel-website",
     "build:antora-local-full": "antora local-antora-playbook-full.yml --stacktrace --clean --fetch",
     "build:antora-local-partial": "antora local-antora-playbook-partial.yml --stacktrace",
     "build:antora-local-full2": "antora antora-playbook-local-full.yml --stacktrace --clean --fetch",


### PR DESCRIPTION
## Summary
- New blog post: "Why AI Already Knows Apache Camel" — why Camel's 19-year stable API, 11,700+ Stack Overflow answers, predictable component model, and machine-readable metadata make it one of the best-trained integration frameworks for AI coding assistants
- Updated Trust by Default page with two new sections (bug fix track record, dependency maintenance) and added blog post links to existing sections for credibility

## Test plan
- [ ] Preview the blog post renders correctly
- [ ] Verify Trust page renders with the new boxes and links
- [ ] Check all blog post links resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)