### PR TITLE
fix: netlify config preview update

### DIFF
--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -63,7 +63,7 @@ jobs:
           PR_NUMBER=${PR_NUMBER//[^0-9]/}
           PR_URL="https://github.com/apache/camel-website/pull/${PR_NUMBER}"
           yarn install
-          DEPLOY_OUTPUT=$(yarn preview:netlify --alias="pr-${PR_NUMBER}" --message="Preview for ${PR_URL}" --json)
+          DEPLOY_OUTPUT=$(yarn preview:netlify --site "$NETLIFY_SITE_ID" --alias="pr-${PR_NUMBER}" --message="Preview for ${PR_URL}" --json)
           echo "Deploy output: $DEPLOY_OUTPUT"
           DEPLOY_URL=$(echo "$DEPLOY_OUTPUT" | jq -r '.deploy_ssl_url // .deploy_url // .url // empty')
           echo "DEPLOY_URL=${DEPLOY_URL}" >> $GITHUB_ENV

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "update:dedupe": "yarn workspaces foreach --all dedupe",
     "preview": "run-s -l build:antora preview:hugo",
     "preview:hugo": "hugo server --bind=0.0.0.0 -D",
-    "preview:netlify": "netlify deploy --dir public --cwd . --filter apache-camel-website",
+    "preview:netlify": "netlify deploy --dir public --cwd .",
     "build:antora-local-full": "antora local-antora-playbook-full.yml --stacktrace --clean --fetch",
     "build:antora-local-partial": "antora local-antora-playbook-partial.yml --stacktrace",
     "build:antora-local-full2": "antora antora-playbook-local-full.yml --stacktrace --clean --fetch",


### PR DESCRIPTION
Ref #1718 

Netlify CLI v26 introduced stricter monorepo detection. It finds two workspace projects (`antora-ui-camel`, `camel-website-util`) and requires selecting one. The `--filter` apache-camel-website flag references the root package name, which isn't in the detected project list, it only sees sub-workspaces.

Let's see if this is enough