### PR TITLE
ci: stop the website stage when yarn install fails

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -55,7 +55,7 @@ pipeline {
             }
 
             steps {
-                sh "cd $WORKSPACE/camel-website && yarn install && yarn clean && yarn workspaces foreach --all install; HUGO_PARAMS_GitHubUsername=$GITHUB_USR HUGO_PARAMS_GitHubToken=$GITHUB_PSW yarn build-all"
+                sh "cd $WORKSPACE/camel-website && yarn install && yarn clean && yarn workspaces foreach --all install && HUGO_PARAMS_GitHubUsername=$GITHUB_USR HUGO_PARAMS_GitHubToken=$GITHUB_PSW yarn build-all"
             }
         }
 


### PR DESCRIPTION
Follow-up to #1747.

The Website stage chained `yarn install && yarn clean && yarn workspaces foreach --all install; ... yarn build-all`. The `;` meant a failed `yarn install` still ran `yarn build-all` against whatever `node_modules` the previous build left behind. That is why build 2786 reported a misleading antora-ui-camel gulp error ("Did you forget to signal async completion?") when the real failure was a YN0018 checksum mismatch during install.

This changes the `;` to `&&` so the stage fails at the install step and the console log shows the actual cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ue7BFcXRDGZvRpovC3EtSR
