### PR TITLE
chore: restore the deadlinks archive checksum so CI's yarn cache matches

### DIFF
--- a/github-release-binary.js
+++ b/github-release-binary.js
@@ -140,7 +140,7 @@ const execute = (path, args) => {
 (async () => {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'github-release-binary'));
   process.on('exit', () => {
-    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmdirSync(tmpDir, { recursive: true });
   })
 
   const binary = process.argv[1].replace('exec.js', '${parts.binary}');

--- a/yarn.lock
+++ b/yarn.lock
@@ -869,7 +869,7 @@ __metadata:
     "@yarnpkg/fslib": "npm:3.0.1"
   bin:
     deadlinks-macos: exec.js
-  checksum: 10/22be5262eab401d58b2ee01c048b661eb9251323161c63c80019f30e633b27594db174451d4cb3578770325061eb52126f8150882b1b11290dac2cead6051b0d
+  checksum: 10/3e24402e537554af39c7fc2996accead74392b6e75eec69a15df93f03e67b03de8d85c81ee17a203d644012b008189b69bed1f9bcdb127917e82b7373bc3361b
   languageName: node
   linkType: hard
 
@@ -880,7 +880,7 @@ __metadata:
     "@yarnpkg/fslib": "npm:3.0.1"
   bin:
     deadlinks-windows: exec.js
-  checksum: 10/976428be72ea3b01892c5294862a2075aa02dd2983125c6dd9e31d1192024a4a90797e3706a2355261cc82d0eba0fd2eae2b48632fe1f89f2af47bfaddfb1c7c
+  checksum: 10/93cce885c57cb5ff5a92d1c32d35c03808c3163513c39fbcfa833b2b1609846d37bb46df49ca68f39d5758284273a6cdae492724f2ed0465a2147f5e2325fc43
   languageName: node
   linkType: hard
 
@@ -891,7 +891,7 @@ __metadata:
     "@yarnpkg/fslib": "npm:3.0.1"
   bin:
     deadlinks-linux: exec.js
-  checksum: 10/4372e9fd8c2f626b7d06987c9db2be0ea593a3e93b0b96a6d37f24639fefd05c4340d12d3a60eaa7f811f0d7e874f4e817ae6a02ec846a1b91e75697313bfb55
+  checksum: 10/4f6e38b06d529c9822e50a2ac89bb8d2dee3c4b6658bdfdd043abcd4f0dedbc886667349435eefa81ed56ccb2f8485758b0511412e3d557549828ffb80c17a72
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes the `main` CI failure since #1740 (https://ci-builds.apache.org/job/Camel/job/Camel.website/job/main/2786/).

### Root cause

#1740 changed one line in the `github-release-binary.js` yarn plugin: the `exec.js` stub it writes into the faux cargo-deadlinks package swapped `rmdirSync` for `rmSync`. The stub is part of the package archive, so the archive bytes and the lockfile checksum for the Linux deadlinks binary changed.

Yarn 4 names global-cache files by locator hash only (`@deadlinks-cargo-deadlinks-github-release-a675f573c0-10.zip`), not by checksum. CI keeps its yarn cache across builds, so `yarn install` found the old archive under the same name and failed with YN0018 "The remote archive doesn't match the expected checksum" instead of refetching. The same happens on any developer machine that installed before #1740.

The Jenkinsfile chains `yarn install && ... ; yarn build-all`, so the build still ran, against stale `node_modules` without the new font packages, and the antora-ui-camel gulp build died with "Did you forget to signal async completion?". That was only a symptom.

### Fix

- `github-release-binary.js`: revert the stub line to `rmdirSync`, so a fresh fetch is byte-identical to the archive CI already has cached.
- `yarn.lock`: the three deadlinks checksums recomputed with the reverted template. Linux returns to its pre-#1740 value; the new macOS and Windows entries get their matching values.

### Verified

- The freshly built Linux archive is byte-identical to a pre-#1740 cache copy.
- Fresh-cache `yarn install --immutable` on Linux (node:lts in Docker) passes.
- `yarn install --immutable` on macOS passes and `yarn build` in antora-ui-camel completes through `bundle:pack`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ue7BFcXRDGZvRpovC3EtSR
