### PR TITLE
Add CVE-2026-46587, CVE-2026-46588 and CVE-2026-49042 advisories

### DIFF
--- a/content/security/CVE-2026-46587.md
+++ b/content/security/CVE-2026-46587.md
@@ -1,0 +1,17 @@
+---
+title: "Apache Camel Security Advisory - CVE-2026-46587"
+date: 2026-07-03T10:00:00+02:00
+url: /security/CVE-2026-46587.html
+draft: false
+type: security-advisory
+cve: CVE-2026-46587
+severity: MEDIUM
+summary: "Camel-Couchbase: Non-Camel-prefixed Exchange headers bypass HeaderFilterStrategy allowing operation override from untrusted input"
+description: "The camel-couchbase component reads several Exchange headers to control its behaviour - CCB_KEY (document key), CCB_ID (document id), CCB_TTL (document expiry), CCB_DDN (design document name) and CCB_VN (view name). The string values of these header constants, defined in CouchbaseConstants, are plain unprefixed names rather than the Camel-prefixed names used by every other Camel component (for example CamelSqlQuery, CamelMongoDbCriteria). Camel's inbound HTTP header filter, HttpHeaderFilterStrategy, blocks only header names that begin with Camel or camel. Because the Couchbase header names do not carry that prefix, they pass through the inbound filter unchanged. When a Camel route exposes an HTTP entry point (for example platform-http) in front of a couchbase producer, an untrusted HTTP client can set these headers directly on its request and override the document key, id, TTL, design document name or view name that the route author configured. No credentials are required when the HTTP consumer is unauthenticated."
+mitigation: "Users are recommended to upgrade to version 4.21.0, which fixes the issue. If users are on the 4.14.x LTS releases stream, then they are suggested to upgrade to 4.14.8. If users are on the 4.18.x releases stream, then they are suggested to upgrade to 4.18.3. The fix renames the camel-couchbase Exchange header constant string values (CCB_KEY, CCB_ID, CCB_TTL, CCB_DDN, CCB_VN) to carry the Camel prefix (CamelCouchbaseKey, CamelCouchbaseId, CamelCouchbaseTtl, CamelCouchbaseDesignDocumentName, CamelCouchbaseViewName) so that they are blocked by the inbound HttpHeaderFilterStrategy; the Java constant field names are unchanged. For deployments that cannot upgrade immediately, strip the affected headers from untrusted inbound messages before they reach the producer (for example removeHeader('CCB_KEY'), removeHeader('CCB_ID'), removeHeader('CCB_TTL'), removeHeader('CCB_DDN') and removeHeader('CCB_VN') in front of the couchbase endpoint), or apply a custom HeaderFilterStrategy that blocks these names."
+credit: "This issue was discovered by Yu Bao from PayPal"
+affected: "From 4.0.0 before 4.14.8, from 4.15.0 before 4.18.3, from 4.19.0 before 4.21.0."
+fixed: 4.14.8, 4.18.3 and 4.21.0
+---
+
+The fix was merged on main in https://github.com/apache/camel/pull/23228 (commit d0dfa4e0ebd062acaf4a86ca476bb4305db9bfd4) and backported to camel-4.18.x in https://github.com/apache/camel/pull/23230 (commit 8d74cdca9befc74b49d9c52ac6a145be1d413e7d) and camel-4.14.x in https://github.com/apache/camel/pull/23231 (commit c16f7ef39849ae8819f50c959b538350b8f839e9). The issue is classified as CWE-20 (Improper Input Validation). It belongs to the same Camel message-header-injection family as CVE-2025-27636, CVE-2025-29891, CVE-2025-30177, CVE-2026-40453, CVE-2026-46453 and CVE-2026-47323, all of which stem from Camel components reading inbound message headers that the default HeaderFilterStrategy does not block because the header names do not start with the Camel prefix. The fix shares its PR with the sibling advisory CVE-2026-46588 (camel-couchdb).

--- a/content/security/CVE-2026-46587.txt.asc
+++ b/content/security/CVE-2026-46587.txt.asc
@@ -1,0 +1,37 @@
+-----BEGIN PGP SIGNED MESSAGE-----
+Hash: SHA512
+
+- ---
+title: "Apache Camel Security Advisory - CVE-2026-46587"
+date: 2026-07-03T10:00:00+02:00
+url: /security/CVE-2026-46587.html
+draft: false
+type: security-advisory
+cve: CVE-2026-46587
+severity: MEDIUM
+summary: "Camel-Couchbase: Non-Camel-prefixed Exchange headers bypass HeaderFilterStrategy allowing operation override from untrusted input"
+description: "The camel-couchbase component reads several Exchange headers to control its behaviour - CCB_KEY (document key), CCB_ID (document id), CCB_TTL (document expiry), CCB_DDN (design document name) and CCB_VN (view name). The string values of these header constants, defined in CouchbaseConstants, are plain unprefixed names rather than the Camel-prefixed names used by every other Camel component (for example CamelSqlQuery, CamelMongoDbCriteria). Camel's inbound HTTP header filter, HttpHeaderFilterStrategy, blocks only header names that begin with Camel or camel. Because the Couchbase header names do not carry that prefix, they pass through the inbound filter unchanged. When a Camel route exposes an HTTP entry point (for example platform-http) in front of a couchbase producer, an untrusted HTTP client can set these headers directly on its request and override the document key, id, TTL, design document name or view name that the route author configured. No credentials are required when the HTTP consumer is unauthenticated."
+mitigation: "Users are recommended to upgrade to version 4.21.0, which fixes the issue. If users are on the 4.14.x LTS releases stream, then they are suggested to upgrade to 4.14.8. If users are on the 4.18.x releases stream, then they are suggested to upgrade to 4.18.3. The fix renames the camel-couchbase Exchange header constant string values (CCB_KEY, CCB_ID, CCB_TTL, CCB_DDN, CCB_VN) to carry the Camel prefix (CamelCouchbaseKey, CamelCouchbaseId, CamelCouchbaseTtl, CamelCouchbaseDesignDocumentName, CamelCouchbaseViewName) so that they are blocked by the inbound HttpHeaderFilterStrategy; the Java constant field names are unchanged. For deployments that cannot upgrade immediately, strip the affected headers from untrusted inbound messages before they reach the producer (for example removeHeader('CCB_KEY'), removeHeader('CCB_ID'), removeHeader('CCB_TTL'), removeHeader('CCB_DDN') and removeHeader('CCB_VN') in front of the couchbase endpoint), or apply a custom HeaderFilterStrategy that blocks these names."
+credit: "This issue was discovered by Yu Bao from PayPal"
+affected: "From 4.0.0 before 4.14.8, from 4.15.0 before 4.18.3, from 4.19.0 before 4.21.0."
+fixed: 4.14.8, 4.18.3 and 4.21.0
+- ---
+
+The fix was merged on main in https://github.com/apache/camel/pull/23228 (commit d0dfa4e0ebd062acaf4a86ca476bb4305db9bfd4) and backported to camel-4.18.x in https://github.com/apache/camel/pull/23230 (commit 8d74cdca9befc74b49d9c52ac6a145be1d413e7d) and camel-4.14.x in https://github.com/apache/camel/pull/23231 (commit c16f7ef39849ae8819f50c959b538350b8f839e9). The issue is classified as CWE-20 (Improper Input Validation). It belongs to the same Camel message-header-injection family as CVE-2025-27636, CVE-2025-29891, CVE-2025-30177, CVE-2026-40453, CVE-2026-46453 and CVE-2026-47323, all of which stem from Camel components reading inbound message headers that the default HeaderFilterStrategy does not block because the header names do not start with the Camel prefix. The fix shares its PR with the sibling advisory CVE-2026-46588 (camel-couchdb).
+-----BEGIN PGP SIGNATURE-----
+
+iQJPBAEBCgA5FiEEXhypCOH+Pe54HVUTBwmP38yc5+YFAmpLW7YbFIAAAAAABAAO
+bWFudTIsMi41KzEuMTIsMCwzAAoJEAcJj9/MnOfmiI4P/2RN/wRzw81h3+gWSgwj
+h2i2e6Urj/Mz37PmL3dbiQshqsSp4jVsUTktlyBT8ULTM4LPDpvuf3EqysEc0rnM
+AHy0Oy/mWAoLFNnDT5j9HDwPm/Vone67QxXgybV/yu23xr8TW9nAoNAyIX6D+1vG
+czU09EKNWq68IqwQXOcK3MICAaeoEEKTU9nxmZO0dbuY2kzjvgizy/L5gJ0VFkK4
+kk51LNVek8kSkZ7Lzpp/EPvUzyA0Cx4jI+lkOwtvUDWePD6s66mnLpmPQJjFwCh+
+IeLGDtkjSS6kIWESONMJlLMgI5nDr836+R5u49kzMsK19RFk4UCMAdq8Mi0Wre10
+fph4S08KaWS08Cw4hFDllXNSIZsGsTivOsDddSJ2Ju47s4bk+jvaKP2f123Bbzby
+fLKs7lpWv76Kw9CjBAw+gQ/I84hF+J4i2HsmFGlKvQ67pSvPRjRAI9fiWbnkQcLl
+7QExYxUQyRTEMW/740r+WrVTXE0TSBomsGeseMHk+rI/Mw9u+6DG5+KZBhlttQNa
+7Cbx0mKVg4NMtp6dz36YTVQL3Vnl1JJYnOV1cbmj1vmGnxPr41/c/31ST3Yiad5Z
+TnHFGt7lRDE2bVY1+ttrexZ64XATwzdiYAbhrKFaM51qpTH13/DvlCMKouzv/byK
+todWDfC02ZMjSamERxzhkCc8
+=FKt+
+-----END PGP SIGNATURE-----

--- a/content/security/CVE-2026-46588.md
+++ b/content/security/CVE-2026-46588.md
@@ -1,0 +1,17 @@
+---
+title: "Apache Camel Security Advisory - CVE-2026-46588"
+date: 2026-07-03T10:00:00+02:00
+url: /security/CVE-2026-46588.html
+draft: false
+type: security-advisory
+cve: CVE-2026-46588
+severity: MEDIUM
+summary: "Camel-CouchDB: Non-Camel-prefixed Exchange headers bypass HeaderFilterStrategy allowing operation override from untrusted input"
+description: "The camel-couchdb component reads several Exchange headers to control its behaviour - CouchDbDatabase (the database name), CouchDbSeq (the changeset sequence number), CouchDbId (the document id), CouchDbRev (the document revision) and CouchDbMethod (the operation method). The string values of these header constants, defined in CouchDbConstants, use the CouchDb prefix rather than the standard Camel prefix used by every other Camel component (for example CamelSqlQuery, CamelMongoDbCriteria). Camel's inbound HTTP header filter, HttpHeaderFilterStrategy, blocks only header names that begin with Camel or camel. Because the CouchDB header names do not carry the Camel prefix, they pass through the inbound filter unchanged. When a Camel route exposes an HTTP entry point (for example platform-http) in front of a couchdb producer, an untrusted HTTP client can set these headers directly on its request and override the database, document id, revision or method that the route author configured. No credentials are required when the HTTP consumer is unauthenticated."
+mitigation: "Users are recommended to upgrade to version 4.21.0, which fixes the issue. If users are on the 4.14.x LTS releases stream, then they are suggested to upgrade to 4.14.8. If users are on the 4.18.x releases stream, then they are suggested to upgrade to 4.18.3. The fix renames the camel-couchdb Exchange header constant string values (CouchDbDatabase, CouchDbSeq, CouchDbId, CouchDbRev, CouchDbMethod) to carry the Camel prefix (CamelCouchDbDatabase, CamelCouchDbSeq, CamelCouchDbId, CamelCouchDbRev, CamelCouchDbMethod) so that they are blocked by the inbound HttpHeaderFilterStrategy; the Java constant field names are unchanged. For deployments that cannot upgrade immediately, strip the affected headers from untrusted inbound messages before they reach the producer (for example removeHeader('CouchDbDatabase'), removeHeader('CouchDbId'), removeHeader('CouchDbRev'), removeHeader('CouchDbSeq') and removeHeader('CouchDbMethod') in front of the couchdb endpoint), or apply a custom HeaderFilterStrategy that blocks these names."
+credit: "This issue was discovered by Yu Bao from PayPal"
+affected: "From 4.0.0 before 4.14.8, from 4.15.0 before 4.18.3, from 4.19.0 before 4.21.0."
+fixed: 4.14.8, 4.18.3 and 4.21.0
+---
+
+The fix was merged on main in https://github.com/apache/camel/pull/23228 (commit f35286f9eaee6740482e6ef11f8c68d785c49567) and backported to camel-4.18.x in https://github.com/apache/camel/pull/23230 (commit 8d74cdca9befc74b49d9c52ac6a145be1d413e7d) and camel-4.14.x in https://github.com/apache/camel/pull/23231 (commit c16f7ef39849ae8819f50c959b538350b8f839e9). The issue is classified as CWE-20 (Improper Input Validation). It belongs to the same Camel message-header-injection family as CVE-2025-27636, CVE-2025-29891, CVE-2025-30177, CVE-2026-40453, CVE-2026-46453 and CVE-2026-47323, all of which stem from Camel components reading inbound message headers that the default HeaderFilterStrategy does not block because the header names do not start with the Camel prefix. The fix shares its PR with the sibling advisory CVE-2026-46587 (camel-couchbase).

--- a/content/security/CVE-2026-46588.txt.asc
+++ b/content/security/CVE-2026-46588.txt.asc
@@ -1,0 +1,37 @@
+-----BEGIN PGP SIGNED MESSAGE-----
+Hash: SHA512
+
+- ---
+title: "Apache Camel Security Advisory - CVE-2026-46588"
+date: 2026-07-03T10:00:00+02:00
+url: /security/CVE-2026-46588.html
+draft: false
+type: security-advisory
+cve: CVE-2026-46588
+severity: MEDIUM
+summary: "Camel-CouchDB: Non-Camel-prefixed Exchange headers bypass HeaderFilterStrategy allowing operation override from untrusted input"
+description: "The camel-couchdb component reads several Exchange headers to control its behaviour - CouchDbDatabase (the database name), CouchDbSeq (the changeset sequence number), CouchDbId (the document id), CouchDbRev (the document revision) and CouchDbMethod (the operation method). The string values of these header constants, defined in CouchDbConstants, use the CouchDb prefix rather than the standard Camel prefix used by every other Camel component (for example CamelSqlQuery, CamelMongoDbCriteria). Camel's inbound HTTP header filter, HttpHeaderFilterStrategy, blocks only header names that begin with Camel or camel. Because the CouchDB header names do not carry the Camel prefix, they pass through the inbound filter unchanged. When a Camel route exposes an HTTP entry point (for example platform-http) in front of a couchdb producer, an untrusted HTTP client can set these headers directly on its request and override the database, document id, revision or method that the route author configured. No credentials are required when the HTTP consumer is unauthenticated."
+mitigation: "Users are recommended to upgrade to version 4.21.0, which fixes the issue. If users are on the 4.14.x LTS releases stream, then they are suggested to upgrade to 4.14.8. If users are on the 4.18.x releases stream, then they are suggested to upgrade to 4.18.3. The fix renames the camel-couchdb Exchange header constant string values (CouchDbDatabase, CouchDbSeq, CouchDbId, CouchDbRev, CouchDbMethod) to carry the Camel prefix (CamelCouchDbDatabase, CamelCouchDbSeq, CamelCouchDbId, CamelCouchDbRev, CamelCouchDbMethod) so that they are blocked by the inbound HttpHeaderFilterStrategy; the Java constant field names are unchanged. For deployments that cannot upgrade immediately, strip the affected headers from untrusted inbound messages before they reach the producer (for example removeHeader('CouchDbDatabase'), removeHeader('CouchDbId'), removeHeader('CouchDbRev'), removeHeader('CouchDbSeq') and removeHeader('CouchDbMethod') in front of the couchdb endpoint), or apply a custom HeaderFilterStrategy that blocks these names."
+credit: "This issue was discovered by Yu Bao from PayPal"
+affected: "From 4.0.0 before 4.14.8, from 4.15.0 before 4.18.3, from 4.19.0 before 4.21.0."
+fixed: 4.14.8, 4.18.3 and 4.21.0
+- ---
+
+The fix was merged on main in https://github.com/apache/camel/pull/23228 (commit f35286f9eaee6740482e6ef11f8c68d785c49567) and backported to camel-4.18.x in https://github.com/apache/camel/pull/23230 (commit 8d74cdca9befc74b49d9c52ac6a145be1d413e7d) and camel-4.14.x in https://github.com/apache/camel/pull/23231 (commit c16f7ef39849ae8819f50c959b538350b8f839e9). The issue is classified as CWE-20 (Improper Input Validation). It belongs to the same Camel message-header-injection family as CVE-2025-27636, CVE-2025-29891, CVE-2025-30177, CVE-2026-40453, CVE-2026-46453 and CVE-2026-47323, all of which stem from Camel components reading inbound message headers that the default HeaderFilterStrategy does not block because the header names do not start with the Camel prefix. The fix shares its PR with the sibling advisory CVE-2026-46587 (camel-couchbase).
+-----BEGIN PGP SIGNATURE-----
+
+iQJPBAEBCgA5FiEEXhypCOH+Pe54HVUTBwmP38yc5+YFAmpLW7wbFIAAAAAABAAO
+bWFudTIsMi41KzEuMTIsMCwzAAoJEAcJj9/MnOfm748P/27KuUx4hgCyfpkdM8bS
+MgILeg4T/vaCShvlzHklBAG3ZYWKMeJDWNWdnXHG8LOQhSM3i1MOI+uhPCyCGbXS
+s2LH2vsQorBw3nlWtJNr5B1vDXiBQBWE0vKswkP4zrP6ArhrkUXJW7kQ4QUUco4w
+xK6Vp4/QmpowoZ6uFoX8usU971xNkHQaEjOzYI/qPiz8R1kbD+sM8LyIIDzbkSTJ
+JjSZ55YvQ3xTf482YrDDxATsGGc9Ns3Z+WwU48ZYryn0epqAwnniX/nsr1ESibW6
+JD0GzRmP5eTvYIaZh0094bky266RYGGpl7/+4zW6todYaW69Nhx6jEdECiQH8Eth
+p2oFw8vameMqVlRVdAslOBkauFyijh1vOVydoUV9T5Nh6PbovEFTgpA6aKgcl2be
+DWp97fsusR5Xd5tah85DycsJw50GIPYRZOOMGjXd+Ja/GaR2r5uKYjCOfZUuWToh
+FzZIs2f2QveUN16zsxm+ACM4EYJ2P8hyI1VTiIWiDiQ2PHxz1BK6tvdC1E8F7dr8
+Id9EtTAusrCUttczCgjXk2F61Xl1DaUU7dztDw4BoqLbCfIAq47mKcyQisughqmQ
+lsW83dTj1KhypIxcMEf3QjTH1p+7zpdcXlvDd/pWFT1NUK0b/zw64FYryJU1wCg6
+T4Zngv3yJw4OV3+9ujiCb3DT
+=m41K
+-----END PGP SIGNATURE-----

--- a/content/security/CVE-2026-49042.md
+++ b/content/security/CVE-2026-49042.md
@@ -1,0 +1,17 @@
+---
+title: "Apache Camel Security Advisory - CVE-2026-49042"
+date: 2026-07-03T10:00:00+02:00
+url: /security/CVE-2026-49042.html
+draft: false
+type: security-advisory
+cve: CVE-2026-49042
+severity: MEDIUM
+summary: "Camel-Langchain4j-Tools: Tool argument headers are not filtered against declared parameters, allowing an LLM to inject arbitrary Exchange headers via tool call arguments"
+description: "Improper Input Validation vulnerability in Apache Camel. The camel-langchain4j-tools, camel-langchain4j-agent and camel-spring-ai-tools producers set all JSON field names returned by the LLM in a tool-call response as Exchange message headers without filtering them against the tool's declared parameter schema. An attacker who can influence the LLM output (for example via prompt injection) can include arbitrary field names in the tool arguments JSON - including Camel-internal control headers such as CamelFileName, CamelHttpUri or CamelExecCommandExecutable - which are then set as Exchange headers and influence the behaviour of downstream producers in the route. The fix filters tool argument field names against the tool specification's declared parameters: only fields whose name matches a declared parameter are set as Exchange headers; undeclared fields are logged at WARN level and skipped."
+mitigation: "Users are recommended to upgrade to version 4.21.0, which fixes the issue. If users are on the 4.18.x releases stream, then they are suggested to upgrade to 4.18.3. After upgrading, only tool argument fields that match a declared parameter.<name> in the tool specification are set as Exchange headers. Tools defined without parameter declarations will have zero argument headers set from LLM tool calls - this is a breaking change for routes that rely on implicit argument passthrough; to restore argument flow, declare the expected parameters explicitly via parameter.<name>=<type>. For deployments that cannot upgrade immediately, strip untrusted headers after the tool invocation (for example removeHeaders('Camel*') and removeHeaders('camel*') after the langchain4j-tools endpoint) and declare explicit parameter schemas for every tool so the LLM-returned arguments are constrained."
+credit: "This issue was discovered by Yu Bao from PayPal"
+affected: "From 4.8.0 before 4.18.3, from 4.19.0 before 4.21.0."
+fixed: 4.18.3 and 4.21.0
+---
+
+The JIRA ticket: https://issues.apache.org/jira/browse/CAMEL-23621 refers to the various commits that resolved the issue, and has more details. The fix was merged on main in https://github.com/apache/camel/pull/23535 (commit 7e65891f77aee72dc24c8099e9ba48a93962042b) and backported to camel-4.18.x in https://github.com/apache/camel/pull/23551 (commit 5d0028f6bc7a70556dc1d408b1b6cadb59e1842d). The fix adds parameter-schema filtering to three components: LangChain4jToolsProducer and LangChain4jAgentProducer check the tool specification's JsonObjectSchema.properties() keyset before setting each argument as a header, and SpringAiToolsEndpoint checks its declared parameters map. In camel-langchain4j-agent the fix also extracts primitive values (int, long, double, boolean, String) from tool arguments instead of setting raw JsonNode objects as headers. The camel-langchain4j-tools component was introduced in 4.8.0 and camel-langchain4j-agent in 4.12.0; neither component exists in the 4.14.x LTS release line prior to 4.14.0, but the 4.14.x LTS line does include these components and should upgrade to 4.18.3 or later. The issue is classified as CWE-20 (Improper Input Validation).

--- a/content/security/CVE-2026-49042.txt.asc
+++ b/content/security/CVE-2026-49042.txt.asc
@@ -1,0 +1,37 @@
+-----BEGIN PGP SIGNED MESSAGE-----
+Hash: SHA512
+
+- ---
+title: "Apache Camel Security Advisory - CVE-2026-49042"
+date: 2026-07-03T10:00:00+02:00
+url: /security/CVE-2026-49042.html
+draft: false
+type: security-advisory
+cve: CVE-2026-49042
+severity: MEDIUM
+summary: "Camel-Langchain4j-Tools: Tool argument headers are not filtered against declared parameters, allowing an LLM to inject arbitrary Exchange headers via tool call arguments"
+description: "Improper Input Validation vulnerability in Apache Camel. The camel-langchain4j-tools, camel-langchain4j-agent and camel-spring-ai-tools producers set all JSON field names returned by the LLM in a tool-call response as Exchange message headers without filtering them against the tool's declared parameter schema. An attacker who can influence the LLM output (for example via prompt injection) can include arbitrary field names in the tool arguments JSON - including Camel-internal control headers such as CamelFileName, CamelHttpUri or CamelExecCommandExecutable - which are then set as Exchange headers and influence the behaviour of downstream producers in the route. The fix filters tool argument field names against the tool specification's declared parameters: only fields whose name matches a declared parameter are set as Exchange headers; undeclared fields are logged at WARN level and skipped."
+mitigation: "Users are recommended to upgrade to version 4.21.0, which fixes the issue. If users are on the 4.18.x releases stream, then they are suggested to upgrade to 4.18.3. After upgrading, only tool argument fields that match a declared parameter.<name> in the tool specification are set as Exchange headers. Tools defined without parameter declarations will have zero argument headers set from LLM tool calls - this is a breaking change for routes that rely on implicit argument passthrough; to restore argument flow, declare the expected parameters explicitly via parameter.<name>=<type>. For deployments that cannot upgrade immediately, strip untrusted headers after the tool invocation (for example removeHeaders('Camel*') and removeHeaders('camel*') after the langchain4j-tools endpoint) and declare explicit parameter schemas for every tool so the LLM-returned arguments are constrained."
+credit: "This issue was discovered by Yu Bao from PayPal"
+affected: "From 4.8.0 before 4.18.3, from 4.19.0 before 4.21.0."
+fixed: 4.18.3 and 4.21.0
+- ---
+
+The JIRA ticket: https://issues.apache.org/jira/browse/CAMEL-23621 refers to the various commits that resolved the issue, and has more details. The fix was merged on main in https://github.com/apache/camel/pull/23535 (commit 7e65891f77aee72dc24c8099e9ba48a93962042b) and backported to camel-4.18.x in https://github.com/apache/camel/pull/23551 (commit 5d0028f6bc7a70556dc1d408b1b6cadb59e1842d). The fix adds parameter-schema filtering to three components: LangChain4jToolsProducer and LangChain4jAgentProducer check the tool specification's JsonObjectSchema.properties() keyset before setting each argument as a header, and SpringAiToolsEndpoint checks its declared parameters map. In camel-langchain4j-agent the fix also extracts primitive values (int, long, double, boolean, String) from tool arguments instead of setting raw JsonNode objects as headers. The camel-langchain4j-tools component was introduced in 4.8.0 and camel-langchain4j-agent in 4.12.0; neither component exists in the 4.14.x LTS release line prior to 4.14.0, but the 4.14.x LTS line does include these components and should upgrade to 4.18.3 or later. The issue is classified as CWE-20 (Improper Input Validation).
+-----BEGIN PGP SIGNATURE-----
+
+iQJPBAEBCgA5FiEEXhypCOH+Pe54HVUTBwmP38yc5+YFAmpLW74bFIAAAAAABAAO
+bWFudTIsMi41KzEuMTIsMCwzAAoJEAcJj9/MnOfmXHUP+wYlqxJ00U/bAQagxCIu
+8zNQiFjz2J0N6wGGE9RaoUC/kAo3Y09TQYy04EbqpEGgT8bUUV5N4Ymt+i566K1j
+6pgaMHbhTz3UbqiWQCo8n/VxukS1ChTnuWig1mm2hBrnQ2fKRISBZrZ8VnP1Fs0N
+dlLwwQCbJjsD82lKDPSgYyAXacXKfy2dGGZkgierqpMX6AOeT0V8gyKzt31d7Hag
+LcHNUWUNB2BqolJdU/iDh3RMq2eN53ACpKQAz3aN7EHWl1TTr35Ge0lhzTGFO5cW
+4Iigc3p8J8PFgV/LEy3RuQ4Qmm7TRKGwjFMb2H5HaH4R6H6ijz31fVtkny8y43iN
+2PaMIoY3KsceUIoe4QfGYD6qQlJTeRk3UkiGSxX+p3tO1AS029aqyhr7vtM+FVUS
+aIcAUZ0/ZzkZdFsD7KfnyQJPHn0fjbI1UMgnIzspACw2+T8SZa0229DuxovLxSxZ
+4/XwHg2yNKYypELsjwFt1y8noPVqh58W1gpzlODYpWX/jtygid2r9f0c4ZIgHvox
+layYR2IqHsp+wtfTfFZEdhAdYSamPC9ulJ1KeSUT2smMBSDTi40wnqmIJgnCS8o1
+SQyeHarhlnN2Megb8ZvwVpnPJQuhnb6VcNlVZcRg09AlHdEep4oR/qAafcrHYuuE
+f1ST/jrT790F4O0QUoZLtH6j
+=Y8Uo
+-----END PGP SIGNATURE-----


### PR DESCRIPTION
## Summary

Adds three new Apache Camel security advisories under `content/security/`:

- **CVE-2026-46587** (MEDIUM) — camel-couchbase: Non-Camel-prefixed Exchange headers (CCB_KEY, CCB_ID, CCB_TTL, CCB_DDN, CCB_VN) bypass HeaderFilterStrategy allowing operation override from untrusted input. Fix: PR #23228 (main), #23230 (4.18.x), #23231 (4.14.x).
- **CVE-2026-46588** (MEDIUM) — camel-couchdb: Non-Camel-prefixed Exchange headers (CouchDbDatabase, CouchDbSeq, CouchDbId, CouchDbRev, CouchDbMethod) bypass HeaderFilterStrategy allowing operation override from untrusted input. Fix: PR #23228 (main), #23230 (4.18.x), #23231 (4.14.x).
- **CVE-2026-49042** (MEDIUM) — camel-langchain4j-tools/agent/spring-ai-tools: Tool argument headers are not filtered against declared parameters, allowing an LLM to inject arbitrary Exchange headers via tool call arguments. Fix: PR #23535 (main), #23551 (4.18.x). JIRA: CAMEL-23621.

## Structure

- CVE-2026-46587 and CVE-2026-46588 are siblings sharing the same fix PR (#23228), with bidirectional cross-references.
- CVE-2026-49042 affects components introduced in 4.8.0+; no 4.14.x backport (the component exists but the fix was only backported to 4.18.x).
- `.txt.asc` (PGP-clearsigned) files are **not included** — the Camel security signing key is required.

## Notes

- Advisory `date` fields are set to `2026-07-03` to match the release date of 4.14.8, 4.18.3 and 4.21.0.
- All three CVEs credit Yu Bao from PayPal.