### PR TITLE
fix(trust): correct the advisory count on the Trust page

### DIFF
--- a/content/trust/_index.md
+++ b/content/trust/_index.md
@@ -84,9 +84,9 @@ someone else to find the problem.
 
 ## A busy advisory page is a good sign
 
-The 4.14.8, 4.18.3 and 4.21.0 releases fixed and disclosed
-[**32 vulnerabilities**](/security/) between them, and every one of them got a full public advisory.
-That is what an active security effort looks like from the outside — not a framework springing
+Camel 4.21.0 fixed and disclosed [**32 vulnerabilities**](/security/), and every one of them got a
+full public advisory. The 4.18.3 and 4.14.8 LTS releases shipped the backports within four days.
+That is what an active security effort looks like from the outside, not a framework springing
 leaks. Researchers across the industry report their findings to the ASF's private security list, and
 we go looking ourselves: when one component turns out to mishandle inbound message headers, we sweep
 the connector portfolio for the same pattern instead of patching only the one that was reported. That


### PR DESCRIPTION
The Trust page currently says:

> The 4.14.8, 4.18.3 and 4.21.0 releases fixed and disclosed **32 vulnerabilities** between them

Read strictly, those three releases fixed **34**. Two findings shipped in the named releases but had their main-line fix in an earlier minor, so neither is part of the 4.21.0 batch:

| Advisory | `fixed:` |
|---|---|
| CVE-2026-40047 | 4.18.3 and 4.19.0 |
| CVE-2026-40859 | 4.14.8, 4.18.3 and 4.20.0 |

32 is exactly the number of advisories fixed in **4.21.0**. The sentence under-counts rather than overstating, so nothing on the page was inflated, but it does not say what it computes.

### The fix

Anchors the figure to the single release it actually describes, and adds the backport timing, which is the stronger claim and was already true:

- 4.21.0, 1 July, 32 advisories
- 4.18.3, 3 July, 34 advisories
- 4.14.8, 4 July, 27 advisories

The "**26 of those 32 fixes were carried all the way back to the 4.14.x LTS line**" sentence further down is correct as written and is untouched.

Verified against `content/security/`: 32 advisories carry `4.21.0` in `fixed:`, 26 of those also carry `4.14.8`, and release dates come from the `RELEASE-*` announcement posts.

### Related

Companion to #1711, which adds a blog post covering the same batch in detail. The two are independent and can merge in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)