### PR TITLE
Restore Camel Quarkus 3.33.x docs

### DIFF
--- a/antora-playbook-snippets/antora-playbook.yml
+++ b/antora-playbook-snippets/antora-playbook.yml
@@ -41,6 +41,7 @@ content:
     - url: https://github.com/apache/camel-quarkus.git
       branches:
         - main
+        - 3.33.x
       start_path: docs
 
     - url: https://github.com/apache/camel-quarkus-examples.git


### PR DESCRIPTION
Camel Quarkus 3.33.x / Camel 4.18.x is not EOL.