### PR TITLE
fix: strip workspaces before netlify deploy to bypass monorepo detection

### DIFF
--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -63,7 +63,8 @@ jobs:
           PR_NUMBER=${PR_NUMBER//[^0-9]/}
           PR_URL="https://github.com/apache/camel-website/pull/${PR_NUMBER}"
           yarn install
-          DEPLOY_OUTPUT=$(yarn preview:netlify --site "$NETLIFY_SITE_ID" --alias="pr-${PR_NUMBER}" --message="Preview for ${PR_URL}" --json)
+          node -e "const fs=require('fs'),p=JSON.parse(fs.readFileSync('package.json','utf8'));delete p.workspaces;fs.writeFileSync('package.json',JSON.stringify(p,null,2)+'\n')"
+          DEPLOY_OUTPUT=$(./node_modules/.bin/netlify deploy --dir public --site "$NETLIFY_SITE_ID" --alias="pr-${PR_NUMBER}" --message="Preview for ${PR_URL}" --json)
           echo "Deploy output: $DEPLOY_OUTPUT"
           DEPLOY_URL=$(echo "$DEPLOY_OUTPUT" | jq -r '.deploy_ssl_url // .deploy_url // .url // empty')
           echo "DEPLOY_URL=${DEPLOY_URL}" >> $GITHUB_ENV


### PR DESCRIPTION
Ref #1718

Netlify CLI v26 detects yarn workspaces and refuses to deploy in CI with "Projects detected" error. Both --cwd (broken since v22.1.7, netlify/cli#7528) and --filter + --dir (--dir silently ignored since v22.1.3, netlify/cli#7342) fail to work around it.

Strip the workspaces field from package.json after yarn install and call netlify directly to avoid monorepo detection entirely.