### PR TITLE
fix(website): use property attribute for og:description meta tag

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -22,10 +22,10 @@
     <meta property="og:site_name" content="{{ .Site.Title }}">
     <meta property="og:url" content="{{ .Permalink }}">
     {{ if .Description}}
-        <meta name="og:description" content="{{ .Description }}">
+        <meta property="og:description" content="{{ .Description }}">
     {{ else }}
         {{ if .Params.preview}}
-        <meta name="og:description" content="{{ .Params.preview }}">
+        <meta property="og:description" content="{{ .Params.preview }}">
         {{ end }}
     {{ end }}
     <meta property="og:type" content="website">


### PR DESCRIPTION
The Open Graph protocol (https://ogp.me/) requires the `property` attribute
for all `og:` meta tags. Both `og:description` entries in `header.html` were
using the `name` attribute instead:

```html
<meta name="og:description" content="...">
```

Social platforms (LinkedIn, Slack, Discord, Facebook) parse only
`property="og:description"` and silently ignore `name="og:description"`.
As a result, sharing any page on the site shows a blank description in the
link preview card.

All other OG tags in the file — `og:title`, `og:site_name`, `og:url`,
`og:type`, `og:image` — already use `property=` correctly.

### The fix

Replaces `name=` with `property=` on both `og:description` tags to match
the rest of the file and the specification.

### Verification

Paste any `camel.apache.org` URL into https://www.opengraph.xyz — the
Description field will be empty before this fix and populated after.
****